### PR TITLE
BAU - Attempt to load missing CSS on PPT Returns FE

### DIFF
--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -1,0 +1,50 @@
+/***************************************
+ ********** Default Styling  ***********
+ ***************************************/
+.card .card-body {
+  padding: 10px;
+}
+
+.card-balance .govuk-heading-m {
+  margin-bottom: 10px;
+}
+
+.card-balance .govuk-heading-l {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+/***************************************
+ ***********  Mobile Styling  **********
+ ***************************************/
+@media only screen and (max-width: 640px) {
+  .card .card-body .govuk-heading-s {
+    color: #1d70b8;
+  }
+
+  .card {
+    background: #f8f8f8;
+    margin-bottom: 20px;
+  }
+}
+
+
+/***************************************
+ ********** Desktop Styling  ***********
+ ***************************************/
+@media only screen and (min-width: 641px) {
+  .card {
+    background: #f8f8f8;
+    margin-bottom: 20px;
+    min-height: 260px;
+  }
+
+  .card .card-body .govuk-heading-s {
+    color: #1d70b8;
+    min-height: 50px;
+  }
+
+  .card .govuk-link {
+    font-size: 19px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,3 @@
-@import '_ppt';
-
 $govuk-assets-path: '/plastic-packaging-tax/assets/';
 $govuk-images-path: "/plastic-packaging-tax/assets/lib/govuk-frontend/govuk/assets/images/";
 $govuk-fonts-path: "/plastic-packaging-tax/assets/lib/govuk-frontend/govuk/assets/fonts/";
@@ -7,3 +5,6 @@ $hmrc-assets-path: "/plastic-packaging-tax/assets/lib/hmrc-frontend/hmrc/assets/
 
 @import 'lib/govuk-frontend/govuk/all';
 @import "lib/hmrc-frontend/hmrc/all";
+
+@import '_ppt';
+@import '_cards';


### PR DESCRIPTION
Because we are sort of sharing the same URI between PPT registrations FE
and PPT returns FE, it could be that there is a confusion on what CSS to
load and probably PPT registrations FE is overriding the CSS config.

It works well locally because the domain (IP:PORT) is different and
there is no "confusion" there.

In QA the domain and start of URI is the same.