### PR TITLE
PPTP-925 'QuickButton' style position is 'absolute'

### DIFF
--- a/tampermonkey/PPT_Auth_AutoComplete.js
+++ b/tampermonkey/PPT_Auth_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name     Plastic Packaging Tax Registration Authorisation
 // @namespace  http://tampermonkey.net/
-// @version   4.0
+// @version   5.0
 // @description Auth Wizard autocomplete script for PPT
 // @author    pmonteiro
 // @match     http*://*/auth-login-stub/gg-sign-in?continue=*plastic-packaging-tax*
@@ -29,10 +29,20 @@
 
 function createQuickButton() {
     let button = document.createElement('button');
-    button.id="quickSubmit";
-    button.innerHTML = 'Quick Submit';
+    button.id='quickSubmit'
+
+    if (!!document.getElementById('global-header')) {
+        button.classList.add('button-start', 'govuk-!-display-none-print')
+    } else {
+        button.classList.add('govuk-button','govuk-!-display-none-print')
+    }
+
+    button.style.position = 'absolute'
+    button.style.top = '50px'
+    button.innerHTML = 'Quick Submit'
     button.onclick = () => document.getElementsByClassName('button')[0].click();
     return button;
+
 }
 
 function getBaseUrl() {


### PR DESCRIPTION
@tmc-ee mentioned that on the returns journey he was seeing two `QuickSubmit` buttons, this is due to the returns and registration microservice sharing the same base URI.

One quick and easy way is to override the buttons on top of each other.

As this is just to help stakeholders navigate on the test environments is should not be an issue.