### PR TITLE
PPTP-994 Make Metadata NrsDetails optional

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -107,7 +107,7 @@ class ReviewRegistrationController @Inject() (
           ).map { response =>
             successSubmissionCounter.inc()
             val updatedMetadata = updatedRegistration.metaData.copy(nrsDetails =
-              NrsDetails(response.nrSubmissionId, response.nrsFailureReason)
+              Some(NrsDetails(response.nrSubmissionId, response.nrsFailureReason))
             )
             auditor.registrationSubmitted(updatedRegistration.copy(metaData = updatedMetadata))
             Redirect(routes.ConfirmationController.displayPage())

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/MetaData.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/MetaData.scala
@@ -29,7 +29,7 @@ case class MetaData(
   registrationReviewed: Boolean = false,
   registrationCompleted: Boolean = false,
   verifiedEmails: Seq[EmailStatus] = Seq(),
-  nrsDetails: NrsDetails = NrsDetails()
+  nrsDetails: Option[NrsDetails] = None
 ) {
 
   def getEmailStatus(email: String): EmailVerificationStatus =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
@@ -174,7 +174,7 @@ class ReviewRegistrationControllerSpec extends ControllerSpec {
         val aReviewedRegistration = aCompleteRegistration.copy(metaData =
           MetaData(registrationReviewed = true,
                    registrationCompleted = true,
-                   nrsDetails = NrsDetails(Some(nrsSubmissionId))
+                   nrsDetails = Some(NrsDetails(Some(nrsSubmissionId)))
           )
         )
         mockRegistrationUpdate(aReviewedRegistration)


### PR DESCRIPTION
These are only required to be capture on the FE and when CiP auditing the
registration.