### PR TITLE
PPTP-291 Create Declaration page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/GenericRegistrationConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/GenericRegistrationConnector.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.connectors
+
+case class GenericRegistrationConnector()

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationController.scala
@@ -23,8 +23,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthActi
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.honesty_declaration
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-import scala.concurrent.Future
-
 @Singleton
 class HonestyDeclarationController @Inject() (
   authenticate: AuthAction,
@@ -39,7 +37,7 @@ class HonestyDeclarationController @Inject() (
 
   def submit(): Action[AnyContent] =
     authenticate { implicit request =>
-      Ok(honesty_declaration())
+      Redirect(routes.HonestyDeclarationController.displayPage())
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.honesty_declaration
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.Future
+
+@Singleton
+class HonestyDeclarationController @Inject() (
+  authenticate: AuthAction,
+  mcc: MessagesControllerComponents,
+  honesty_declaration: honesty_declaration
+) extends FrontendController(mcc) with I18nSupport {
+
+  def displayPage(): Action[AnyContent] =
+    authenticate { implicit request =>
+      Ok(honesty_declaration())
+    }
+
+  def submit(): Action[AnyContent] =
+    authenticate { implicit request =>
+      Ok(honesty_declaration())
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/honesty_declaration.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/honesty_declaration.scala.html
@@ -1,0 +1,43 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.paragraphBody
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.pageTitle
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
+
+@this(
+  govukLayout: main_template,
+  pageTitle: pageTitle,
+  paragraphBody: paragraphBody,
+  govukButton: GovukButton,
+  formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@govukLayout(
+  title = Title("honestyDeclaration.title"),
+  backButton = Some(BackButton(messages("site.back"), pptRoutes.RegistrationController.displayPage()))) {
+
+  @formHelper(action = pptRoutes.HonestyDeclarationController.submit(), 'autoComplete -> "off") {
+      @pageTitle(messages("honestyDeclaration.title"))
+      @paragraphBody(message = messages("honestyDeclaration.description"))
+      @govukButton(Button(content = Text(messages("site.button.continue")), attributes = Map("id" -> "submit")))
+  }
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/registration_page.scala.html
@@ -15,85 +15,83 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes._
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components._
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskName
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{TaskName, TaskStatus, Title}
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 
 
 @this(
-govukLayout: main_template,
-pageTitle: pageTitle,
-paragraphBody: paragraphBody,
-govukButton: GovukButton,
-link: link,
-govukTag: GovukTag
+    govukLayout: main_template,
+    pageTitle: pageTitle,
+    paragraphBody: paragraphBody,
+    govukButton: GovukButton,
+    link: link,
+    govukTag: GovukTag
 )
 
 @(tasks: Map[TaskName, TaskStatus])(implicit request: Request[_], messages: Messages)
 
-@task(index: Int, title: String, linkText: String, linkTargetUrl: String, status: TaskStatus) = {
-<h2 class="app-task-list__section">
-    <span class="app-task-list__section-number">@{index}.</span>
-    @messages(title)
-</h2>
-<div class="app-task-list__items no-item-padding">
-    <div class="app-task-list__item">
-                        <span class='app-task-list__task-name'>
-                            @link(text = messages(linkText), call = Call("GET", linkTargetUrl))
-                        </span>
-        @getTag(status)
+@task(index: Int, title: String, linkText: String, linkCall: Call, status: TaskStatus) = {
+    <h2 class="app-task-list__section">
+        <span class="app-task-list__section-number">@{index}</span>
+        @messages(title)
+    </h2>
+    <div class="app-task-list__items no-item-padding">
+        <div class="app-task-list__item">
+            <span class='app-task-list__task-name'>
+                @link(text = messages(linkText), call = linkCall)
+            </span>
+            @getTag(status)
+        </div>
     </div>
-</div>
 }
 
 @getTag(status: TaskStatus) = {
-@status match {
-case TaskStatus.Completed => {@govukTag(Tag(content = Text(messages("task.status.completed")), classes = "govuk-tag app-task-list__task-completed"))}
-case TaskStatus.InProgress => {@govukTag(Tag(content = Text(messages("task.status.inProgress")), classes = "govuk-tag govuk-tag--to-do app-task-list__task-completed govuk-tag--red"))}
-case TaskStatus.NotStarted => {@govukTag(Tag(content = Text(messages("task.status.notStarted")), classes = "govuk-tag govuk-tag--to-do app-task-list__task-completed govuk-tag--grey"))}
-case _ => {@govukTag(Tag(content = Text(messages("task.status.notStarted")), classes = "govuk-tag govuk-tag--to-do app-task-list__task-completed govuk-tag--grey"))}
-}
+    @status match {
+        case TaskStatus.Completed  => {@govukTag(Tag(content = Text(messages("task.status.completed")),  classes = "govuk-tag app-task-list__task-completed"))}
+        case TaskStatus.InProgress => {@govukTag(Tag(content = Text(messages("task.status.inProgress")), classes = "govuk-tag govuk-tag--to-do app-task-list__task-completed govuk-tag--red"))}
+        case TaskStatus.NotStarted => {@govukTag(Tag(content = Text(messages("task.status.notStarted")), classes = "govuk-tag govuk-tag--to-do app-task-list__task-completed govuk-tag--grey"))}
+        case _                     => {@govukTag(Tag(content = Text(messages("task.status.notStarted")), classes = "govuk-tag govuk-tag--to-do app-task-list__task-completed govuk-tag--grey"))}
+    }
 }
 
 @getStatus(taskName: TaskName) = @{
-tasks.getOrElse(taskName, TaskStatus.NotStarted)
+    tasks.getOrElse(taskName, TaskStatus.NotStarted)
 }
 
 @govukLayout(title = Title("registrationPage.title")) {
 
-@pageTitle(text = messages("registrationPage.title"))
+    @pageTitle(text = messages("registrationPage.title"))
 
-<ol class="app-task-list">
+    <ol class="app-task-list">
 
-    <li>
-        @task(1, "registrationPage.organisationDetails", "registrationPage.businessInfo", "http://businessInfo",
-        getStatus(TaskName.OrganisationDetails))
-    </li>
-    <li>
-        @task(2, "registrationPage.plasticPackagingDetails", "registrationPage.plasticPackagingInfo",
-        "http://plasticPackagingInfo", getStatus(TaskName.PlasticPackagingDetails))
-    </li>
-    <li>
-        @task(3, "registrationPage.businessContactDetails", "registrationPage.businessContactInfo",
-        "http://businessContactInfo", getStatus(TaskName.BusinessContactDetails))
-    </li>
-    <li>
-        @task(4, "registrationPage.applicantContactDetails", "registrationPage.applicantContactInfo",
-        "http://applicantContactInfo", getStatus(TaskName.ApplicantContactDetails))
-    </li>
+        <li>
+            @task(1, "registrationPage.organisationDetails", "registrationPage.businessInfo",
+                pptRoutes.HonestyDeclarationController.displayPage(), getStatus(TaskName.OrganisationDetails))
+        </li>
+        <li>
+            @task(2, "registrationPage.plasticPackagingDetails", "registrationPage.plasticPackagingInfo",
+                pptRoutes.RegistrationController.displayPage(), getStatus(TaskName.PlasticPackagingDetails))
+        </li>
+        <li>
+            @task(3, "registrationPage.businessContactDetails", "registrationPage.businessContactInfo",
+                pptRoutes.RegistrationController.displayPage(), getStatus(TaskName.BusinessContactDetails))
+        </li>
+        <li>
+            @task(4, "registrationPage.applicantContactDetails", "registrationPage.applicantContactInfo",
+                pptRoutes.RegistrationController.displayPage(), getStatus(TaskName.ApplicantContactDetails))
+        </li>
 
-</ol>
+    </ol>
 
-<h2 id="review-declaration" class="govuk-heading-m">@messages("registrationPage.declaration.header")</h2>
-@paragraphBody(message = messages("registrationPage.declaration.description"), id = Some("review-declaration-element"))
-@govukButton(
-Button(
-href = Some(""),
-isStartButton = true,
-content = Text(messages("registrationPage.declaration.buttonName"))
-)
-)
+    <h2 id="review-declaration" class="govuk-heading-m">@messages("registrationPage.declaration.header")</h2>
+    @paragraphBody(message = messages("registrationPage.declaration.description"), id = Some("review-declaration-element"))
+    @govukButton(
+        Button(
+            href = Some(""),
+            isStartButton = true,
+            content = Text(messages("registrationPage.declaration.buttonName"))
+        )
+    )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import sbt.GlobFilter
-import sbt.Keys.includeFilter
 import uk.gov.hmrc.DefaultBuildSettings.integrationTestSettings
 import uk.gov.hmrc.SbtArtifactory
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
@@ -47,7 +45,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     ".*(BuildInfo|Routes|Options).*",
     "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 85,
+  coverageMinimum := 88,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,5 +1,10 @@
 # microservice specific routes
 
 GET        /assets/*file            controllers.Assets.versioned(path="/public", file: Asset)
+
 GET        /start                   uk.gov.hmrc.plasticpackagingtax.registration.controllers.StartController.displayStartPage()
+
 GET        /registration            uk.gov.hmrc.plasticpackagingtax.registration.controllers.RegistrationController.displayPage()
+
+GET        /honesty-declaration     uk.gov.hmrc.plasticpackagingtax.registration.controllers.HonestyDeclarationController.displayPage()
+POST       /honesty-declaration     uk.gov.hmrc.plasticpackagingtax.registration.controllers.HonestyDeclarationController.submit()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -6,6 +6,12 @@ service.name=Plastic Packaging Tax
 title.format={0} - {1} - GOV.UK
 title.withSection.format={0} - {1} - {2} - GOV.UK
 
+site.back = Back
+site.button.continue = Continue
+
+honestyDeclaration.title = Declaration
+honestyDeclaration.description = By submitting this application to register for Plastic Packaging Tax, you are making a legal declaration that the information is correct and complete to the best of your knowledge and belief. A false declaration can result in prosecution.
+
 startPage.title.sectionHeader = Guidance
 startPage.title = Plastic Packaging Tax Service
 startPage.description = If you’re a business manufacturing or importing plastic packaging into UK you can use Plastic Packaging Tax Service to make tax return

--- a/test/spec/ControllerSpec.scala
+++ b/test/spec/ControllerSpec.scala
@@ -21,9 +21,10 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.mvc.Result
-import play.api.test.DefaultAwaitTimeout
+import play.api.libs.json.JsValue
+import play.api.mvc.{AnyContentAsJson, Request, Result}
 import play.api.test.Helpers.contentAsString
+import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import play.twirl.api.Html
 
 import scala.concurrent.Future
@@ -32,5 +33,13 @@ trait ControllerSpec
     extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with MockAuthAction
     with BeforeAndAfterEach with DefaultAwaitTimeout {
 
+  import utils.FakeRequestCSRFSupport._
+
   protected def viewOf(result: Future[Result]) = Html(contentAsString(result))
+
+  protected def postRequest(body: JsValue): Request[AnyContentAsJson] =
+    FakeRequest("POST", "")
+      .withJsonBody(body)
+      .withCSRFToken
+
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationControllerSpec.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import spec.UnitViewSpec
+
+class HonestyDeclarationControllerSpec extends UnitViewSpec {}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/HonestyDeclarationControllerSpec.scala
@@ -16,6 +16,69 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
-import spec.UnitViewSpec
+import akka.http.scaladsl.model.StatusCodes.OK
+import controllers.Assets.SEE_OTHER
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{redirectLocation, status}
+import play.twirl.api.HtmlFormat
+import spec.ControllerSpec
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.honesty_declaration
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class HonestyDeclarationControllerSpec extends UnitViewSpec {}
+class HonestyDeclarationControllerSpec extends ControllerSpec {
+  private val page        = mock[honesty_declaration]
+  private val fakeRequest = FakeRequest("GET", "/")
+  private val mcc         = stubMessagesControllerComponents()
+
+  private val controller =
+    new HonestyDeclarationController(authenticate = mockAuthAction,
+                                     mcc = mcc,
+                                     honesty_declaration = page
+    )
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(page)
+    super.afterEach()
+  }
+
+  "Honesty Declaration Controller" should {
+
+    "return 200" when {
+
+      "user is authorised and display page method is invoked" in {
+        authorizedUser()
+        val result = controller.displayPage()(fakeRequest)
+
+        status(result) mustBe OK.intValue
+      }
+    }
+
+    "return an error" when {
+
+      "user is not authorised" in {
+        unAuthorizedUser()
+        val result = controller.displayPage()(fakeRequest)
+
+        intercept[RuntimeException](status(result))
+      }
+    }
+
+    "return 303 (SEE_OTHER) and redirect to honesty declaration" when {
+      "user submits the honesty declaration form" in {
+        authorizedUser()
+        val result = controller.submit()(FakeRequest("POST", ""))
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(routes.HonestyDeclarationController.displayPage().url)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationControllerSpec.scala
@@ -74,20 +74,4 @@ class RegistrationControllerSpec extends ControllerSpec {
       }
     }
   }
-  "Registration Controller" should {
-
-    "display task list" when {
-
-      "display page method is invoked" in {
-        authorizedUser()
-        val result = controller.displayPage()(fakeRequest)
-
-        viewOf(result) must be(
-          registrationPage(controller.taskStatuses)(fakeRequest,
-                                                    controller.messagesApi.preferred(fakeRequest)
-          )
-        )
-      }
-    }
-  }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/HonestyDeclarationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/HonestyDeclarationViewSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views
+
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import spec.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.honesty_declaration
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class HonestyDeclarationViewSpec extends UnitViewSpec with Matchers {
+
+  private val page                   = instanceOf[honesty_declaration]
+  private def createView(): Document = page()(request, messages)
+
+  "Honesty Declaration View" should {
+
+    "have proper messages for labels" in {
+      messages must haveTranslationFor("honestyDeclaration.title")
+      messages must haveTranslationFor("honestyDeclaration.description")
+      messages must haveTranslationFor("site.button.continue")
+    }
+
+    val view = createView()
+
+    "display 'Back' button" in {
+
+      view.getElementById("back-link") must haveHref(routes.RegistrationController.displayPage())
+    }
+
+    "display title" in {
+
+      view.getElementsByClass("govuk-heading-xl").first() must containMessage(
+        "honestyDeclaration.title"
+      )
+    }
+
+    "display page hint" in {
+
+      view.getElementsByClass("govuk-body").first() must containMessage(
+        "honestyDeclaration.description"
+      )
+    }
+
+    "display 'Continue' button" in {
+
+      view must containElementWithID("submit")
+      view.getElementById("submit") must containMessage("Continue")
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
@@ -17,8 +17,10 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.views
 
 import org.scalatest.matchers.must.Matchers
+import play.api.mvc.Call
 import play.twirl.api.Html
 import spec.UnitViewSpec
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.registration_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{TaskName, TaskStatus}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
@@ -26,13 +28,13 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 @ViewTest
 class RegistrationViewSpec extends UnitViewSpec with Matchers {
 
-  private val registrationPage: registration_page = instanceOf[registration_page]
-
   val taskStatuses: Map[TaskName, TaskStatus] = Map(
     TaskName.OrganisationDetails     -> TaskStatus.Completed,
     TaskName.PlasticPackagingDetails -> TaskStatus.InProgress,
     TaskName.BusinessContactDetails  -> TaskStatus.NotStarted
   )
+
+  private val registrationPage: registration_page = instanceOf[registration_page]
 
   private def createView(): Html = registrationPage(taskStatuses)
 
@@ -81,7 +83,7 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
         title: String,
         description: String,
         tagStatus: String,
-        href: String
+        href: Call
       ) = {
         taskListElementHeader.get(index).text() must include(messages(title))
         val taskItem = taskItems.get(index)
@@ -94,25 +96,25 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
                    "registrationPage.organisationDetails",
                    "registrationPage.businessInfo",
                    "task.status.completed",
-                   "http://businessInfo"
+                   routes.HonestyDeclarationController.displayPage()
       )
       validateTask(1,
                    "registrationPage.plasticPackagingDetails",
                    "registrationPage.plasticPackagingInfo",
                    "task.status.inProgress",
-                   "http://plasticPackagingInfo"
+                   routes.RegistrationController.displayPage()
       )
       validateTask(2,
                    "registrationPage.businessContactDetails",
                    "registrationPage.businessContactInfo",
                    "task.status.notStarted",
-                   "http://businessContactInfo"
+                   routes.RegistrationController.displayPage()
       )
       validateTask(3,
                    "registrationPage.applicantContactDetails",
                    "registrationPage.applicantContactInfo",
                    "task.status.notStarted",
-                   "http://applicantContactInfo"
+                   routes.RegistrationController.displayPage()
       )
     }
 


### PR DESCRIPTION
**Create the Honesty Declaration page**
 * This is a page that will allow us to integrate with the Generic registration service.
 * In order to connect to the Generic Registration service we require a `/POST` request to be made between our service and the generic registration service.
 * This means we need to control that interaction via a `/POST` request to our own service, as we should avoid `/GET` requests.
 
**Integrate 'honesty-declaration' with 'registration' page**

* Took the liberty to create indentation on the
`registration_page.scala.html` page to help read the code a bit better.
* The other links on the registration page should probably point to the
  current registration page for the time being, instead of pointing to a
non-existing page.