### PR TITLE
PPTP-1017 : Capture PPT weight page refactor

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
@@ -1,70 +1,88 @@
 @*
- * Copyright 2021 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukButton, GovukInput, govukFieldset}
 @import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.govukFieldset
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityWeight
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.paragraphBody
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.sectionHeader
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.errorSummary
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.saveButtons
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{errorSummary, paragraphBody, saveButtons, sectionHeader}
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
 
 @this(
-  govukLayout: main_template,
-  paragraphBody: paragraphBody,
-  govukButton: GovukButton,
-  govukInput: GovukInput,
-  sectionHeader: sectionHeader,
-  govukFieldset: govukFieldset,
-  errorSummary: errorSummary,
-  formHelper: formWithCSRF,
-  saveButtons: saveButtons,
+        govukLayout: main_template,
+        paragraphBody: paragraphBody,
+        govukButton: GovukButton,
+        govukInput: GovukInput,
+        sectionHeader: sectionHeader,
+        govukFieldset: govukFieldset,
+        errorSummary: errorSummary,
+        formHelper: formWithCSRF,
+        saveButtons: saveButtons,
+        govukInsetText: GovukInsetText,
 )
 @(form: Form[LiabilityWeight])(implicit request: Request[_], messages: Messages)
 
-@totalWeightField = @{form("totalKg")}
+@totalWeightField = @{
+    form("totalKg")
+}
 
 @errorMessages = @{
     val errors = (form.errors).map(err => messages(err.message, err.key)).mkString("<br>")
     if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 }
 
