### PR TITLE
PPTP-837 Create a unique HTML id for Organisation details

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
@@ -200,7 +200,7 @@
         )
     )
 
-    <h2 id="primary-contact-details" class="govuk-heading-m">
+    <h2 id="organisation-details" class="govuk-heading-m">
         @messages("reviewRegistration.organisationDetails.check.label")</h2>
     @govukSummaryList(
         {if (incorporationDetails.isDefined) ukCompanySummary() else if (soleTraderDetails.isDefined) soleTraderSummary() else partnershipSummary()}


### PR DESCRIPTION
### Description of Work carried through

There is an issue whereby duplicate IDs are used on the Review Registration screen. `primary-contact-details` is used twice.
This issue is picked up by both Axe and VNU checks.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
