### PR TITLE
PPTP-1026  - Liability Check - Move Liability section

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityStartDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityStartDateController.scala
@@ -62,7 +62,7 @@ class LiabilityStartDateController @Inject() (
                   case Right(_) =>
                     FormAction.bindFromRequest match {
                       case SaveAndContinue =>
-                        Redirect(routes.LiabilityWeightController.displayPage())
+                        Redirect(routes.CheckLiabilityDetailsAnswersController.displayPage())
                       case _ =>
                         Redirect(routes.RegistrationController.displayPage())
                     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightController.scala
@@ -64,7 +64,7 @@ class LiabilityWeightController @Inject() (
               case Right(_) =>
                 FormAction.bindFromRequest match {
                   case SaveAndContinue =>
-                    Redirect(routes.CheckLiabilityDetailsAnswersController.displayPage())
+                    Redirect(routes.LiabilityStartDateController.displayPage())
                   case _ =>
                     Redirect(routes.RegistrationController.displayPage())
                 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
@@ -37,7 +37,7 @@
 
 @govukLayout(
   title = Title("checkLiabilityDetailsAnswers.title"),
-  backButton = Some(BackButton(messages("site.back"), pptRoutes.LiabilityWeightController.displayPage(), messages("site.back.hiddenText")))) {
+  backButton = Some(BackButton(messages("site.back"), pptRoutes.LiabilityStartDateController.displayPage(), messages("site.back.hiddenText")))) {
 
     @pageTitle(text = messages("checkLiabilityDetailsAnswers.title"))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_start_date_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_start_date_page.scala.html
@@ -47,7 +47,7 @@
 
 @govukLayout(
   title = Title("liabilityStartDatePage.title"),
-  backButton = Some(BackButton(messages("site.back"), pptRoutes.RegistrationController.displayPage(), messages("site.back.hiddenText")))) {
+  backButton = Some(BackButton(messages("site.back"), pptRoutes.LiabilityWeightController.displayPage(), messages("site.back.hiddenText")))) {
     @errorSummary(form.errors)
 
     @sectionHeader(messages("liabilityStartDatePage.sectionHeader"))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
@@ -47,9 +47,7 @@
     if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 }
 
-@govukLayout(
-  title = Title("liabilityWeightPage.title"),
-  backButton = Some(BackButton(messages("site.back"), pptRoutes.LiabilityStartDateController.displayPage(), messages("site.back.hiddenText")))) {
+@govukLayout(title = Title("liabilityWeightPage.title")) {
   @errorSummary(form.errors)
 
   @sectionHeader(messages("liabilityWeightPage.sectionHeader"))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/start_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/start_page.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInsetText
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes.RegistrationController
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.bulletList
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.dashList
@@ -101,7 +101,7 @@ govukButton: GovukButton
 
     @govukButton(
         Button(
-            href = Some(RegistrationController.displayPage().url),
+            href = Some(pptRoutes.LiabilityWeightController.displayPage().url),
             isStartButton = true,
             content = Text(messages("startPage.buttonName"))
             )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityStartDateControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityStartDateControllerTest.scala
@@ -99,7 +99,7 @@ class LiabilityStartDateControllerTest extends ControllerSpec {
           formAction._1 match {
             case "SaveAndContinue" =>
               redirectLocation(result) mustBe Some(
-                routes.LiabilityWeightController.displayPage().url
+                routes.CheckLiabilityDetailsAnswersController.displayPage().url
               )
             case _ =>
               redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightControllerTest.scala
@@ -90,7 +90,7 @@ class LiabilityWeightControllerTest extends ControllerSpec {
           formAction._1 match {
             case "SaveAndContinue" =>
               redirectLocation(result) mustBe Some(
-                routes.CheckLiabilityDetailsAnswersController.displayPage().url
+                routes.LiabilityStartDateController.displayPage().url
               )
             case _ =>
               redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -59,7 +59,9 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
     "display 'Back' button" in {
 
-      view.getElementById("back-link") must haveHref(routes.LiabilityWeightController.displayPage())
+      view.getElementById("back-link") must haveHref(
+        routes.LiabilityStartDateController.displayPage()
+      )
     }
 
     "display title" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityStartDateViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityStartDateViewSpec.scala
@@ -58,7 +58,7 @@ class LiabilityStartDateViewSpec extends UnitViewSpec with Matchers {
 
     "display 'Back' button" in {
 
-      view.getElementById("back-link") must haveHref(routes.RegistrationController.displayPage())
+      view.getElementById("back-link") must haveHref(routes.LiabilityWeightController.displayPage())
     }
 
     "display title" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
@@ -60,9 +60,7 @@ class LiabilityWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display 'Back' button" in {
 
-      view.getElementById("back-link") must haveHref(
-        routes.LiabilityStartDateController.displayPage()
-      )
+      view.getElementById("back-link") mustBe null
     }
 
     "display title" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/StartViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/StartViewSpec.scala
@@ -172,7 +172,7 @@ class StartViewSpec extends UnitViewSpec with Matchers {
 
       view.getElementsByClass("govuk-button").first() must containMessage("startPage.buttonName")
       view.getElementsByClass("govuk-button").first() must haveHref(
-        uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes.RegistrationController.displayPage().url
+        uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes.LiabilityWeightController.displayPage().url
       )
     }
 


### PR DESCRIPTION
Work includes:

* Link Start page to Plastic Weight page
* Make 'Liability Weight' the first PPT 
* Make 'Liability Start Date' the 2nd PPT page
* Change Liability Details CYAP 'Back' link 

UAT changes can be found [here](https://github.com/hmrc/plastic-packaging-tax-acceptance/pull/44)