### PR TITLE
PPTP-1038 : Never persist registration as completed

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/DownstreamServiceError.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/DownstreamServiceError.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.connectors
 
-class ServiceError(private val message: String, private val cause: Exception)
+class ServiceError(private val message: String, private val cause: Throwable)
     extends Exception(message, cause) {}
 
-case class DownstreamServiceError(private val message: String, private val cause: Exception)
+case class DownstreamServiceError(private val message: String, private val cause: Throwable)
     extends ServiceError(message, cause) {}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
@@ -84,6 +84,9 @@ case class Registration(
     else
       this.primaryContactDetails.status
 
+  def asCompleted(): Registration =
+    this.copy(metaData = this.metaData.copy(registrationCompleted = true))
+
 }
 
 object Registration {

--- a/test/base/unit/MockConnectors.scala
+++ b/test/base/unit/MockConnectors.scala
@@ -138,6 +138,13 @@ trait MockConnectors extends MockitoSugar with RegistrationBuilder with BeforeAn
       Future.successful(subscription)
     )
 
+  protected def mockSubscriptionSubmitFailure(
+    ex: Exception
+  ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
+    when(mockSubscriptionsConnector.submitSubscription(any(), any())(any())).thenReturn(
+      Future.failed(ex)
+    )
+
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     reset(mockIncorpIdConnector, mockSoleTraderConnector)


### PR DESCRIPTION
In order that the status of the PPT subscription is rendered correctly on the tasklist page, we should never persist the registration as completed. This is not necessary since the registration is deleted once a successful subscription is made.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work) - N/A
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave - N/A