+@pptWeightQuestion = {
+    <h1 class="govuk-heading-l">@messages("liabilityWeightPage.question")</h1>
+}
+
+@pptGuidanceLink = {
+    <a id="guidance-link" href="@messages("liabilityWeightPage.guidance.href")" target="_blank">@messages("liabilityWeightPage.guidance.description")</a>
+}
+
+@pptWeightHelp = {
+    <p class="govuk-body">@messages("liabilityWeightPage.info")</p>
+    <p class="govuk-body">@Html(messages("liabilityWeightPage.info2", pptGuidanceLink))</p>
+}
+
 @govukLayout(title = Title("liabilityWeightPage.title")) {
-  @errorSummary(form.errors)
 
-  @sectionHeader(messages("liabilityWeightPage.sectionHeader"))
+    @errorSummary(form.errors)
 
-  @formHelper(action = pptRoutes.LiabilityWeightController.submit(), 'autoComplete -> "off") {
-    @govukInput(
-    Input(
-        id = s"${totalWeightField.name}",
-        name = totalWeightField.name,
-        value = totalWeightField.value,
-        hint = Some(Hint(content = HtmlContent(Html( messages("liabilityWeightPage.hint"))))),
-        label = Label(
-            isPageHeading = true,
-            classes = s"govuk-label--l",
-            content = Text(messages("liabilityWeightPage.question"))),
-            errorMessage = errorMessages)
+    @sectionHeader(messages("liabilityWeightPage.sectionHeader"))
+
+    @pptWeightQuestion
+
+    @pptWeightHelp
+
+    @formHelper(action = pptRoutes.LiabilityWeightController.submit(), 'autoComplete -> "off") {
+        @govukInput(
+            Input(
+                id = s"${totalWeightField.name}",
+                name = totalWeightField.name,
+                value = totalWeightField.value,
+                hint = None,
+                label = Label(
+                    content = Text(messages("liabilityWeightPage.label"))
+                ),
+                errorMessage = errorMessages,
+                suffix = Some(PrefixOrSuffix(
+                    content = Text("kg")
+                )),
+                classes = "govuk-input--width-5"
+            )
         )
-    @saveButtons()
+        @saveButtons()
     }
-  }
+}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -68,17 +68,21 @@ task.status.inProgress = In Progress
 task.status.completed = Completed
 task.status.cannotStartYet = Cannot Start Yet
 
-liabilityStartDatePage.sectionHeader = Plastic Packaging Details
+liabilityStartDatePage.sectionHeader = Plastic packaging details
 liabilityStartDatePage.title = What is the date you first became liable?
 liabilityStartDatePage.hint = For example, 12 11 2007
 liabilityStartDatePage.question = What is the date you first became liable?
 liabilityStartDate.formatting.error = Liability start date - wrong format
 liabilityStartDate.outOfRange.error = Liability start date - out of range
 
+liabilityWeightPage.sectionHeader = Plastic packaging details
 liabilityWeightPage.title = Enter the weight of plastic packaging processed
-liabilityWeightPage.question = What was the total weight of plastic packaging processed in the last 12 months?
-liabilityWeightPage.hint = This includes all manufactured, imported and converted plastic packaging except for any external transit packaging that was applied to imported goods before they entered the UK.
-liabilityWeightPage.sectionHeader = Plastic Packaging Details
+liabilityWeightPage.info = This includes all plastic packaging that you''ve manufactured, converted or imported into the UK. The packaging could be made with recycled plastic or not.
+liabilityWeightPage.info2 = If you''re unsure what to include, you can follow {0}.
+liabilityWeightPage.guidance.description = the current guidance for businesses (opens in a new tab)
+liabilityWeightPage.guidance.href = https://www.gov.uk/government/publications/get-your-business-ready-for-the-plastic-packaging-tax/further-information-for-businesses
+liabilityWeightPage.label = Weight, in kilograms
+liabilityWeightPage.question = How much plastic packaging have you processed in the last 12 months?
 liabilityWeight.outOfRange.error = Weight out of range
 liabilityWeight.empty.error = Weight cannot be empty
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
@@ -35,12 +35,16 @@ class LiabilityWeightViewSpec extends UnitViewSpec with Matchers {
   "Liability Weight View" should {
 
     "have proper messages for labels" in {
-      messages must haveTranslationFor("liabilityWeightPage.title")
-      messages must haveTranslationFor("liabilityWeightPage.question")
-      messages must haveTranslationFor("liabilityWeightPage.hint")
       messages must haveTranslationFor("liabilityWeightPage.sectionHeader")
-      messages must haveTranslationFor("liabilityWeight.empty.error")
+      messages must haveTranslationFor("liabilityWeightPage.title")
+      messages must haveTranslationFor("liabilityWeightPage.info")
+      messages must haveTranslationFor("liabilityWeightPage.info2")
+      messages must haveTranslationFor("liabilityWeightPage.guidance.description")
+      messages must haveTranslationFor("liabilityWeightPage.guidance.href")
+      messages must haveTranslationFor("liabilityWeightPage.question")
+      messages must haveTranslationFor("liabilityWeightPage.label")
       messages must haveTranslationFor("liabilityWeight.outOfRange.error")
+      messages must haveTranslationFor("liabilityWeight.empty.error")
     }
 
     val view = createView()
@@ -76,14 +80,33 @@ class LiabilityWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display liability weight question" in {
 
-      view.getElementsByAttributeValueMatching("for", "totalKg").text() must include(
+      view.getElementsByClass("govuk-heading-l").text() must include(
         messages("liabilityWeightPage.question")
       )
     }
 
-    "display question hint" in {
+    "display liability weight information" in {
 
-      view.getElementById("totalKg-hint") must containMessage("liabilityWeightPage.hint")
+      view.getElementsByClass("govuk-body").text() must include(
+        messages("liabilityWeightPage.info",
+                 "liabilityWeightPage.info2",
+                 "liabilityWeightPage.guidance.description"
+        )
+      )
+    }
+
+    "display liability weight information link" in {
+
+      view.getElementById("guidance-link") must haveHref(
+        messages("liabilityWeightPage.guidance.href")
+      )
+    }
+
+    "display total weight label" in {
+
+      view.getElementsByAttributeValue("for", "totalKg").get(0).text() mustBe messages(
+        "liabilityWeightPage.label"
+      )
     }
 
     "display total weight input box" in {


### PR DESCRIPTION
Refactored to be consistent with the latest version in the prototype. In order to include all the necessary help text and remain compliant with the GDS guidelines, I had to remove use of the main page question as a text field heading and add the main question and help text as separate page pieces.