### PR TITLE
PPTP-389 Change the feedback link construction

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -45,6 +45,10 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   lazy val serviceIdentifier = "plastic-packaging-tax"
 
+  lazy val selfBaseUrl: String = config
+    .getOptional[String]("platform.frontend.host")
+    .getOrElse("http://localhost:9250")
+
   lazy val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
 
   lazy val reportAProblemPartialUrl: String =
@@ -62,25 +66,28 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val pptServiceHost: String =
     servicesConfig.baseUrl("plastic-packaging-tax-registration")
 
-  lazy val contactFrontendHost: String =
-    servicesConfig.baseUrl("contact-frontend")
-
   lazy val incorpIdJourneyCallbackUrl: String = config.get[String]("urls.incorpIdCallback")
+
+  lazy val feedbackAuthenticatedLink: String = config.get[String]("urls.feedback.authenticatedLink")
+
+  lazy val feedbackUnauthenticatedLink: String =
+    config.get[String]("urls.feedback.unauthenticatedLink")
+
+  lazy val exitSurveyUrl  = config.get[String]("urls.exitSurvey")
+  lazy val hmrcPrivacyUrl = config.get[String]("urls.hmrcPrivacy")
+  lazy val govUkUrl       = config.get[String]("urls.govUk")
 
   lazy val incorpJourneyUrl           = s"$incorpIdHost/incorporated-entity-identification/api/journey"
   lazy val pptRegistrationUrl: String = s"$pptServiceHost/registrations"
-  lazy val exitSurveyUrl              = config.get[String]("urls.exitSurvey")
-  lazy val hmrcPrivacyUrl             = config.get[String]("urls.hmrcPrivacy")
-  lazy val govUkUrl                   = config.get[String]("urls.govUk")
 
   def incorpDetailsUrl(journeyId: String): String = s"$incorpJourneyUrl/$journeyId"
 
   def pptRegistrationUrl(id: String): String = s"$pptRegistrationUrl/$id"
 
   def authenticatedFeedbackUrl(): String =
-    s"$contactFrontendHost/contact/beta-feedback?service=${serviceIdentifier}"
+    s"$feedbackAuthenticatedLink?service=${serviceIdentifier}"
 
   def unauthenticatedFeedbackUrl(): String =
-    s"$contactFrontendHost/contact/beta-feedback-unauthenticated?service=${serviceIdentifier}"
+    s"$feedbackUnauthenticatedLink?service=${serviceIdentifier}"
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/phaseBanner.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/phaseBanner.scala.html
@@ -26,9 +26,9 @@
 @isAuthenticated = @{request.isInstanceOf[AuthenticatedRequest[_]]}
 @feedbackUrl = @{
   if (isAuthenticated) {
-    s"${appConfig.authenticatedFeedbackUrl()}&backUrl=${request.host}${request.uri}"
+    s"${appConfig.authenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
   } else {
-    s"${appConfig.unauthenticatedFeedbackUrl()}&backUrl=${request.host}${request.uri}"
+    s"${appConfig.unauthenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -94,12 +94,6 @@ microservice {
       port = 8502
       url = "http://localhost:8502"
     }
-
-    contact-frontend {
-      host = localhost
-      port = 9250
-      url = "http://localhost:9250"
-    }
   }
 }
 
@@ -144,6 +138,10 @@ urls {
   loginContinue = "http://localhost:8503/plastic-packaging-tax/registration"
   incorpIdCallback = "http://localhost:8503/plastic-packaging-tax/incorp-id-callback"
   exitSurvey = "http://localhost:9514/feedback/plastic-packaging-tax-registration"
+  feedback = {
+    authenticatedLink = "http://localhost:9250/contact/beta-feedback"
+    unauthenticatedLink = "http://localhost:9250/contact/beta-feedback-unauthenticated"
+  }
   hmrcPrivacy = "http://localhost:8503/help/privacy"
   govUk = "https://www.gov.uk"
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
@@ -34,6 +34,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         |microservice.services.plastic-packaging-tax-registration.port=8502
         |microservice.services.contact-frontend.host=localhost
         |microservice.services.contact-frontend.port=9250
+        |urls.feedback.authenticatedLink="http://localhost:9250/contact/beta-feedback"
+        |urls.feedback.unauthenticatedLink="http://localhost:9250/contact/beta-feedback-unauthenticated"
       """.stripMargin
     )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
@@ -38,12 +38,12 @@ class PhaseBannerSpec extends UnitViewSpec with Matchers {
   private val authenticatedLink =
     "http://localhost:9250/contact/beta-feedback?" +
       "service=plastic-packaging-tax&" +
-      "backUrl=localhost/plastic-packaging-tax/some-page"
+      "backUrl=http://localhost:9250/plastic-packaging-tax/some-page"
 
   private val unauthenticatedLink =
     "http://localhost:9250/contact/beta-feedback-unauthenticated?" +
       "service=plastic-packaging-tax&" +
-      "backUrl=localhost/plastic-packaging-tax/some-page"
+      "backUrl=http://localhost:9250/plastic-packaging-tax/some-page"
 
   override def beforeEach(): Unit = {
     super.beforeEach()


### PR DESCRIPTION
I mistakingly inserted the `contact-frontend` service on our lists of
microservice dependencies, when we do not need that, as we simply
require a HMRC base URI, as we did with the exit survey.

In order to provide the `backUrl` logic on the `contact-frontend`
service we will need to use the `platform.frontend.host` property which
is available on all environments, but we need to have a fallback
solution for local.