### PR TITLE
PPTP-757 Add user headers to correct Registration payload

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -98,13 +98,6 @@ class ReviewRegistrationController @Inject() (
       registration.copy(metaData = updatedMetaData)
     }
 
-  /*
-  TODO: This will need to be refactored once: (remember to make sure correct sequence of events occur: complete, audit, redirect etc for pass and fail)
-  1. The PPT EIS/IF Stub has been implemented
-  2. The EIS/IF and ETMP 'Create Registration/Subscription' request/response schemas are made available to us
-  3. If a submission has been successful we will need to remove the registration/submission document.
-  4. Once we have a lot more clarity. KISS.
-   */
   def submit(): Action[AnyContent] =
     (authenticate andThen journeyAction).async { implicit request =>
       markRegistrationAsCompleted().flatMap {
@@ -112,7 +105,7 @@ class ReviewRegistrationController @Inject() (
           val updatedRegistrationWithUserHeaders =
             updatedRegistration.copy(userHeaders = Some(request.headers.toSimpleMap))
           subscriptionsConnector.submitSubscription(getSafeId(updatedRegistrationWithUserHeaders),
-                                                    updatedRegistration
+                                                    updatedRegistrationWithUserHeaders
           ).map { response =>
             successSubmissionCounter.inc()
             auditor.registrationSubmitted(updatedRegistration)

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -60,13 +60,6 @@ trait ControllerSpec
   def getRequest(session: (String, String) = "" -> ""): Request[AnyContentAsEmpty.type] =
     FakeRequest("GET", "").withSession(session).withCSRFToken
 
-  protected def viewOf(result: Future[Result]): Html = Html(contentAsString(result))
-
-  protected def postRequest(body: JsValue): Request[AnyContentAsJson] =
-    postRequest
-      .withJsonBody(body)
-      .withCSRFToken
-
   def authRequest(
     headers: Headers = Headers(),
     user: SignedInUser = PptTestData.newUser("123", Some(pptEnrolment("333")))
@@ -79,6 +72,14 @@ trait ControllerSpec
       )
     )
 
+  protected def viewOf(result: Future[Result]): Html = Html(contentAsString(result))
+
+  protected def postRequest(body: JsValue): Request[AnyContentAsJson] =
+    postRequest
+      .withJsonBody(body)
+      .withHeaders(testUserHeaders.toSeq: _*)
+      .withCSRFToken
+
   protected def postRequestEncoded(
     form: AnyRef,
     formAction: (String, String) = saveAndContinueFormAction
@@ -88,13 +89,6 @@ trait ControllerSpec
       .withFormUrlEncodedBody(bodyForm: _*)
       .withCSRFToken
   }
-
-  protected def postJsonRequestEncoded(
-    body: (String, String)*
-  ): Request[AnyContentAsFormUrlEncoded] =
-    postRequest
-      .withFormUrlEncodedBody(body: _*)
-      .withCSRFToken
 
   private def postRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("POST", "")
 
@@ -110,5 +104,12 @@ trait ControllerSpec
       case c: String                   => c
       case _                           => ""
     }
+
+  protected def postJsonRequestEncoded(
+    body: (String, String)*
+  ): Request[AnyContentAsFormUrlEncoded] =
+    postRequest
+      .withFormUrlEncodedBody(body: _*)
+      .withCSRFToken
 
 }

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -42,6 +42,7 @@ trait PptTestData {
   protected val testNino          = "SE12345678"
   protected val testSatur         = "123456789"
   protected val safeNumber        = "XXPPTP123456789"
+  protected val testUserHeaders   = Map("Host" -> "localhost", "headerKey" -> "headerValue")
 
   protected val testCompanyAddress = IncorporationAddressDetails(address_line_1 = Some("testLine1"),
                                                                  address_line_2 = Some("testLine2"),


### PR DESCRIPTION
I have made a mistake and added the userHeaders to the incorrect
registration instance/version and the tests did not capture it.

So this is about adding the headers to the correct registrations
instance and updating the unit tests.