### PR TITLE
PPTP-1055 : Added partnership name

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
@@ -159,6 +159,7 @@ class IncorpIdController @Inject() (
   ): OrganisationDetails = {
     val updatedPartnershipDetails: PartnershipDetails = organisationDetails.partnershipDetails.fold(
       PartnershipDetails(partnershipType = partnershipTypeEnum,
+                         partnershipName = None,
                          generalPartnershipDetails = generalPartnershipDetails,
                          scottishPartnershipDetails = scottishPartnershipDetails
       )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.Pa
 
 case class PartnershipDetails(
   partnershipType: PartnershipTypeEnum,
+  partnershipName: Option[String] = None,
   generalPartnershipDetails: Option[GeneralPartnershipDetails] = None,
   scottishPartnershipDetails: Option[ScottishPartnershipDetails] = None
   // TODO: other partnership type details here

--- a/tampermonkey/PPT_AutoComplete.js
+++ b/tampermonkey/PPT_AutoComplete.js
@@ -392,6 +392,7 @@ const primaryContactAddress = () => {
      if (currentPageIs('/plastic-packaging-tax/primary-contact-business-address')) {
 
          document.getElementById('addressLine1').value = '2-3 Scala Street'
+         document.getElementById('addressLine2').value = 'Soho'
          document.getElementById('townOrCity').value = 'London'
          document.getElementById('postCode').value = 'W1T 2HN'
          document.getElementsByClassName('govuk-button')[0].click()


### PR DESCRIPTION
This is to remain compatible with the back end. Tests checking the mapping between the internal model and that required by EIS were enhanced to check that the partnership name is correctly handled. It is not clear, at this stage, where the partnership name will be captured.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work) - N/A
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave - N/A
