### PR TITLE
PPTP-893 Use 'InternalId' to save registration progress 

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AuthActionImpl @Inject() (
   override val authConnector: AuthConnector,
-  userEmailAllowedList: UtrAllowedList,
+  userEmailAllowedList: EmailAllowedList,
   metrics: Metrics,
   mcc: MessagesControllerComponents
 ) extends AuthAction with AuthorisedFunctions {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -24,10 +24,6 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{agentCode, _}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction.{
-  pptEnrolmentIdentifierName,
-  pptEnrolmentKey
-}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{
@@ -40,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AuthActionImpl @Inject() (
   override val authConnector: AuthConnector,
-  utrAllowedList: UtrAllowedList,
+  userEmailAllowedList: UtrAllowedList,
   metrics: Metrics,
   mcc: MessagesControllerComponents
 ) extends AuthAction with AuthorisedFunctions {
@@ -90,13 +86,7 @@ class AuthActionImpl @Inject() (
                                           Some(loginTimes)
           )
 
-          getPptEnrolmentId(allEnrolments, pptEnrolmentIdentifierName) match {
-            case None =>
-              throw InsufficientEnrolments(
-                s"key: $pptEnrolmentKey and identifier: $pptEnrolmentIdentifierName is not found"
-              )
-            case Some(id) => executeRequest(request, block, identityData, id, allEnrolments)
-          }
+          executeRequest(request, block, identityData, email.getOrElse(""), allEnrolments)
       }
   }
 
@@ -104,37 +94,17 @@ class AuthActionImpl @Inject() (
     request: Request[A],
     block: AuthenticatedRequest[A] => Future[Result],
     identityData: IdentityData,
-    id: String,
+    email: String,
     allEnrolments: Enrolments
   ) =
-    if (utrAllowedList.isAllowed(id)) {
+    if (userEmailAllowedList.isAllowed(email)) {
       val pptLoggedInUser = SignedInUser(allEnrolments, identityData)
-      block(new AuthenticatedRequest(request, pptLoggedInUser, Some(id)))
+      block(new AuthenticatedRequest(request, pptLoggedInUser, identityData.internalId))
     } else {
-      logger.warn("User id is not allowed, access denied")
+      logger.warn("User is not allowed, access denied")
       Future.successful(Results.Redirect(routes.UnauthorisedController.onPageLoad()))
     }
 
-  private def getPptEnrolmentId(enrolments: Enrolments, identifier: String): Option[String] =
-    getPptEnrolment(enrolments, identifier) match {
-      case Some(enrolmentId) => Option(enrolmentId).filter(_.value.trim.nonEmpty).map(_.value)
-      case None              => Option.empty
-    }
-
-  private def getPptEnrolment(
-    enrolmentsList: Enrolments,
-    identifier: String
-  ): Option[EnrolmentIdentifier] =
-    enrolmentsList.enrolments
-      .filter(_.key == pptEnrolmentKey)
-      .flatMap(_.identifiers)
-      .find(_.key == identifier)
-
-}
-
-object AuthAction {
-  val pptEnrolmentKey            = "HMRC-PPT-ORG"
-  val pptEnrolmentIdentifierName = "UTR"
 }
 
 @ImplementedBy(classOf[AuthActionImpl])

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -97,10 +97,9 @@ class AuthActionImpl @Inject() (
     email: String,
     allEnrolments: Enrolments
   ) =
-    if (userEmailAllowedList.isAllowed(email)) {
-      val pptLoggedInUser = SignedInUser(allEnrolments, identityData)
-      block(new AuthenticatedRequest(request, pptLoggedInUser, identityData.internalId))
-    } else {
+    if (userEmailAllowedList.isAllowed(email))
+      block(new AuthenticatedRequest(request, SignedInUser(allEnrolments, identityData)))
+    else {
       logger.warn("User is not allowed, access denied")
       Future.successful(Results.Redirect(routes.UnauthorisedController.onPageLoad()))
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/EmailAllowedList.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/EmailAllowedList.scala
@@ -21,15 +21,15 @@ import play.api.Configuration
 
 import javax.inject.Provider
 
-@ProvidedBy(classOf[UtrAllowedListProvider])
-class UtrAllowedList(values: Seq[String]) {
-  def isAllowed(utr: String): Boolean = values.isEmpty || values.contains(utr)
+@ProvidedBy(classOf[EmailAllowedListProvider])
+class EmailAllowedList(emails: Seq[String]) {
+  def isAllowed(email: String): Boolean = emails.isEmpty || emails.contains(email)
 }
 
-class UtrAllowedListProvider @Inject() (configuration: Configuration)
-    extends Provider[UtrAllowedList] {
+class EmailAllowedListProvider @Inject() (configuration: Configuration)
+    extends Provider[EmailAllowedList] {
 
-  override def get(): UtrAllowedList =
-    new UtrAllowedList(configuration.get[Seq[String]]("allowedList.utr").map(_.trim))
+  override def get(): EmailAllowedList =
+    new EmailAllowedList(configuration.get[Seq[String]]("allowedList.emails").map(_.trim))
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AuthenticatedRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AuthenticatedRequest.scala
@@ -19,8 +19,5 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.request
 import play.api.mvc.{Request, WrappedRequest}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 
-class AuthenticatedRequest[+A](
-  request: Request[A],
-  val user: SignedInUser,
-  val enrolmentId: Option[String]
-) extends WrappedRequest[A](request) {}
+class AuthenticatedRequest[+A](request: Request[A], val user: SignedInUser)
+    extends WrappedRequest[A](request) {}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyAction.scala
@@ -39,10 +39,10 @@ class JourneyAction @Inject() (registrationConnector: RegistrationConnector, aud
   ): Future[Either[Result, JourneyRequest[A]]] = {
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromRequestAndSession(request, request.session)
-    request.enrolmentId.filter(_.trim.nonEmpty) match {
+    request.user.identityData.internalId.filter(_.trim.nonEmpty) match {
       case Some(id) =>
         loadOrCreateRegistration(id).map {
-          case Right(reg)  => Right(new JourneyRequest[A](request, reg, Some(id)))
+          case Right(reg)  => Right(new JourneyRequest[A](request, reg))
           case Left(error) => throw error
         }
       case None =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyRequest.scala
@@ -20,6 +20,5 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registra
 
 class JourneyRequest[+A](
   val authenticatedRequest: AuthenticatedRequest[A],
-  val registration: Registration,
-  override val enrolmentId: Option[String]
-) extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user, enrolmentId) {}
+  val registration: Registration
+) extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user) {}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -164,5 +164,5 @@ urls {
 accessibility-statement.service-path = "/plastic-packaging-tax"
 
 allowedList {
-  utr = []
+  emails = []
 }

--- a/tampermonkey/PPT_Auth_AutoComplete.js
+++ b/tampermonkey/PPT_Auth_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     Plastic Packaging Tax Registration Authorisation
 // @namespace  http://tampermonkey.net/
-// @version   4.0
+// @version   5.0
 // @description Auth Wizard autocomplete script for PPT
 // @author    pmonteiro
 // @match     http*://*/auth-login-stub/gg-sign-in?continue=*plastic-packaging-tax*
@@ -17,11 +17,8 @@
     document.getElementById("affinityGroupSelect").selectedIndex = 1;
 
     document.getElementsByName("enrolment[0].name")[0].value = "HMRC-PPT-ORG";
-    document.getElementById("input-0-0-name").value = "UTR";
-    document.getElementById("input-0-0-value").value = "1234567890";
-    document.getElementsByName("enrolment[1].name")[0].value = "HMRC-PPT-ORG";
-    document.getElementById("input-1-0-name").value = "PPTReference";
-    document.getElementById("input-1-0-value").value = "XMPPT0000000001";
+    document.getElementById("input-0-0-name").value = "PPTReference";
+    document.getElementById("input-0-0-value").value = "XMPPT0000000001";
 
     document.getElementById('global-header').appendChild(createQuickButton())
 

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
   AuthActionImpl,
-  UtrAllowedList
+  EmailAllowedList
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 
@@ -41,7 +41,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
   val mockAuthAction = new AuthActionImpl(mockAuthConnector,
-                                          new UtrAllowedList(Seq.empty),
+                                          new EmailAllowedList(Seq.empty),
                                           metricsMock,
                                           stubMessagesControllerComponents()
   )

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -16,7 +16,7 @@
 
 package base
 
-import base.PptTestData.{newUser, pptEnrolment}
+import base.PptTestData.newUser
 import org.joda.time.DateTimeZone.UTC
 import org.joda.time.{DateTime, LocalDate}
 import org.mockito.ArgumentMatchers
@@ -46,7 +46,6 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
                                           stubMessagesControllerComponents()
   )
 
-  private val exampleUser     = newUser("external1", Some(pptEnrolment("123")))
   val nrsGroupIdentifierValue = Some("groupIdentifierValue")
   val nrsCredentialRole       = Some(User)
   val nrsMdtpInformation      = MdtpInformation("deviceId", "sessionId")
@@ -69,6 +68,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val currentLoginTime: DateTime  = new DateTime(1530442800000L, UTC)
   val previousLoginTime: DateTime = new DateTime(1530464400000L, UTC)
   val nrsLoginTimes               = LoginTimes(currentLoginTime, Some(previousLoginTime))
+  private val exampleUser         = newUser()
 
   // format: off
   def authorizedUser(user: SignedInUser = exampleUser): Unit =

--- a/test/base/PptTestData.scala
+++ b/test/base/PptTestData.scala
@@ -18,9 +18,8 @@ package base
 
 import org.joda.time.{DateTime, LocalDate}
 import uk.gov.hmrc.auth.core.ConfidenceLevel.L50
+import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.auth.core.retrieve.{AgentInformation, Credentials, LoginTimes, Name}
-import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.IdentityData
 
@@ -29,13 +28,10 @@ object PptTestData {
   val nrsCredentials: Credentials =
     Credentials(providerId = "providerId", providerType = "providerType")
 
-  def newUser(
-    externalId: String = "123",
-    enrolments: Option[Enrolments] = Some(pptEnrolment("123"))
-  ): SignedInUser =
-    SignedInUser(enrolments.getOrElse(Enrolments(Set())),
-                 IdentityData(Some("Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"),
-                              Some(externalId),
+  def newUser(internalId: String = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b"): SignedInUser =
+    SignedInUser(Enrolments(Set()),
+                 IdentityData(Some(internalId),
+                              Some("123"),
                               None,
                               Some(nrsCredentials),
                               Some(L50),
@@ -61,19 +57,5 @@ object PptTestData {
                               Some(LoginTimes(DateTime.now, None))
                  )
     )
-
-  def pptEnrolment(pptEnrolmentId: String) =
-    newEnrolments(
-      newEnrolment(AuthAction.pptEnrolmentKey,
-                   AuthAction.pptEnrolmentIdentifierName,
-                   pptEnrolmentId
-      )
-    )
-
-  def newEnrolments(enrolment: Enrolment*): Enrolments =
-    Enrolments(enrolment.toSet)
-
-  def newEnrolment(key: String, identifierName: String, identifierValue: String): Enrolment =
-    Enrolment(key).withIdentifier(identifierName, identifierValue)
 
 }

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -68,7 +68,7 @@ trait ControllerSpec
     headers: Headers = Headers(),
     user: SignedInUser = PptTestData.newUser("123")
   ): AuthenticatedRequest[AnyContentAsEmpty.type] =
-    new AuthenticatedRequest(FakeRequest().withHeaders(headers), user, user.identityData.internalId)
+    new AuthenticatedRequest(FakeRequest().withHeaders(headers), user)
 
   protected def viewOf(result: Future[Result]): Html = Html(contentAsString(result))
 

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package base.unit
 
-import base.PptTestData.pptEnrolment
 import base.{MockAuthAction, PptTestData}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
@@ -31,7 +30,6 @@ import play.twirl.api.Html
 import spec.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
   Continue,
   SaveAndComeBackLater,
   SaveAndContinue,
@@ -68,15 +66,9 @@ trait ControllerSpec
 
   def authRequest(
     headers: Headers = Headers(),
-    user: SignedInUser = PptTestData.newUser("123", Some(pptEnrolment("333")))
+    user: SignedInUser = PptTestData.newUser("123")
   ): AuthenticatedRequest[AnyContentAsEmpty.type] =
-    new AuthenticatedRequest(
-      FakeRequest().withHeaders(headers),
-      user,
-      user.enrolments.getEnrolment(AuthAction.pptEnrolmentKey).flatMap(
-        e => e.getIdentifier(AuthAction.pptEnrolmentIdentifierName).map(i => i.value)
-      )
-    )
+    new AuthenticatedRequest(FakeRequest().withHeaders(headers), user, user.identityData.internalId)
 
   protected def viewOf(result: Future[Result]): Html = Html(contentAsString(result))
 
@@ -95,8 +87,6 @@ trait ControllerSpec
       .withFormUrlEncodedBody(bodyForm: _*)
       .withCSRFToken
   }
-
-  private def postRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("POST", "")
 
   protected def getTuples(cc: AnyRef): Seq[(String, String)] =
     cc.getClass.getDeclaredFields.foldLeft(Map.empty[String, String]) { (a, f) =>
@@ -117,5 +107,7 @@ trait ControllerSpec
     postRequest
       .withFormUrlEncodedBody(body: _*)
       .withCSRFToken
+
+  private def postRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("POST", "")
 
 }

--- a/test/base/unit/UnitViewSpec.scala
+++ b/test/base/unit/UnitViewSpec.scala
@@ -35,7 +35,7 @@ class UnitViewSpec
   import utils.FakeRequestCSRFSupport._
 
   implicit val request: Request[AnyContent] =
-    new AuthenticatedRequest(FakeRequest().withCSRFToken, PptTestData.newUser(), Some("123"))
+    new AuthenticatedRequest(FakeRequest().withCSRFToken, PptTestData.newUser())
 
   protected implicit def messages(implicit request: Request[_]): Messages =
     realMessagesApi.preferred(request)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -31,10 +31,10 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
   private val okResponseGenerator = (_: AuthenticatedRequest[_]) => Future(Results.Ok)
 
   private def createAuthAction(
-    utrAllowedList: UtrAllowedList = new UtrAllowedList(Seq.empty)
+    emailAllowedList: EmailAllowedList = new EmailAllowedList(Seq.empty)
   ): AuthAction =
     new AuthActionImpl(mockAuthConnector,
-                       utrAllowedList,
+                       emailAllowedList,
                        metricsMock,
                        stubMessagesControllerComponents()
     )
@@ -66,7 +66,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       authorizedUser(user)
 
       await(
-        createAuthAction(new UtrAllowedList(Seq(allowedEmail))).invokeBlock(
+        createAuthAction(new EmailAllowedList(Seq(allowedEmail))).invokeBlock(
           authRequest(Headers(), user),
           okResponseGenerator
         )
@@ -78,7 +78,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       authorizedUser(user)
 
       val result =
-        createAuthAction(new UtrAllowedList(Seq("not.allowed@hmrc.co.uk"))).invokeBlock(
+        createAuthAction(new EmailAllowedList(Seq("not.allowed@hmrc.co.uk"))).invokeBlock(
           authRequest(Headers(), user),
           okResponseGenerator
         )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/EmailAllowedListProviderSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/EmailAllowedListProviderSpec.scala
@@ -21,34 +21,35 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
 
-class UtrAllowedListProviderSpec extends AnyWordSpec with Matchers with MockitoSugar {
+class EmailAllowedListProviderSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
-  "UtrAllowedListProvider" should {
+  "EmailAllowedListProvider" should {
 
+    val allowedEmail = "allowed@test.com"
     "load correctly from configuration" in {
 
-      val config   = Configuration("allowedList.utr.0" -> "1234")
-      val provider = new UtrAllowedListProvider(config)
-      provider.get() mustBe a[UtrAllowedList]
+      val config   = Configuration("allowedList.emails.0" -> allowedEmail)
+      val provider = new EmailAllowedListProvider(config)
+      provider.get() mustBe a[EmailAllowedList]
     }
 
     "trim spaces during loading" in {
 
-      val config   = Configuration("allowedList.utr.0" -> " 1234 ")
-      val provider = new UtrAllowedListProvider(config)
-      provider.get().isAllowed("1234") mustBe true
+      val config   = Configuration("allowedList.emails.0" -> s" $allowedEmail ")
+      val provider = new EmailAllowedListProvider(config)
+      provider.get().isAllowed(allowedEmail) mustBe true
     }
 
     "allow empty list" in {
 
-      val config   = Configuration("allowedList.utr.0" -> "")
-      val provider = new UtrAllowedListProvider(config)
-      provider.get() mustBe a[UtrAllowedList]
+      val config   = Configuration("allowedList.emails.0" -> "")
+      val provider = new EmailAllowedListProvider(config)
+      provider.get() mustBe a[EmailAllowedList]
     }
 
     "throw exception when there is not configuration key" in {
 
-      val provider = new UtrAllowedListProvider(Configuration.empty)
+      val provider = new EmailAllowedListProvider(Configuration.empty)
       an[Exception] mustBe thrownBy {
         provider.get()
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/EmailAllowedListSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/EmailAllowedListSpec.scala
@@ -20,23 +20,25 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
-class UtrAllowedListSpec extends AnyWordSpec with Matchers with MockitoSugar {
+class EmailAllowedListSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
-  "utr allow list" when {
+  "email allow list" when {
+    val testEmail1 = "email1@test.com"
+    val testEmail2 = "email2@test.com"
     "is empty" should {
       "allow everyone" in {
-        val utrAllowedList = new UtrAllowedList(Seq.empty)
-        utrAllowedList.isAllowed("12345") mustBe true
-        utrAllowedList.isAllowed("0987") mustBe true
+        val emailAllowedList = new EmailAllowedList(Seq.empty)
+        emailAllowedList.isAllowed(testEmail1) mustBe true
+        emailAllowedList.isAllowed(testEmail2) mustBe true
       }
     }
     "has elements" should {
-      val utrAllowedList = new UtrAllowedList(Seq("12345"))
-      "allow listed utr" in {
-        utrAllowedList.isAllowed("12345") mustBe true
+      val emailAllowedList = new EmailAllowedList(Seq(testEmail1))
+      "allow listed email" in {
+        emailAllowedList.isAllowed(testEmail1) mustBe true
       }
-      "disallow not listed utr" in {
-        utrAllowedList.isAllowed("0987") mustBe false
+      "disallow not listed email" in {
+        emailAllowedList.isAllowed(testEmail2) mustBe false
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
@@ -63,8 +63,7 @@ class PhaseBannerSpec extends UnitViewSpec with Matchers {
         import utils.FakeRequestCSRFSupport._
 
         val request = new AuthenticatedRequest(FakeRequest("GET", requestPath).withCSRFToken,
-                                               PptTestData.newUser(),
-                                               Some("123")
+                                               PptTestData.newUser()
         )
         createBanner(request)
           .getElementsByClass("govuk-phase-banner__text").first()


### PR DESCRIPTION

* At the beginning of Alpha phase we have used UTR to save the registration user journey progress.
As we progressed through Alpha, we were told that two legal entities we had to support woud not have an UTR. 

* This work is about replacing the enrolment key UTR with the User Internal Id, which is always present in the Auth record and is unique to this user.

* This will allow us to continue to support the "Save And Come Back Later" functionality.

* Prior to this ticket we also had a UTR allowlist which will have to be replaced with an email allowlist, which is a standard practice in other HMRC services during Private Beta phase.

 * Once in Private Beta we will be required to filter early bird users on our service, one way would to filter by their email addresses. This is a common practice at other services.
