### PR TITLE
PPTP-2019 Change Liability Task List link and Re-order CYAP answers

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
@@ -47,6 +47,23 @@
                 rows = Seq(
                     SummaryListRow(
                         key = Key(
+                            content = Text(messages("checkLiabilityDetailsAnswers.weight"))
+                        ),
+                        value = Value(
+                            content = Text(registration.liabilityDetails.weight.flatMap(_.totalKg).map(w => s"${w.toString} kg").getOrElse(""))
+                        ),
+                        actions = Some(Actions(
+                            items = Seq(
+                                ActionItem(
+                                    href = pptRoutes.LiabilityWeightController.displayPage().url,
+                                    content = Text(messages("site.link.change")),
+                                    visuallyHiddenText = Some(messages("checkLiabilityDetailsAnswers.weight"))
+                                )
+                            )
+                        ))
+                    ),
+                    SummaryListRow(
+                        key = Key(
                             content = Text(messages("checkLiabilityDetailsAnswers.date"))
                             ),
                         value = Value(
@@ -61,25 +78,7 @@
                                 )
                             )
                         ))
-                    ),
-                    SummaryListRow(
-                        key = Key(
-                            content = Text(messages("checkLiabilityDetailsAnswers.weight"))
-                            ),
-                        value = Value(
-                            content = Text(registration.liabilityDetails.weight.flatMap(_.totalKg).map(w => s"${w.toString} kg").getOrElse(""))
-                            ),
-                        actions = Some(Actions(
-                            items = Seq(
-                                ActionItem(
-                                    href = pptRoutes.LiabilityWeightController.displayPage().url,
-                                    content = Text(messages("site.link.change")),
-                                    visuallyHiddenText = Some(messages("checkLiabilityDetailsAnswers.weight"))
-                                    )
-                                )
-                            ))
-                        )
-
+                    )
                 ).filterNot(_.value.content == Empty)
             )
         )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/registration_page.scala.html
@@ -79,7 +79,7 @@
             @task(1, "registrationPage.prepareApplication", Set(
                 TaskSection(
                     title  = "registrationPage.liabilityDetails",
-                    link   = pptRoutes.LiabilityStartDateController.displayPage(),
+                    link   = pptRoutes.LiabilityWeightController.displayPage(),
                     status = registration.liabilityDetailsStatus
                 ),
                 TaskSection(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -73,10 +73,10 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
     "display liability date" in {
 
-      view.getElementsByClass("govuk-summary-list__key").first() must containMessage(
+      view.getElementsByClass("govuk-summary-list__key").get(1) must containMessage(
         "checkLiabilityDetailsAnswers.date"
       )
-      view.getElementsByClass("govuk-summary-list__value").first() must containText(
+      view.getElementsByClass("govuk-summary-list__value").get(1) must containText(
         registration.liabilityDetails.startDate.get.asLocalDate.format(
           DateTimeFormatter.ofPattern("dd MMM yyyy")
         )
@@ -85,46 +85,46 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
     "display empty value when no date on registration object" in {
 
-      viewWithEmptyRegistration.getElementsByClass(
-        "govuk-summary-list__key"
-      ).first() must containMessage("checkLiabilityDetailsAnswers.date")
-      viewWithEmptyRegistration.getElementsByClass(
-        "govuk-summary-list__value"
-      ).first.text() mustBe ""
+      viewWithEmptyRegistration.getElementsByClass("govuk-summary-list__key").get(
+        1
+      ) must containMessage("checkLiabilityDetailsAnswers.date")
+      viewWithEmptyRegistration.getElementsByClass("govuk-summary-list__value").get(
+        1
+      ).text() mustBe ""
     }
 
     val summaryList = view.getElementsByClass("govuk-summary-list")
 
     "display link to change liability date" in {
 
-      summaryList.first.getElementsByClass("govuk-link").first() must haveHref(
+      summaryList.first.getElementsByClass("govuk-link").get(1) must haveHref(
         routes.LiabilityStartDateController.displayPage()
       )
     }
 
     "display liability weight" in {
 
-      view.getElementsByClass("govuk-summary-list__key").get(1) must containMessage(
+      view.getElementsByClass("govuk-summary-list__key").first() must containMessage(
         "checkLiabilityDetailsAnswers.weight"
       )
-      view.getElementsByClass("govuk-summary-list__value").get(1) must containText(
+      view.getElementsByClass("govuk-summary-list__value").first() must containText(
         registration.liabilityDetails.weight.get.totalKg.get.toString
       )
     }
 
     "display empty value when no weight on registration object" in {
 
-      viewWithEmptyRegistration.getElementsByClass("govuk-summary-list__key").get(
-        1
-      ) must containMessage("checkLiabilityDetailsAnswers.weight")
-      viewWithEmptyRegistration.getElementsByClass("govuk-summary-list__value").get(
-        1
-      ).text() mustBe ""
+      viewWithEmptyRegistration.getElementsByClass(
+        "govuk-summary-list__key"
+      ).first() must containMessage("checkLiabilityDetailsAnswers.weight")
+      viewWithEmptyRegistration.getElementsByClass(
+        "govuk-summary-list__value"
+      ).first().text() mustBe ""
     }
 
     "display link to change liability weight" in {
 
-      summaryList.first.getElementsByClass("govuk-link").get(1) must haveHref(
+      summaryList.first.getElementsByClass("govuk-link").first() must haveHref(
         routes.LiabilityWeightController.displayPage()
       )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
@@ -20,7 +20,6 @@ import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
 import play.api.data.Form
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityWeight
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability_weight_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/PartnershipTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/PartnershipTypeViewSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{
   SCOTTISH_LIMITED_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{OrganisationType, PartnershipType}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipType
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partnership_type
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
@@ -133,7 +133,7 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
             "task.status.inProgress"
           )
           sectionLink(prepareApplicationElem, LIABILITY_DETAILS) must haveHref(
-            routes.LiabilityStartDateController.displayPage()
+            routes.LiabilityWeightController.displayPage()
           )
 
           sectionName(prepareApplicationElem, BUSINESS_DETAILS) mustBe messages(
@@ -201,7 +201,7 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
             "task.status.completed"
           )
           sectionLink(prepareApplicationElem, LIABILITY_DETAILS) must haveHref(
-            routes.LiabilityStartDateController.displayPage()
+            routes.LiabilityWeightController.displayPage()
           )
 
           sectionName(prepareApplicationElem, BUSINESS_DETAILS) mustBe messages(
@@ -271,7 +271,7 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
             "task.status.completed"
           )
           sectionLink(prepareApplicationElem, LIABILITY_DETAILS) must haveHref(
-            routes.LiabilityStartDateController.displayPage()
+            routes.LiabilityWeightController.displayPage()
           )
 
           sectionName(prepareApplicationElem, BUSINESS_DETAILS) mustBe messages(


### PR DESCRIPTION
* **PPTP-2019 Change Liability link on TaskList page**
The /GET link should be the Liability Weight questions and no longer the
Liability Start date question, as based on UR we have swapped them.

* **PPTP-2019 Re-order answers on Liability CYAP**
* **BAU - Clean imports** 