### PR TITLE
PPTP-1020 Liability Check - 3. Will you still be liable in April 22 Page?

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -127,4 +127,9 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   def unauthenticatedFeedbackUrl(): String =
     s"$feedbackUnauthenticatedLink?service=${serviceIdentifier}"
 
+  lazy val isLiabilityPreLaunchEnabled =
+    config
+      .getOptional[Boolean](s"features.liabilityPreLaunch")
+      .getOrElse(true)
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -127,9 +127,9 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   def unauthenticatedFeedbackUrl(): String =
     s"$feedbackUnauthenticatedLink?service=${serviceIdentifier}"
 
-  lazy val isLiabilityPreLaunchEnabled: Boolean =
+  lazy val isPreLaunch: Boolean =
     config
       .getOptional[Boolean](s"features.liabilityPreLaunch")
-      .getOrElse(true)
+      .getOrElse(false)
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -127,7 +127,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   def unauthenticatedFeedbackUrl(): String =
     s"$feedbackUnauthenticatedLink?service=${serviceIdentifier}"
 
-  lazy val isLiabilityPreLaunchEnabled =
+  lazy val isLiabilityPreLaunchEnabled: Boolean =
     config
       .getOptional[Boolean](s"features.liabilityPreLaunch")
       .getOrElse(true)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersController.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.check_liability_details_answers_page
