### PR TITLE
PPTP-1018 : New not liable page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.not_liable
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class NotLiableController @Inject() (
+  authenticate: AuthAction,
+  journeyAction: JourneyAction,
+  mcc: MessagesControllerComponents,
+  page: not_liable
+) extends FrontendController(mcc) with I18nSupport {
+
+  def displayPage(): Action[AnyContent] =
+    authenticate { implicit request =>
+      Ok(page())
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
@@ -1,24 +1,29 @@
 @*
- * Copyright 2021 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @this()
 
 @(text: String, textHidden: Option[String] = None, call: Call, target: String = "_self", id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
 
-@hasHint = @{textHidden.exists(_.nonEmpty)}
+@hasHint = @{
+    textHidden.exists(_.nonEmpty)
+}
 
-<a class="@classes" href="@call" target=@target @id.map{id => id="@id" }>
- <span @if(hasHint){aria-hidden="true"}>@text</span>@if(hasHint){<span class="govuk-visually-hidden">@{textHidden.getOrElse("")}</span>}</a>
+<a class="@classes" href="@call" target=@target @id.map { id => id="@id"}><span @if(hasHint) {
+    aria-hidden="true"}>@text</span>@if(hasHint) {
+    <span class="govuk-visually-hidden">@{
+        textHidden.getOrElse("")
+    }</span>
+}</a>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/pageHeading.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/pageHeading.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles.gdsPageHeading
+
+@this()
+
+@(text: String, classes: String = "govuk-heading-l", id: Option[String] = None)
+
+<h1 class="@{classes}" @id.map{id => id="@id"}>@text</h1>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/paragraph.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/paragraph.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
+
+<p class="@classes" @id.map{id => id="@id"}>@content</p>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/subHeading.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/subHeading.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles.gdsPageHeading
+
+@this()
+
+@(text: String, classes: String = "govuk-heading-m", id: Option[String] = None)
+
+<h2 class="@{classes}" @id.map{id => id="@id"}>@text</h2>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
@@ -17,12 +17,14 @@
 @import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityWeight
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{errorSummary, paragraphBody, saveButtons, sectionHeader}
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components._
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 
 @this(
         govukLayout: main_template,
-        paragraphBody: paragraphBody,
+        pageHeading: pageHeading,
+        paragraph: paragraph,
+        link: link,
         govukButton: GovukButton,
         govukInput: GovukInput,
         sectionHeader: sectionHeader,
@@ -44,16 +46,30 @@
 }
 
 @pptWeightQuestion = {
-    <h1 class="govuk-heading-l">@messages("liabilityWeightPage.question")</h1>
+    @pageHeading(
+        text = messages("liabilityWeightPage.question")
+    )
 }
 
 @pptGuidanceLink = {
-    <a id="guidance-link" href="@messages("liabilityWeightPage.guidance.href")" target="_blank">@messages("liabilityWeightPage.guidance.description")</a>
+    @link(
+        id = Some("guidance-link"),
+        target = "_blank",
+        text = messages("liabilityWeightPage.guidance.description"),
+        call = Call(
+            method = "GET",
+            url = messages("liabilityWeightPage.guidance.href")
+        )
+    )
 }
 
 @pptWeightHelp = {
-    <p class="govuk-body">@messages("liabilityWeightPage.info")</p>
-    <p class="govuk-body">@Html(messages("liabilityWeightPage.info2", pptGuidanceLink))</p>
+    @paragraph(
+        content = Html(messages("liabilityWeightPage.info"))
+    )
+    @paragraph(
+        content = Html(messages("liabilityWeightPage.info2", pptGuidanceLink))
+    )
 }
 
 @govukLayout(title = Title("liabilityWeightPage.title")) {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/not_liable.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/not_liable.scala.html
@@ -1,0 +1,119 @@
+@*
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.govukfrontend.views.html.components.govukFieldset
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components._
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
+@import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.components._
+
+@this(
+        govukLayout: main_template,
+        pageHeading: pageHeading,
+        subHeading: subHeading,
+        paragraph: paragraph,
+        link: link,
+        govukButton: GovukButton,
+        govukInput: GovukInput,
+        sectionHeader: sectionHeader,
+        govukFieldset: govukFieldset,
+        errorSummary: errorSummary,
+        formHelper: formWithCSRF,
+        saveButtons: saveButtons,
+        govukInsetText : GovukInsetText,
+        appConfig: AppConfig
+)
+@()(implicit request: Request[_], messages: Messages)
+
+@isAuthenticated = @{request.isInstanceOf[AuthenticatedRequest[_]]}
+
+@feedbackUrl = @{
+    if (isAuthenticated) {
+        s"${appConfig.authenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
+    } else {
+        s"${appConfig.unauthenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
+    }
+}
+
+@notLiableHead = {
+    @pageHeading(
+        text = messages("notLiable.title"),
+        id = Some("page-heading")
+    )
+}
+
+@recordsWarning = {
+    @govukInsetText(InsetText(
+        content = Text(messages("notLiable.inset")),
+        id = Some("records-warning")
+    ))
+}
+
+@guidanceLink = @{
+    link(
+        id = Some("guidance-link"),
+        target = "_blank",
+        text = messages("notLiable.guidance.link.description"),
+        call = Call(
+            method = "GET",
+            url = messages("notLiable.guidance.link.href")
+        )
+    )
+}
+
+@guidance = {
+    @paragraph(
+        content = Html(messages("notLiable.guidance", guidanceLink)),
+        id = Some("guidance-text")
+    )
+}
+
+@feedbackLink = @{
+    link(
+        id = Some("feedback-link"),
+        text = messages("notLiable.think.feedback.link.description"),
+        call = Call(
+            method = "GET",
+            url = feedbackUrl
+        )
+    )
+}
+
+@feedback = {
+    @subHeading(
+        text = messages("notLiable.think.title"),
+        id = Some("feedback-heading")
+    )
+    @paragraph(
+        content = Html(messages("notLiable.think.info")),
+        id = Some("feedback-text1")
+    )
+    @paragraph(
+        content = Html(messages("notLiable.think.feedback", feedbackLink)),
+        id = Some("feedback-text2")
+    )
+}
+
+@govukLayout(title = Title("notLiable.pageTitle")) {
+
+    @notLiableHead
+    @recordsWarning
+    @guidance
+    @feedback
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,6 +14,8 @@ POST       /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controll
 GET        /total-packaging-weight        uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityWeightController.displayPage()
 POST       /total-packaging-weight        uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityWeightController.submit()
 
+GET        /not-liable  uk.gov.hmrc.plasticpackagingtax.registration.controllers.NotLiableController.displayPage()
+
 GET        /check-plastic-packaging-answers    uk.gov.hmrc.plasticpackagingtax.registration.controllers.CheckLiabilityDetailsAnswersController.displayPage()
 POST       /check-plastic-packaging-answers    uk.gov.hmrc.plasticpackagingtax.registration.controllers.CheckLiabilityDetailsAnswersController.submit()
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -217,3 +217,14 @@ organisationDetails.notSupportCompanyTypePage.tellUs = Tell us what you think
 organisationDetails.notSupportCompanyTypePage.paragraph.2 = This is a new service and we want to know what you think of it.
 organisationDetails.feedback = {0}. Your thoughts and ideas will help us to make improvements.
 organisationDetails.feedback.link = Send us your feedback
+
+notLiable.pageTitle = You do not currently need to register at this time
+notLiable.title = You do not currently need to register for Plastic Packaging Tax
+notLiable.inset = You may need to register for it in the future. You must keep records of all the plastic packaging you manufacture, convert or import into the UK.
+notLiable.guidance = The Plastic Packaging Tax guidance has {0}.
+notLiable.guidance.link.description = more information on the type of records you must keep (opens in a new tab)
+notLiable.guidance.link.href = https://www.gov.uk/government/publications/get-your-business-ready-for-the-plastic-packaging-tax/further-information-for-businesses#record-keeping
+notLiable.think.title = Tell us what you think
+notLiable.think.info = This is a new service and we want to know what you think of it.
+notLiable.think.feedback = {0}. Your thoughts and ideas will help us to make improvements.
+notLiable.think.feedback.link.description = Send us your feedback

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableControllerTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import base.unit.ControllerSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status.OK
+import play.api.test.Helpers.status
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.not_liable
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class NotLiableControllerTest extends ControllerSpec {
+
+  private val page = mock[not_liable]
+  private val mcc  = stubMessagesControllerComponents()
+
+  private val controller =
+    new NotLiableController(authenticate = mockAuthAction,
+                            mockJourneyAction,
+                            mcc = mcc,
+                            page = page
+    )
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(page)
+    super.afterEach()
+  }
+
+  "Not liable Controller" should {
+
+    "return 200" when {
+
+      "user is authorised and display page method is invoked" in {
+        authorizedUser()
+        val result = controller.displayPage()(getRequest())
+
+        status(result) mustBe OK
+      }
+    }
+
+    "return an error" when {
+
+      "user is not authorised" in {
+        unAuthorizedUser()
+        val result = controller.displayPage()(getRequest())
+
+        intercept[RuntimeException](status(result))
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.test.FakeRequest
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.not_liable
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+
+@ViewTest
+class NotLiableViewSpec extends UnitViewSpec with Matchers {
+
+  private val page      = instanceOf[not_liable]
+  private val appConfig = instanceOf[AppConfig]
+
+  private def createView(): Document =
+    page()(request, messages)
+
+  "Not Liable View" should {
+
+    "have proper messages for labels" in {
+      messages must haveTranslationFor("notLiable.pageTitle")
+      messages must haveTranslationFor("notLiable.title")
+      messages must haveTranslationFor("notLiable.inset")
+      messages must haveTranslationFor("notLiable.guidance")
+      messages must haveTranslationFor("notLiable.guidance.link.description")
+      messages must haveTranslationFor("notLiable.guidance.link.href")
+      messages must haveTranslationFor("notLiable.think.title")
+      messages must haveTranslationFor("notLiable.think.info")
+      messages must haveTranslationFor("notLiable.think.feedback")
+      messages must haveTranslationFor("notLiable.think.feedback.link.description")
+    }
+
+    val view = createView()
+
+    "contain timeout dialog function" in {
+
+      containTimeoutDialogFunction(view) mustBe true
+    }
+
+    "display sign out link" in {
+
+      displaySignOutLink(view)
+    }
+
+    "display title" in {
+
+      view.select("title").text() must include(messages("notLiable.pageTitle"))
+    }
+
+    "display page heading" in {
+
+      view.getElementById("page-heading").text() must include(messages("notLiable.title"))
+    }
+
+    "display need for recording warning" in {
+
+      view.getElementById("records-warning").text() must include(messages("notLiable.inset"))
+    }
+
+    "display guidance text" in {
+
+      view.getElementById("guidance-text").text() must include(
+        messages("notLiable.guidance", messages("notLiable.guidance.link.description"))
+      )
+    }
+
+    "display guidance link" in {
+
+      view.getElementById("guidance-link") must haveHref(messages("notLiable.guidance.link.href"))
+    }
+
+    "display feedback subheading" in {
+
+      view.getElementById("feedback-heading").text must include(messages("notLiable.think.title"))
+    }
+
+    "display feedback text" in {
+
+      view.getElementById("feedback-text1").text must include(messages("notLiable.think.info"))
+      view.getElementById("feedback-text2").text must include(
+        messages("notLiable.think.feedback", messages("notLiable.think.feedback.link.description"))
+      )
+    }
+
+    "display feedback link for authenticated users" in {
+
+      view.getElementById("feedback-link") must haveHref(
+        s"${appConfig.authenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}/"
+      )
+    }
+
+    "display feedback link for unauthenticated users" in {
+
+      val unauthenticatedView = page()(FakeRequest(), messages)
+      unauthenticatedView.getElementById("feedback-link") must haveHref(
+        s"${appConfig.unauthenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}/"
+      )
+    }
+  }
+}


### PR DESCRIPTION
I've added some new Twirl components for common page elements which encapsulate use of the required govuk css classes and back-ported their use to the liability weight page. I've used HTML ids more judiciously on the not liable page which (I believe) makes the unit tests less brittle.