### PR TITLE
PPTP-292 Incorporated Entity Identification FE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
 
-# plastic-packaging-tax-registration-frontend
+# Plastic Packaging Tax Registration (PPT) Frontend
 
-This is a placeholder README.md for a new repository
+This is the Scala microservice responsible for the PPT registration UI user journey, which is part of the PPT tax regime, as discussed in this [GovUk Guindance](https://www.gov.uk/government/publications/introduction-of-plastic-packaging-tax/plastic-packaging-tax)
+ 
+This service integrates with the HMRC Strategic Generic Registration service, namely: 
+ * [Incorporated Entity Identification Frontend](https://github.com/hmrc/incorporated-entity-identification-frontend)
 
-### License
+### How to run the service
 
-This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
+* Start a MongoDB instance
+
+* Start the microservices
+ 
+```
+# Start the plastic packaging services and dependencies 
+sm --start PLASTIC_PACKAGING_TAX_ALL -f
+
+# start the incorporated Entity Identification Frontend and dependencies
+sm --start INCORPORATED_ENTITY_IDENTIFICATION_ALL
+
+# confirm all services are running
+sm -s 
+```
+
+* Visit http://localhost:9949/auth-login-stub/gg-sign-in
+* Enter the redirect url: http://localhost:8503/plastic-packaging-tax/start and press **Submit**.
+  
 
 ### Precheck
 
@@ -26,3 +46,8 @@ sbt scalafmt        # format compile sources
 sbt test:scalafmt   # format test sources
 sbt sbt:scalafmt    # format .sbt source
 ```
+
+### License
+
+This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
+

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -21,22 +21,33 @@ import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
-class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig) {
-  private val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
+class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesConfig) {
 
-  private val assetsUrl         = config.get[String]("assets.url")
-  private val serviceIdentifier = "MyService"
+  lazy val assetsUrl: String = config.get[String]("assets.url")
 
-  val assetsPrefix: String   = assetsUrl + config.get[String]("assets.version")
-  val analyticsToken: String = config.get[String](s"google-analytics.token")
-  val analyticsHost: String  = config.get[String](s"google-analytics.host")
+  lazy val assetsPrefix: String = assetsUrl + config.get[String]("assets.version")
 
-  val reportAProblemPartialUrl: String =
+  lazy val serviceIdentifier = "plastic-packaging-tax"
+
+  lazy val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
+
+  lazy val reportAProblemPartialUrl: String =
     s"$contactBaseUrl/contact/problem_reports_ajax?service=$serviceIdentifier"
 
-  val reportAProblemNonJSUrl: String =
+  lazy val reportAProblemNonJSUrl: String =
     s"$contactBaseUrl/contact/problem_reports_nonjs?service=$serviceIdentifier"
 
   lazy val loginUrl         = config.get[String]("urls.login")
   lazy val loginContinueUrl = config.get[String]("urls.loginContinue")
+
+  lazy val incorpIdHost: String =
+    servicesConfig.baseUrl("incorporated-entity-identification-frontend")
+
+  lazy val exitSurveyUrl: String = config.get[String]("urls.exitSurvey")
+
+  lazy val incorpIdJourneyCallbackUrl: String = config.get[String]("urls.incorpIdCallback")
+
+  def createIncorpIdJourneyUrl: String =
+    s"$incorpIdHost/incorporated-entity-identification/api/journey"
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/IncorpIdConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/IncorpIdConnector.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.connectors
+
+import javax.inject.{Inject, Singleton}
+import play.api.http.Status.CREATED
+import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, InternalServerException}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.IncorpIdCreateRequest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class IncorpIdConnector @Inject() (httpClient: HttpClient, config: AppConfig)(implicit
+  ec: ExecutionContext
+) {
+
+  def createJourney(payload: IncorpIdCreateRequest)(implicit hc: HeaderCarrier): Future[String] =
+    httpClient.POST(config.createIncorpIdJourneyUrl, payload).map {
+      case response @ HttpResponse(CREATED, _, _) =>
+        (response.json \ "journeyStartUrl").as[String]
+      case response =>
+        throw new InternalServerException(
+          s"Invalid response from incorporated entity identification: Status: ${response.status} Body: ${response.body}"
+        )
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class IncorpIdController @Inject() (authenticate: AuthAction, mcc: MessagesControllerComponents)(
+  implicit
+  appConfig: AppConfig,
+  val executionContext: ExecutionContext
+) extends FrontendController(mcc) with I18nSupport {
+
+  def incorpIdCallback(journeyId: String): Action[AnyContent] =
+    authenticate {
+      implicit request =>
+        Redirect(routes.RegistrationController.displayPage())
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/IncorpIdCreateRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/IncorpIdCreateRequest.scala
@@ -14,6 +14,17 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.connectors
+package uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration
 
-case class GenericRegistrationConnector()
+import play.api.libs.json.{Json, OFormat}
+
+case class IncorpIdCreateRequest(
+  continueUrl: String,
+  optServiceName: Option[String] = None,
+  deskProServiceId: String,
+  signOutUrl: String
+)
+
+object IncorpIdCreateRequest {
+  implicit val format: OFormat[IncorpIdCreateRequest] = Json.format[IncorpIdCreateRequest]
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,3 +8,5 @@ GET        /registration            uk.gov.hmrc.plasticpackagingtax.registration
 
 GET        /honesty-declaration     uk.gov.hmrc.plasticpackagingtax.registration.controllers.HonestyDeclarationController.displayPage()
 POST       /honesty-declaration     uk.gov.hmrc.plasticpackagingtax.registration.controllers.HonestyDeclarationController.submit()
+
+GET        /incorp-id-callback      uk.gov.hmrc.plasticpackagingtax.registration.controllers.IncorpIdController.incorpIdCallback(journeyId)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,6 +80,12 @@ microservice {
       host = localhost
       port = 9250
     }
+
+    incorporated-entity-identification-frontend {
+      host = localhost
+      port = 9718
+      url = "http://localhost:9718"
+    }
   }
 }
 
@@ -117,5 +123,6 @@ assets {
 urls {
   login = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue = "http://localhost:8503/plastic-packaging-tax/registration"
+  incorpIdCallback = "http://localhost:8503/plastic-packaging-tax/incorp-id-callback"
+  exitSurvey = "http://localhost:9514/feedback/plastic-packaging-tax"
 }
-

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -24,6 +24,7 @@ object AppDependencies {
     "org.mockito"             %  "mockito-core"             % "3.5.7"                 % Test,
     "org.scalatestplus"       %% "scalatestplus-mockito"    % "1.0.0-M2"              % Test,
     "com.vladsch.flexmark"    %  "flexmark-all"             % "0.35.10"               % "test, it",
-    "org.scalatestplus.play"  %% "scalatestplus-play"       % "4.0.3"                 % "test, it"
+    "org.scalatestplus.play"  %% "scalatestplus-play"       % "4.0.3"                 % "test, it",
+    "com.github.tomakehurst"  %  "wiremock-jre8"            % "2.27.2"                % "test, it"
   )
 }

--- a/test/base/it/ConnectorISpec.scala
+++ b/test/base/it/ConnectorISpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base.it
+
+import com.codahale.metrics.SharedMetricRegistries
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterEach, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
+
+import scala.concurrent.ExecutionContext
+
+class ConnectorISpec extends WiremockTestServer with GuiceOneAppPerSuite {
+
+  def overrideConfig: Map[String, Any] =
+    Map("microservice.services.incorporated-entity-identification-frontend.host" -> wireHost,
+        "microservice.services.incorporated-entity-identification-frontend.port" -> incorpIdWirePort
+    )
+
+  override def fakeApplication(): Application = {
+    SharedMetricRegistries.clear()
+    new GuiceApplicationBuilder().configure(overrideConfig).build()
+  }
+
+  protected implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+  protected implicit val hc: HeaderCarrier    = HeaderCarrier()
+  protected val httpClient: DefaultHttpClient = app.injector.instanceOf[DefaultHttpClient]
+}

--- a/test/base/it/WiremockTestServer.scala
+++ b/test/base/it/WiremockTestServer.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base.it
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+
+trait WiremockTestServer
+    extends AnyWordSpec with Matchers with MockitoSugar with BeforeAndAfterAll {
+
+  val wireHost = "localhost"
+
+  val incorpIdWirePort       = 20001
+  val incorpIdWireMockServer = new WireMockServer(incorpIdWirePort)
+
+  protected def stubFor(mappingBuilder: MappingBuilder): StubMapping =
+    incorpIdWireMockServer.stubFor(mappingBuilder)
+
+}

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package spec
+package base.unit
 
 import base.MockAuthAction
 import org.scalatest.BeforeAndAfterEach
@@ -26,14 +26,19 @@ import play.api.mvc.{AnyContentAsJson, Request, Result}
 import play.api.test.Helpers.contentAsString
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait ControllerSpec
     extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with MockAuthAction
     with BeforeAndAfterEach with DefaultAwaitTimeout {
 
   import utils.FakeRequestCSRFSupport._
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  implicit val config: AppConfig = mock[AppConfig]
 
   protected def viewOf(result: Future[Result]) = Html(contentAsString(result))
 

--- a/test/base/unit/UnitViewSpec.scala
+++ b/test/base/unit/UnitViewSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package spec
+package base.unit
 
 import base.Injector
 import org.scalatest.wordspec.AnyWordSpec
@@ -22,6 +22,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
+import spec.ViewMatchers
 
 class UnitViewSpec extends AnyWordSpec with ViewMatchers with Injector with GuiceOneAppPerSuite {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.config
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
+
+  private val validConfig: Config =
+    ConfigFactory.parseString(
+      """
+        |microservice.services.incorporated-entity-identification-frontend.host=localhost
+        |microservice.services.incorporated-entity-identification-frontend.port=9718
+      """.stripMargin
+    )
+
+  private val validServicesConfiguration = Configuration(validConfig)
+  private val validAppConfig: AppConfig  = appConfig(validServicesConfiguration)
+
+  private def appConfig(conf: Configuration) =
+    new AppConfig(conf, servicesConfig(conf))
+
+  private def servicesConfig(conf: Configuration) = new ServicesConfig(conf)
+
+  "The config" should {
+
+    "have 'createIncorpIdJourneyUrl' defined" in {
+      validAppConfig.createIncorpIdJourneyUrl must be(
+        "http://localhost:9718/incorporated-entity-identification/api/journey"
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandlerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandlerTest.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.config
 
+import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.http.Status
 import play.api.test.DefaultAwaitTimeout
 import play.api.test.Helpers.{redirectLocation, status, stubMessagesApi}
-import spec.UnitViewSpec
 import uk.gov.hmrc.auth.core.NoActiveSession
 import uk.gov.hmrc.hmrcfrontend.views.Utils.urlEncode
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_template

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/IncorpIdConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/IncorpIdConnectorISpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.connectors
+
+import base.Injector
+import base.it.ConnectorISpec
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post}
+import org.scalatest.concurrent.ScalaFutures
+import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.IncorpIdCreateRequest
+
+class IncorpIdConnectorISpec extends ConnectorISpec with Injector with ScalaFutures {
+
+  lazy val connector: IncorpIdConnector = app.injector.instanceOf[IncorpIdConnector]
+  val incorpId                          = "uuid-id"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    WireMock.configureFor(wireHost, incorpIdWirePort)
+    incorpIdWireMockServer.start()
+  }
+
+  override protected def afterAll(): Unit = {
+    incorpIdWireMockServer.stop()
+    super.afterAll()
+  }
+
+  "createJourney" should {
+    "call the test only route to stub the journey" in {
+      val testJourneyConfig =
+        IncorpIdCreateRequest(continueUrl = "/plastic-packaging-tax/registration",
+                              deskProServiceId = "plastic-packaging-tax",
+                              signOutUrl = "/feedback/plastic-packaging-tax"
+        )
+      val testJourneyStartUrl  = "/identify-your-incorporated-business/uuid-id/company-number"
+      val testDeskProServiceId = "plastic-packaging-tax"
+
+      stubFor(
+        post("/incorporated-entity-identification/api/journey")
+          .willReturn(
+            aResponse()
+              .withStatus(Status.CREATED)
+              .withBody(
+                Json.obj("journeyStartUrl"  -> testJourneyStartUrl,
+                         "deskProServiceId" -> testDeskProServiceId
+                ).toString
+              )
+          )
+      )
+
+      val res = await(connector.createJourney(testJourneyConfig))
+
+      res mustBe testJourneyStartUrl
+    }
+
+    "throw exception if http status is not 'CREATED'" in {
+      val testJourneyConfig =
+        IncorpIdCreateRequest(continueUrl = "/plastic-packaging-tax/registration",
+                              deskProServiceId = "plastic-packaging-tax",
+                              signOutUrl = "/feedback/plastic-packaging-tax"
+        )
+
+      stubFor(
+        post("/incorporated-entity-identification/api/journey")
+          .willReturn(
+            aResponse()
+              .withStatus(Status.INTERNAL_SERVER_ERROR)
+          )
+      )
+
+      intercept[Exception] {
+        await(connector.createJourney(testJourneyConfig))
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdControllerSpec.scala
@@ -16,44 +16,28 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
-import akka.http.scaladsl.model.StatusCodes.OK
 import base.unit.ControllerSpec
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, when}
+import controllers.Assets.SEE_OTHER
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.FakeRequest
-import play.api.test.Helpers.status
-import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.start_page
+import play.api.test.Helpers.{redirectLocation, status}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class StartControllerSpec extends ControllerSpec {
+class IncorpIdControllerSpec extends ControllerSpec {
 
   private val fakeRequest = FakeRequest("GET", "/")
   private val mcc         = stubMessagesControllerComponents()
-  private val startPage   = mock[start_page]
-  private val controller  = new StartController(mcc, startPage)
 
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
-    when(startPage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
-  }
+  private val controller =
+    new IncorpIdController(authenticate = mockAuthAction, mcc)(config, ec)
 
-  override protected def afterEach(): Unit = {
-    reset(startPage)
-    super.afterEach()
-  }
+  "incorpIdCallback" should {
+    "redirect to the registration page" in {
+      authorizedUser()
+      val result = controller.incorpIdCallback("uuid-id")(fakeRequest)
 
-  "Start Controller" should {
-
-    "return 200" when {
-
-      "display page method is invoked" in {
-
-        val result = controller.displayStartPage()(fakeRequest)
-
-        status(result) mustBe OK.intValue
-      }
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)
     }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationControllerSpec.scala
@@ -17,13 +17,13 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import akka.http.scaladsl.model.StatusCodes.OK
+import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.FakeRequest
 import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
-import spec.ControllerSpec
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.registration_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/FooterViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/FooterViewSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.views
 
+import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
 import play.twirl.api.Html
-import spec.UnitViewSpec
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.start_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/HonestyDeclarationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/HonestyDeclarationViewSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.views
 
+import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
-import spec.UnitViewSpec
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.honesty_declaration
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.views
 
+import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.mvc.Call
 import play.twirl.api.Html
-import spec.UnitViewSpec
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.registration_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{TaskName, TaskStatus}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/StartViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/StartViewSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.views
 
+import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
 import play.twirl.api.Html
-import spec.UnitViewSpec
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.start_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/model/TitleSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/model/TitleSpec.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.views.model
 
+import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
-import spec.UnitViewSpec
 
 class TitleSpec extends UnitViewSpec with Matchers {
 


### PR DESCRIPTION
This is just the integration between PPT FE and the IncorpID FE
microservice.

I have also organised the base spec folder, separating the `unit` and `integration` base setup.

```
Outstanding work is to save the `journeyId` from the IncorpId FE
microservice in order to manage the statuses of each task.
Subsequent tickets will address the above.
```