@@ -32,7 +33,8 @@ class CheckLiabilityDetailsAnswersController @Inject() (
   journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
   page: check_liability_details_answers_page
-) extends FrontendController(mcc) with I18nSupport {
+)(implicit appConfig: AppConfig)
+    extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =
     (authenticate andThen journeyAction) { implicit request =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
-import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
@@ -25,6 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.check_liability_details_answers_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.Future
 
 @Singleton
@@ -32,14 +32,22 @@ class CheckLiabilityDetailsAnswersController @Inject() (
   authenticate: AuthAction,
   journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
-  page: check_liability_details_answers_page
-)(implicit appConfig: AppConfig)
-    extends FrontendController(mcc) with I18nSupport {
+  page: check_liability_details_answers_page,
+  appConfig: AppConfig
+) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =
     (authenticate andThen journeyAction) { implicit request =>
-      Ok(page(request.registration))
+      Ok(page(request.registration, backLink))
     }
+
+  private def backLink = {
+    val backLink = {
+      if (appConfig.isPreLaunch) routes.LiabilityLiableDateController.displayPage()
+      else routes.LiabilityStartDateController.displayPage()
+    }
+    backLink
+  }
 
   def submit(): Action[AnyContent] =
     (authenticate andThen journeyAction).async { _ =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateController.scala
@@ -66,7 +66,7 @@ class LiabilityLiableDateController @Inject() (
                   case SaveAndContinue =>
                     if (liableDate.answer.getOrElse(false))
                       Redirect(routes.CheckLiabilityDetailsAnswersController.displayPage())
-                    else Redirect(routes.CheckLiabilityDetailsAnswersController.displayPage())
+                    else Redirect(routes.NotLiableController.displayPage())
                   case _ => Redirect(routes.RegistrationController.displayPage())
                 }
               case Left(error) => throw error

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateController.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
   FormAction,
   SaveAndContinue
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Date, LiabilityLiableDate}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability_liable_date_page
@@ -80,8 +80,16 @@ class LiabilityLiableDateController @Inject() (
   )(implicit req: JourneyRequest[AnyContent]): Future[Either[ServiceError, Registration]] =
     update { registration =>
       val updatedLiableDetails =
-        registration.liabilityDetails.copy(isLiable = formData.answer)
+        registration.liabilityDetails.copy(isLiable = formData.answer,
+                                           startDate = startDate(formData)
+        )
       registration.copy(liabilityDetails = updatedLiableDetails)
+    }
+
+  private def startDate(formData: LiabilityLiableDate): Option[Date] =
+    formData.answer match {
+      case Some(true)  => Some(Date(Some(1), Some(4), Some(2022)))
+      case Some(false) => None
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightController.scala
@@ -66,7 +66,7 @@ class LiabilityWeightController @Inject() (
               case Right(_) =>
                 FormAction.bindFromRequest match {
                   case SaveAndContinue =>
-                    if (appConfig.isLiabilityPreLaunchEnabled)
+                    if (appConfig.isPreLaunch)
                       Redirect(routes.LiabilityLiableDateController.displayPage())
                     else
                       Redirect(routes.LiabilityStartDateController.displayPage())

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableController.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
-import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.not_liable
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -28,7 +27,6 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class NotLiableController @Inject() (
   authenticate: AuthAction,
-  journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
   page: not_liable
 ) extends FrontendController(mcc) with I18nSupport {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/LiabilityLiableDate.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/LiabilityLiableDate.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.forms
+
+import play.api.data.Form
+import play.api.data.Forms.{mapping, text}
+
+case class LiabilityLiableDate(answer: Option[Boolean])
+
+object LiabilityLiableDate extends CommonFormValidators {
+
+  lazy val emptyError = "liabilityLiableDatePage.question.empty.error"
+  val yes             = "yes"
+  val no              = "no"
+
+  def form(): Form[LiabilityLiableDate] =
+    Form(
+      mapping(
+        "answer" -> text()
+          .verifying(emptyError, contains(Seq(yes, no)))
+      )(LiabilityLiableDate.apply)(LiabilityLiableDate.unapply)
+    )
+
+  def apply(value: String): LiabilityLiableDate =
+    if (value == yes)
+      LiabilityLiableDate(Some(true))
+    else if (value == no)
+      LiabilityLiableDate(Some(false))
+    else LiabilityLiableDate(None)
+
+  def unapply(liableDate: LiabilityLiableDate): Option[String] =
+    liableDate.answer.flatMap { value =>
+      if (value) Some(yes)
+      else Some(no)
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetails.scala
@@ -22,10 +22,11 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 case class LiabilityDetails(
   weight: Option[LiabilityWeight] = None,
-  startDate: Option[Date] = None
+  startDate: Option[Date] = None,
+  isLiable: Option[Boolean] = None
 ) {
-  def isCompleted: Boolean  = weight.isDefined && startDate.isDefined
-  def isInProgress: Boolean = weight.isDefined || startDate.isDefined
+  def isCompleted: Boolean  = weight.isDefined && (startDate.isDefined || isLiable.isDefined)
+  def isInProgress: Boolean = weight.isDefined || startDate.isDefined || isLiable.isDefined
 
   def status: TaskStatus =
     if (isCompleted) TaskStatus.Completed

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
@@ -17,6 +17,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
+@import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.pageTitle
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
@@ -33,11 +34,16 @@
   pageTitle: pageTitle,
   saveAndContinue: saveAndContinue
 )
-@(registration: Registration)(implicit request: Request[_], messages: Messages)
+@(registration: Registration)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@backLink = @{
+  if(appConfig.isLiabilityPreLaunchEnabled) pptRoutes.LiabilityLiableDateController.displayPage()
+  else pptRoutes.LiabilityStartDateController.displayPage()
+}
 
 @govukLayout(
   title = Title("checkLiabilityDetailsAnswers.title"),
-  backButton = Some(BackButton(messages("site.back"), pptRoutes.LiabilityStartDateController.displayPage(), messages("site.back.hiddenText")))) {
+  backButton = Some(BackButton(messages("site.back"), backLink, messages("site.back.hiddenText")))) {
 
     @pageTitle(text = messages("checkLiabilityDetailsAnswers.title"))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
@@ -34,12 +34,7 @@
   pageTitle: pageTitle,
   saveAndContinue: saveAndContinue
 )
-@(registration: Registration)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
-
-@backLink = @{
-  if(appConfig.isPreLaunch) pptRoutes.LiabilityLiableDateController.displayPage()
-  else pptRoutes.LiabilityStartDateController.displayPage()
-}
+@(registration: Registration, backLink: Call)(implicit request: Request[_], messages: Messages)
 
 @govukLayout(
   title = Title("checkLiabilityDetailsAnswers.title"),

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
@@ -37,7 +37,7 @@
 @(registration: Registration)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @backLink = @{
-  if(appConfig.isLiabilityPreLaunchEnabled) pptRoutes.LiabilityLiableDateController.displayPage()
+  if(appConfig.isPreLaunch) pptRoutes.LiabilityLiableDateController.displayPage()
   else pptRoutes.LiabilityStartDateController.displayPage()
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_liable_date_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_liable_date_page.scala.html
@@ -1,0 +1,70 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.sectionHeader
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.errorSummary
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.saveButtons
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate.yes
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate.no
+
+@this(
+    formHelper: formWithCSRF,
+    govukLayout: main_template,
+    govukRadios : GovukRadios,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    errorSummary: errorSummary
+)
+
+@(form: Form[LiabilityLiableDate])(implicit request: Request[_], messages: Messages)
+
+@govukLayout(
+    title = Title("liabilityLiableDatePage.title"),
+    backButton = Some(BackButton(messages("site.back"), pptRoutes.LiabilityWeightController.displayPage(), messages("site.back.hiddenText")))) {
+    @errorSummary(form.errors)
+
+    @sectionHeader(messages("liabilityLiableDatePage.sectionHeader"))
+
+    @formHelper(action = pptRoutes.LiabilityLiableDateController.submit(), 'autoComplete -> "off") {
+
+    @govukRadios(Radios(
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("liabilityLiableDatePage.question")),
+                classes = "govuk-fieldset__legend--l",
+                isPageHeading = true
+                ))
+            )),
+        hint = Some(Hint(content = Text(messages("liabilityLiableDatePage.hint")))),
+        idPrefix = Some(form("answer").name),
+        name = form("answer").name,
+        items = Seq(
+            RadioItem(content = Text("Yes"), value = Some("yes"), checked = form("answer").value.contains(yes)),
+            RadioItem(content = Text("No"), value = Some("no"), checked = form("answer").value.contains(no))
+        ),
+        classes = "govuk-radios",
+        errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+        ))
+
+    @saveButtons()
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,11 +8,11 @@ GET        /register-plastic-packaging-tax                  uk.gov.hmrc.plasticp
 
 GET        /incorp-id-callback      uk.gov.hmrc.plasticpackagingtax.registration.controllers.IncorpIdController.incorpIdCallback(journeyId)
 
-GET        /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityLiableDateController.displayPage()
-POST       /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityLiableDateController.submit()
+GET        /liability-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityLiableDateController.displayPage()
+POST       /liability-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityLiableDateController.submit()
 
-GET        /start-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.displayPage()
-POST       /start-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.submit()
+GET        /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.displayPage()
+POST       /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.submit()
 
 GET        /total-packaging-weight        uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityWeightController.displayPage()
 POST       /total-packaging-weight        uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityWeightController.submit()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,8 +8,11 @@ GET        /register-plastic-packaging-tax                  uk.gov.hmrc.plasticp
 
 GET        /incorp-id-callback      uk.gov.hmrc.plasticpackagingtax.registration.controllers.IncorpIdController.incorpIdCallback(journeyId)
 
-GET        /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.displayPage()
-POST       /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.submit()
+GET        /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityLiableDateController.displayPage()
+POST       /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityLiableDateController.submit()
+
+GET        /start-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.displayPage()
+POST       /start-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityStartDateController.submit()
 
 GET        /total-packaging-weight        uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityWeightController.displayPage()
 POST       /total-packaging-weight        uk.gov.hmrc.plasticpackagingtax.registration.controllers.LiabilityWeightController.submit()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -116,6 +116,10 @@ microservice {
   }
 }
 
+features {
+  liabilityPreLaunch = false
+}
+
 timeoutDialog {
   timeout = "13m"
   countdown = "2m"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -75,6 +75,13 @@ liabilityStartDatePage.question = What is the date you first became liable?
 liabilityStartDate.formatting.error = Liability start date - wrong format
 liabilityStartDate.outOfRange.error = Liability start date - out of range
 
+liabilityLiableDatePage.sectionHeader = Liability details
+liabilityLiableDatePage.title = What is your liability date?
+liabilityLiableDatePage.hint = To register for this service, you must expect your business to continue being liable for Plastic Packaging Tax until at least 1 April 2022, when the tax starts.
+liabilityLiableDatePage.question = Will you still be liable for the Plastic Packaging Tax by 1 April 2022?
+liabilityLiableDatePage.question.empty.error = Choose an option
+
+liabilityWeightPage.sectionHeader = Plastic packaging details
 liabilityWeightPage.sectionHeader = Plastic packaging details
 liabilityWeightPage.title = Enter the weight of plastic packaging processed
 liabilityWeightPage.info = This includes all plastic packaging that you''ve manufactured, converted or imported into the UK. The packaging could be made with recycled plastic or not.

--- a/tampermonkey/PPT_AutoComplete.js
+++ b/tampermonkey/PPT_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PPT Registration AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      13.0
+// @version      14.0
 // @description
 // @author       pmonteiro
 // @match        http*://*/plastic-packaging-tax*
@@ -317,6 +317,14 @@ const liabilityStartDate = () => {
     }
 }
 
+const liabilityLiableDate = () => {
+    if (currentPageIs('/plastic-packaging-tax/liability-date')) {
+
+        document.getElementById('answer').checked = true
+        document.getElementsByClassName('govuk-button')[0].click()
+    }
+}
+
 const liabilityWeight = () => {
     if (currentPageIs('/plastic-packaging-tax/total-packaging-weight')) {
 
@@ -437,6 +445,7 @@ const completeJourney = () => {
     organisationType()
 
     // Liability Details
+    liabilityLiableDate()
     liabilityStartDate()
     liabilityWeight()
     liabilityCheckYourAnswers()

--- a/test/base/unit/UnitViewSpec.scala
+++ b/test/base/unit/UnitViewSpec.scala
@@ -19,6 +19,7 @@ package base.unit
 import base.{Injector, PptTestData}
 import com.codahale.metrics.SharedMetricRegistries
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
@@ -29,8 +30,8 @@ import spec.{PptTestData, ViewMatchers}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
 
 class UnitViewSpec
-    extends AnyWordSpec with MockRegistrationConnector with ViewMatchers with ViewAssertions
-    with Injector with GuiceOneAppPerSuite with PptTestData {
+    extends AnyWordSpec with MockRegistrationConnector with MockitoSugar with ViewMatchers
+    with ViewAssertions with Injector with GuiceOneAppPerSuite with PptTestData {
 
   import utils.FakeRequestCSRFSupport._
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
@@ -38,7 +38,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         |microservice.services.plastic-packaging-tax-registration.port=8502
         |microservice.services.contact-frontend.host=localhost
         |microservice.services.contact-frontend.port=9250
-        |features.liabilityPreLaunch=false
+        |features.isPreLaunch=false
         |urls.feedback.authenticatedLink="http://localhost:9250/contact/beta-feedback"
         |urls.feedback.unauthenticatedLink="http://localhost:9250/contact/beta-feedback-unauthenticated"
       """.stripMargin
@@ -125,8 +125,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
       )
     }
     "inspect feature flags" when {
-      "and check that 'liabilityPreLaunch' is true" in {
-        validAppConfig.isLiabilityPreLaunchEnabled mustBe false
+      "and check that 'liabilityPreLaunch' is false" in {
+        validAppConfig.isPreLaunch mustBe false
       }
     }
   }
@@ -137,7 +137,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
     "inspect feature flags" when {
       "and check that 'liabilityPreLaunch' default value is 'true'" in {
-        emptyAppConfig.isLiabilityPreLaunchEnabled mustBe true
+        emptyAppConfig.isPreLaunch mustBe false
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
@@ -38,13 +38,13 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
         |microservice.services.plastic-packaging-tax-registration.port=8502
         |microservice.services.contact-frontend.host=localhost
         |microservice.services.contact-frontend.port=9250
+        |features.liabilityPreLaunch=false
         |urls.feedback.authenticatedLink="http://localhost:9250/contact/beta-feedback"
         |urls.feedback.unauthenticatedLink="http://localhost:9250/contact/beta-feedback-unauthenticated"
       """.stripMargin
     )
 
-  private val validServicesConfiguration = Configuration(validConfig)
-  private val validAppConfig: AppConfig  = appConfig(validServicesConfiguration)
+  private val emptyConfig: Config = ConfigFactory.parseString("")
 
   private def appConfig(conf: Configuration) =
     new AppConfig(conf, servicesConfig(conf))
@@ -52,6 +52,8 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
   private def servicesConfig(conf: Configuration) = new ServicesConfig(conf)
 
   "The config" should {
+
+    val validAppConfig: AppConfig = appConfig(Configuration(validConfig))
 
     "have 'incorpJourneyUrl' defined" in {
       validAppConfig.incorpJourneyUrl must be(
@@ -121,6 +123,22 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
       validAppConfig.unauthenticatedFeedbackUrl() must be(
         "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax"
       )
+    }
+    "inspect feature flags" when {
+      "and check that 'liabilityPreLaunch' is true" in {
+        validAppConfig.isLiabilityPreLaunchEnabled mustBe false
+      }
+    }
+  }
+
+  "with an empty config" should {
+
+    val emptyAppConfig: AppConfig = appConfig(Configuration(emptyConfig))
+
+    "inspect feature flags" when {
+      "and check that 'liabilityPreLaunch' default value is 'true'" in {
+        emptyAppConfig.isLiabilityPreLaunchEnabled mustBe true
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersControllerTest.scala
@@ -44,7 +44,7 @@ class CheckLiabilityDetailsAnswersControllerTest extends ControllerSpec {
     val registration = aRegistration()
     mockRegistrationFind(registration)
     given(page.apply(refEq(registration))(any(), any(), any())).willReturn(HtmlFormat.empty)
-    when(config.isLiabilityPreLaunchEnabled).thenReturn(false)
+    when(config.isPreLaunch).thenReturn(false)
   }
 
   override protected def afterEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersControllerTest.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.{any, refEq}
 import org.mockito.BDDMockito.`given`
-import org.mockito.Mockito.reset
+import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.OK
 import play.api.libs.json.JsObject
@@ -43,7 +43,8 @@ class CheckLiabilityDetailsAnswersControllerTest extends ControllerSpec {
     super.beforeEach()
     val registration = aRegistration()
     mockRegistrationFind(registration)
-    given(page.apply(refEq(registration))(any(), any())).willReturn(HtmlFormat.empty)
+    given(page.apply(refEq(registration))(any(), any(), any())).willReturn(HtmlFormat.empty)
+    when(config.isLiabilityPreLaunchEnabled).thenReturn(false)
   }
 
   override protected def afterEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/CheckLiabilityDetailsAnswersControllerTest.scala
@@ -36,14 +36,15 @@ class CheckLiabilityDetailsAnswersControllerTest extends ControllerSpec {
     new CheckLiabilityDetailsAnswersController(authenticate = mockAuthAction,
                                                mockJourneyAction,
                                                mcc = mcc,
-                                               page = page
+                                               page = page,
+                                               appConfig = config
     )
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     val registration = aRegistration()
     mockRegistrationFind(registration)
-    given(page.apply(refEq(registration))(any(), any(), any())).willReturn(HtmlFormat.empty)
+    given(page.apply(refEq(registration), any())(any(), any())).willReturn(HtmlFormat.empty)
     when(config.isPreLaunch).thenReturn(false)
   }
 
@@ -56,11 +57,22 @@ class CheckLiabilityDetailsAnswersControllerTest extends ControllerSpec {
 
     "return 200" when {
 
-      "user is authorised and display page method is invoked" in {
-        authorizedUser()
-        val result = controller.displayPage()(getRequest())
+      "user is authorised and display page method is invoked" when {
+        "and 'isPreLaunch' is true" in {
+          when(config.isPreLaunch).thenReturn(true)
+          authorizedUser()
+          val result = controller.displayPage()(getRequest())
 
-        status(result) mustBe OK
+          status(result) mustBe OK
+        }
+
+        "and 'isPreLaunch' is false" in {
+          when(config.isPreLaunch).thenReturn(false)
+          authorizedUser()
+          val result = controller.displayPage()(getRequest())
+
+          status(result) mustBe OK
+        }
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateControllerSpec.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.JsObject
 import play.api.test.Helpers.{redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Date, LiabilityLiableDate}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.LiabilityDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability_liable_date_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -91,6 +91,9 @@ class LiabilityLiableDateControllerSpec extends ControllerSpec {
 
           status(result) mustBe SEE_OTHER
           modifiedRegistration.liabilityDetails.isLiable mustBe Some(true)
+          modifiedRegistration.liabilityDetails.startDate mustBe Some(
+            Date(Some(1), Some(4), Some(2022))
+          )
 
           formAction._1 match {
             case "SaveAndContinue" =>
@@ -113,6 +116,7 @@ class LiabilityLiableDateControllerSpec extends ControllerSpec {
           status(result) mustBe SEE_OTHER
 
           modifiedRegistration.liabilityDetails.isLiable mustBe Some(false)
+          modifiedRegistration.liabilityDetails.startDate mustBe None
 
           formAction._1 match {
             case "SaveAndContinue" =>

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateControllerSpec.scala
@@ -81,7 +81,7 @@ class LiabilityLiableDateControllerSpec extends ControllerSpec {
 
     forAll(Seq(saveAndContinueFormAction, saveAndComeBackLaterFormAction)) { formAction =>
       "return 303 (OK) for " + formAction._1 when {
-        "user submits positive answer" in {
+        "user submits 'Yes' answer" in {
           authorizedUser()
           mockRegistrationFind(aRegistration())
           mockRegistrationUpdate(aRegistration())
@@ -102,7 +102,7 @@ class LiabilityLiableDateControllerSpec extends ControllerSpec {
           }
         }
 
-        "user submits negative answer" in {
+        "user submits 'No' answer" in {
           authorizedUser()
           mockRegistrationFind(aRegistration())
           mockRegistrationUpdate(aRegistration())
@@ -116,9 +116,7 @@ class LiabilityLiableDateControllerSpec extends ControllerSpec {
 
           formAction._1 match {
             case "SaveAndContinue" =>
-              redirectLocation(result) mustBe Some(
-                routes.CheckLiabilityDetailsAnswersController.displayPage().url
-              )
+              redirectLocation(result) mustBe Some(routes.NotLiableController.displayPage().url)
             case "SaveAndComeBackLater" =>
               redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)
           }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityLiableDateControllerSpec.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import base.unit.ControllerSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.Inspectors.forAll
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.data.Form
+import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
+import play.api.libs.json.JsObject
+import play.api.test.Helpers.{redirectLocation, status}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.LiabilityDetails
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability_liable_date_page
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class LiabilityLiableDateControllerSpec extends ControllerSpec {
+  private val page = mock[liability_liable_date_page]
+  private val mcc  = stubMessagesControllerComponents()
+
+  private val controller =
+    new LiabilityLiableDateController(authenticate = mockAuthAction,
+                                      mockJourneyAction,
+                                      mockRegistrationConnector,
+                                      mcc = mcc,
+                                      page = page
+    )
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(page.apply(any[Form[LiabilityLiableDate]])(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(page)
+    super.afterEach()
+  }
+
+  "Liability Liable Date Controller" should {
+
+    "return 200" when {
+
+      "user is authorised and display page method is invoked" in {
+        authorizedUser()
+        mockRegistrationFind(aRegistration())
+
+        val result = controller.displayPage()(getRequest())
+
+        status(result) mustBe OK
+      }
+
+      "user is authorised, a registration already exists and display page method is invoked" in {
+        val registration =
+          aRegistration(withLiabilityDetails(LiabilityDetails(isLiable = Some(true))))
+        authorizedUser()
+        mockRegistrationFind(registration)
+
+        val result = controller.displayPage()(getRequest())
+
+        status(result) mustBe OK
+      }
+    }
+
+    forAll(Seq(saveAndContinueFormAction, saveAndComeBackLaterFormAction)) { formAction =>
+      "return 303 (OK) for " + formAction._1 when {
+        "user submits positive answer" in {
+          authorizedUser()
+          mockRegistrationFind(aRegistration())
+          mockRegistrationUpdate(aRegistration())
+
+          val correctForm = Seq("answer" -> "yes", formAction)
+          val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+          status(result) mustBe SEE_OTHER
+          modifiedRegistration.liabilityDetails.isLiable mustBe Some(true)
+
+          formAction._1 match {
+            case "SaveAndContinue" =>
+              redirectLocation(result) mustBe Some(
+                routes.CheckLiabilityDetailsAnswersController.displayPage().url
+              )
+            case "SaveAndComeBackLater" =>
+              redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)
+          }
+        }
+
+        "user submits negative answer" in {
+          authorizedUser()
+          mockRegistrationFind(aRegistration())
+          mockRegistrationUpdate(aRegistration())
+
+          val correctForm = Seq("answer" -> "no", formAction)
+          val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+          status(result) mustBe SEE_OTHER
+
+          modifiedRegistration.liabilityDetails.isLiable mustBe Some(false)
+
+          formAction._1 match {
+            case "SaveAndContinue" =>
+              redirectLocation(result) mustBe Some(
+                routes.CheckLiabilityDetailsAnswersController.displayPage().url
+              )
+            case "SaveAndComeBackLater" =>
+              redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)
+          }
+        }
+      }
+
+      "return 400 (BAD_REQUEST) for " + formAction._1 when {
+        "user does not pick an answer" in {
+          authorizedUser()
+          mockRegistrationFind(aRegistration())
+          val result =
+            controller.submit()(postRequestEncoded(JsObject.empty, formAction))
+
+          status(result) mustBe BAD_REQUEST
+        }
+
+        "user enters invalid data" in {
+          authorizedUser()
+          mockRegistrationFind(aRegistration())
+          val incorrectForm = Seq("answer" -> "maybe", formAction)
+          val result        = controller.submit()(postJsonRequestEncoded(incorrectForm: _*))
+
+          status(result) mustBe BAD_REQUEST
+        }
+      }
+
+      "return an error for " + formAction._1 when {
+
+        "user is not authorised" in {
+          unAuthorizedUser()
+          val result = controller.displayPage()(getRequest())
+
+          intercept[RuntimeException](status(result))
+        }
+
+        "user submits form and the registration update fails" in {
+          authorizedUser()
+          mockRegistrationFind(aRegistration())
+          mockRegistrationUpdateFailure()
+
+          val correctForm = Seq("answer" -> "yes", formAction)
+          val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+          intercept[DownstreamServiceError](status(result))
+        }
+
+        "user submits form and a registration update runtime exception occurs" in {
+          authorizedUser()
+          mockRegistrationFind(aRegistration())
+          mockRegistrationException()
+
+          val correctForm = Seq("answer" -> "yes", formAction)
+          val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+          intercept[RuntimeException](status(result))
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightControllerTest.scala
@@ -41,7 +41,8 @@ class LiabilityWeightControllerTest extends ControllerSpec {
                                   mockJourneyAction,
                                   mockRegistrationConnector,
                                   mcc = mcc,
-                                  page = page
+                                  page = page,
+                                  appConfig = config
     )
 
   override protected def beforeEach(): Unit = {
@@ -76,24 +77,52 @@ class LiabilityWeightControllerTest extends ControllerSpec {
 
     forAll(Seq(saveAndContinueFormAction, saveAndComeBackLaterFormAction)) { formAction =>
       "return 303 (OK) for " + formAction._1 when {
-        "user submits the liability total weight" in {
-          authorizedUser()
-          mockRegistrationFind(aRegistration())
-          mockRegistrationUpdate(aRegistration())
-          val result =
-            controller.submit()(postRequestEncoded(LiabilityWeight(Some(2000)), formAction))
+        "user submits the liability total weight" when {
+          "and feature flag 'liabilityPreLaunch' is disabled" in {
+            authorizedUser()
+            mockRegistrationFind(aRegistration())
+            mockRegistrationUpdate(aRegistration())
+            val result =
+              controller.submit()(postRequestEncoded(LiabilityWeight(Some(2000)), formAction))
 
-          status(result) mustBe SEE_OTHER
+            status(result) mustBe SEE_OTHER
 
-          modifiedRegistration.liabilityDetails.weight mustBe Some(LiabilityWeight(Some(2000)))
+            modifiedRegistration.liabilityDetails.weight mustBe Some(LiabilityWeight(Some(2000)))
 
-          formAction._1 match {
-            case "SaveAndContinue" =>
-              redirectLocation(result) mustBe Some(
-                routes.LiabilityStartDateController.displayPage().url
-              )
-            case _ =>
-              redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)
+            formAction._1 match {
+              case "SaveAndContinue" =>
+                redirectLocation(result) mustBe Some(
+                  routes.LiabilityStartDateController.displayPage().url
+                )
+              case _ =>
+                redirectLocation(result) mustBe Some(
+                  routes.RegistrationController.displayPage().url
+                )
+            }
+          }
+          "and feature flag 'liabilityPreLaunch' is enabled" in {
+            authorizedUser()
+            mockRegistrationFind(aRegistration())
+            mockRegistrationUpdate(aRegistration())
+            when(config.isLiabilityPreLaunchEnabled).thenReturn(true)
+
+            val result =
+              controller.submit()(postRequestEncoded(LiabilityWeight(Some(2000)), formAction))
+
+            status(result) mustBe SEE_OTHER
+
+            modifiedRegistration.liabilityDetails.weight mustBe Some(LiabilityWeight(Some(2000)))
+
+            formAction._1 match {
+              case "SaveAndContinue" =>
+                redirectLocation(result) mustBe Some(
+                  routes.LiabilityLiableDateController.displayPage().url
+                )
+              case _ =>
+                redirectLocation(result) mustBe Some(
+                  routes.RegistrationController.displayPage().url
+                )
+            }
           }
         }
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityWeightControllerTest.scala
@@ -104,7 +104,7 @@ class LiabilityWeightControllerTest extends ControllerSpec {
             authorizedUser()
             mockRegistrationFind(aRegistration())
             mockRegistrationUpdate(aRegistration())
-            when(config.isLiabilityPreLaunchEnabled).thenReturn(true)
+            when(config.isPreLaunch).thenReturn(true)
 
             val result =
               controller.submit()(postRequestEncoded(LiabilityWeight(Some(2000)), formAction))

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotLiableControllerTest.scala
@@ -32,11 +32,7 @@ class NotLiableControllerTest extends ControllerSpec {
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new NotLiableController(authenticate = mockAuthAction,
-                            mockJourneyAction,
-                            mcc = mcc,
-                            page = page
-    )
+    new NotLiableController(authenticate = mockAuthAction, mcc = mcc, page = page)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetailsSpec.scala
@@ -33,20 +33,55 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
     }
 
     "be IN_PROGRESS " when {
-      "liability details is partially filled" in {
-        val liabilityDetails =
-          LiabilityDetails(startDate = None, weight = Some(LiabilityWeight(Some(4000))))
-        liabilityDetails.status mustBe TaskStatus.InProgress
+      "liability details are partially filled" when {
+        "and 'liabilityPreLaunch' flag is enabled" when {
+          "and only 'isLiable' has been answered" in {
+            val liabilityDetails =
+              LiabilityDetails(isLiable = Some(true), weight = None)
+            liabilityDetails.status mustBe TaskStatus.InProgress
+          }
+
+          "and only liability weight has been answered" in {
+            val liabilityDetails =
+              LiabilityDetails(startDate = None, weight = Some(LiabilityWeight(Some(4000))))
+            liabilityDetails.status mustBe TaskStatus.InProgress
+          }
+        }
+
+        "and 'liabilityPreLaunch' flag is disabled" when {
+          "and only 'startDate' has been answered" in {
+            val liabilityDetails =
+              LiabilityDetails(startDate = Some(Date(Some(1), Some(4), Some(2022))), weight = None)
+            liabilityDetails.status mustBe TaskStatus.InProgress
+          }
+
+          "and only liability weight has been answered" in {
+            val liabilityDetails =
+              LiabilityDetails(startDate = None, weight = Some(LiabilityWeight(Some(4000))))
+            liabilityDetails.status mustBe TaskStatus.InProgress
+          }
+        }
+
       }
     }
 
     "be COMPLETED " when {
-      "liability details are all filled in" in {
-        val liabilityDetails = LiabilityDetails(startDate =
-                                                  Some(Date(Some(1), Some(5), Some(2022))),
-                                                weight = Some(LiabilityWeight(Some(4000)))
-        )
-        liabilityDetails.status mustBe TaskStatus.Completed
+      "and 'liabilityPreLaunch' flag is enabled" when {
+        "and liability details are all filled in" in {
+          val liabilityDetails =
+            LiabilityDetails(isLiable = Some(false), weight = Some(LiabilityWeight(Some(4000))))
+          liabilityDetails.status mustBe TaskStatus.Completed
+        }
+      }
+
+      "and 'liabilityPreLaunch' flag is disabled" when {
+        "and liability details are all filled in" in {
+          val liabilityDetails = LiabilityDetails(startDate =
+                                                    Some(Date(Some(1), Some(5), Some(2022))),
+                                                  weight = Some(LiabilityWeight(Some(4000)))
+          )
+          liabilityDetails.status mustBe TaskStatus.Completed
+        }
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -39,7 +39,7 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
     page(reg)(request, messages, appConfig)
 
   "Chek liability details answers View" should {
-    when(appConfig.isLiabilityPreLaunchEnabled).thenReturn(false)
+    when(appConfig.isPreLaunch).thenReturn(false)
 
     "have proper messages for labels" in {
       messages must haveTranslationFor("checkLiabilityDetailsAnswers.title")
@@ -83,7 +83,7 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
       "and feature flag 'liabilityPreLaunch' is enabled" in {
 
-        when(appConfig.isLiabilityPreLaunchEnabled).thenReturn(true)
+        when(appConfig.isPreLaunch).thenReturn(true)
 
         createView().getElementById("back-link") must haveHref(
           routes.LiabilityLiableDateController.displayPage()

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -20,6 +20,7 @@ import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
+import play.api.mvc.Call
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
@@ -35,8 +36,11 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
   private val registration         = aRegistration()
   private val appConfig: AppConfig = mock[AppConfig]
 
-  private def createView(reg: Registration = registration): Document =
-    page(reg)(request, messages, appConfig)
+  private def createView(
+    reg: Registration = registration,
+    backLink: Call = routes.LiabilityStartDateController.displayPage()
+  ): Document =
+    page(reg, backLink)(request, messages)
 
   "Chek liability details answers View" should {
     when(appConfig.isPreLaunch).thenReturn(false)
@@ -52,12 +56,14 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
     val viewWithEmptyRegistration = createView(Registration("id"))
 
     "validate other rendering  methods" in {
-      page.f(registration)(request, messages, appConfig).select("title").text() must include(
-        messages("checkLiabilityDetailsAnswers.title")
-      )
-      page.render(registration, request, messages, appConfig).select("title").text() must include(
-        messages("checkLiabilityDetailsAnswers.title")
-      )
+      page.f(registration, routes.LiabilityStartDateController.displayPage())(request,
+                                                                              messages
+      ).select("title").text() must include(messages("checkLiabilityDetailsAnswers.title"))
+      page.render(registration,
+                  routes.LiabilityStartDateController.displayPage(),
+                  request,
+                  messages
+      ).select("title").text() must include(messages("checkLiabilityDetailsAnswers.title"))
     }
 
     "contain timeout dialog function" in {
@@ -85,9 +91,9 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
         when(appConfig.isPreLaunch).thenReturn(true)
 
-        createView().getElementById("back-link") must haveHref(
-          routes.LiabilityLiableDateController.displayPage()
-        )
+        createView(backLink = routes.LiabilityLiableDateController.displayPage()).getElementById(
+          "back-link"
+        ) must haveHref(routes.LiabilityLiableDateController.displayPage())
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityLiableDateViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityLiableDateViewSpec.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.data.Form
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate.form
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability_liable_date_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class LiabilityLiableDateViewSpec extends UnitViewSpec with Matchers {
+
+  private val page = instanceOf[liability_liable_date_page]
+
+  private def createView(form: Form[LiabilityLiableDate] = LiabilityLiableDate.form()): Document =
+    page(form)(request, messages)
+
+  "Liability section 'Liable Date' view" should {
+
+    "have proper messages for labels" in {
+      messages must haveTranslationFor("liabilityLiableDatePage.sectionHeader")
+      messages must haveTranslationFor("liabilityLiableDatePage.title")
+      messages must haveTranslationFor("liabilityLiableDatePage.hint")
+      messages must haveTranslationFor("liabilityLiableDatePage.question")
+      messages must haveTranslationFor("liabilityLiableDatePage.question.empty.error")
+    }
+
+    val view = createView()
+
+    "validate other rendering  methods" in {
+      page.f(form())(request, messages).select("title").text() must include(
+        messages("liabilityLiableDatePage.title")
+      )
+      page.render(form(), request, messages).select("title").text() must include(
+        messages("liabilityLiableDatePage.title")
+      )
+    }
+
+    "contain timeout dialog function" in {
+
+      containTimeoutDialogFunction(view) mustBe true
+    }
+
+    "display sign out link" in {
+
+      displaySignOutLink(view)
+    }
+
+    "display 'Back' button" in {
+
+      view.getElementById("back-link") must haveHref(routes.LiabilityWeightController.displayPage())
+    }
+
+    "display title" in {
+
+      view.select("title").text() must include(messages("liabilityLiableDatePage.title"))
+    }
+
+    "display header" in {
+
+      view.getElementsByClass("govuk-caption-xl").text() must include(
+        messages("liabilityLiableDatePage.sectionHeader")
+      )
+    }
+
+    "display radio inputs" in {
+
+      view must containElementWithID("answer")
+      view.getElementsByClass("govuk-label").first().text() mustBe "Yes"
+      view must containElementWithID("answer-2")
+      view.getElementsByClass("govuk-label").get(1).text() mustBe "No"
+    }
+
+    "display 'Save And Continue' button" in {
+
+      view must containElementWithID("submit")
+      view.getElementById("submit").text() mustBe "Save and Continue"
+    }
+
+    "display 'Save and come back later' button" in {
+
+      view.getElementById("save_and_come_back_later").text() mustBe "Save and come back later"
+    }
+  }
+
+  "Liability section 'Liable Date' view when filled" should {
+
+    "display radio button checked" in {
+
+      val form = LiabilityLiableDate.form()
+        .fill(LiabilityLiableDate("yes"))
+      val view = createView(form)
+
+      view.getElementById("answer").attr("value") mustBe "yes"
+    }
+
+    "display error" when {
+
+      "no radio button checked" in {
+
+        val form = LiabilityLiableDate.form()
+          .fillAndValidate(LiabilityLiableDate(None))
+        val view = createView(form)
+
+        view must haveGovukGlobalErrorSummary
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityStartDateViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityStartDateViewSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.matchers.must.Matchers
 import base.unit.UnitViewSpec
 import play.api.data.Form
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityStartDate.form
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Date, LiabilityStartDate}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability_start_date_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
@@ -43,6 +44,15 @@ class LiabilityStartDateViewSpec extends UnitViewSpec with Matchers {
     }
 
     val view = createView()
+
+    "validate other rendering  methods" in {
+      page.f(form())(request, messages).select("title").text() must include(
+        messages("liabilityStartDatePage.title")
+      )
+      page.render(form(), request, messages).select("title").text() must include(
+        messages("liabilityStartDatePage.title")
+      )
+    }
 
     "contain timeout dialog function" in {
 
@@ -124,8 +134,7 @@ class LiabilityStartDateViewSpec extends UnitViewSpec with Matchers {
 
     "display data in date inputs" in {
 
-      val form = LiabilityStartDate
-        .form()
+      val form = LiabilityStartDate.form()
         .fill(aRegistration().liabilityDetails.startDate.get)
       val view = createView(form)
 
@@ -139,8 +148,7 @@ class LiabilityStartDateViewSpec extends UnitViewSpec with Matchers {
 
     "Start date is not entered" in {
 
-      val form = LiabilityStartDate
-        .form()
+      val form = LiabilityStartDate.form()
         .fillAndValidate(Date(None, None, None))
       val view = createView(form)
 


### PR DESCRIPTION
* **Create 'liabilityPreLaunch' feature flag**
This will help us swap between two pages in the liability section.
Before the 6th April 2022 it shoud be enabled, and disabled after that.

* **Add Liable Date page to Liability details section'**
* **PPTP-1020 Update liability pre-launch URI**
This will very likely be changed in the future by our product team to
reflect the action on the page.

* **Wiring 'NotLiable' page into the Liability journey**
Remove unnecessary class parameters from the `NotLiableController`

* **Rename 'isLiabilityPreLaunchEnabled' with 'isPreLaunch'** 