### PR TITLE
PPTP-1138 : Display Error Page when Business Registration Fails

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
@@ -38,6 +38,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   Registration
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.business_registration_failure_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -52,6 +53,7 @@ class IncorpIdController @Inject() (
   soleTraderConnector: SoleTraderInorpIdConnector,
   generalPartnershipConnector: GeneralPartnershipConnector,
   scottishPartnershipConnector: ScottishPartnershipConnector,
+  business_registration_failure_page: business_registration_failure_page,
   mcc: MessagesControllerComponents
 )(implicit val executionContext: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
@@ -61,7 +63,11 @@ class IncorpIdController @Inject() (
       implicit request =>
         saveRegistrationDetails(journeyId).flatMap(res => res)
           .map {
-            case Right(_)    => Redirect(routes.RegistrationController.displayPage())
+            case Right(registration) =>
+              if (registration.organisationDetails.businessPartnerIdPresent())
+                Redirect(routes.RegistrationController.displayPage())
+              else
+                Ok(business_registration_failure_page())
             case Left(error) => throw error
           }
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -180,27 +180,21 @@ class ReviewRegistrationController @Inject() (
         registration.organisationDetails.incorporationDetails.flatMap(
           details => details.registration.registeredBusinessPartnerId
         )
-    }.getOrElse(throw new Exception("Safe Id is required for a Subscription create"))
+    }.getOrElse(throw new IllegalStateException("Safe Id is required for a Subscription create"))
 
   private def getSoleTraderDetails()(implicit
     request: JourneyRequest[AnyContent]
   ): Future[SoleTraderIncorporationDetails] =
-    request.registration.organisationDetails.soleTraderDetails.fold(
-      throw new Exception("Unable to fetch sole trader details from cache")
-    )(details => Future.successful(details))
+    Future.successful(request.registration.organisationDetails.soleTraderDetails.get)
 
   private def getPartnershipDetails()(implicit
     request: JourneyRequest[AnyContent]
   ): Future[PartnershipDetails] =
-    request.registration.organisationDetails.partnershipDetails.fold(
-      throw new Exception("Unable to fetch partnership details from cache")
-    )(details => Future.successful(details))
+    Future.successful(request.registration.organisationDetails.partnershipDetails.get)
 
   private def getIncorporationDetails()(implicit
     request: JourneyRequest[AnyContent]
   ): Future[IncorporationDetails] =
-    request.registration.organisationDetails.incorporationDetails.fold(
-      throw new Exception("Unable to fetch incorporation details from cache")
-    )(details => Future.successful(details))
+    Future.successful(request.registration.organisationDetails.incorporationDetails.get)
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
@@ -18,7 +18,16 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.OrgType
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
+  OrgType,
+  PARTNERSHIP,
+  SOLE_TRADER,
+  UK_COMPANY
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{
+  GENERAL_PARTNERSHIP,
+  SCOTTISH_PARTNERSHIP
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   IncorporationDetails,
   PartnershipDetails,
@@ -33,7 +42,26 @@ case class OrganisationDetails(
   soleTraderDetails: Option[SoleTraderIncorporationDetails] = None,
   incorporationDetails: Option[IncorporationDetails] = None,
   partnershipDetails: Option[PartnershipDetails] = None
-)
+) {
+
+  def businessPartnerIdPresent() =
+    organisationType match {
+      case Some(UK_COMPANY) =>
+        incorporationDetails.get.registration.registeredBusinessPartnerId.isDefined
+      case Some(SOLE_TRADER) =>
+        soleTraderDetails.get.registration.registeredBusinessPartnerId.isDefined
+      case Some(PARTNERSHIP) =>
+        partnershipDetails.get.partnershipType match {
+          case GENERAL_PARTNERSHIP =>
+            partnershipDetails.get.generalPartnershipDetails.get.registration.registeredBusinessPartnerId.isDefined
+          case SCOTTISH_PARTNERSHIP =>
+            partnershipDetails.get.scottishPartnershipDetails.get.registration.registeredBusinessPartnerId.isDefined
+          case _ => false
+        }
+      case _ => false
+    }
+
+}
 
 object OrganisationDetails {
   implicit val format: OFormat[OrganisationDetails] = Json.format[OrganisationDetails]

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/business_registration_failure_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/business_registration_failure_page.scala.html
@@ -1,0 +1,31 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+
+@this(govukLayout: main_template)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@govukLayout(title = Title("businessEntityIdentification.failure.title")) {
+ <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+   <h1 class="govuk-heading-xl" >@messages("businessEntityIdentification.failure.heading")</h1>
+   <p class="govuk-body">@messages("businessEntityIdentification.failure.detail")</p>
+  </div>
+ </div>
+}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -260,3 +260,6 @@ liabilityExpectToExceedThresholdWeightPage.guidance.href = https://www.gov.uk/go
 liabilityExpectToExceedThresholdWeightPage.radio.option.yes= Yes
 liabilityExpectToExceedThresholdWeightPage.radio.option.no= No
 
+businessEntityIdentification.failure.title = We have been unable to identify your organisation
+businessEntityIdentification.failure.heading = We have been unable to identify your organisation
+businessEntityIdentification.failure.detail = TODO: content to assist user to go here

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -21,13 +21,17 @@ import base.{MockAuthAction, PptTestData}
 import builders.RegistrationBuilder
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.PARTNERSHIP
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
+  PARTNERSHIP,
+  SOLE_TRADER,
+  UK_COMPANY
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{
   GENERAL_PARTNERSHIP,
   PartnershipTypeEnum,
   SCOTTISH_PARTNERSHIP
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, OrgType}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.{
   EmailStatus,
   VerificationStatus
@@ -107,12 +111,34 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                                      registrationStatus = "REGISTERED"
     )
 
+  protected val unregisteredIncorporationRegistrationDetails: IncorporationRegistrationDetails =
+    IncorporationRegistrationDetails(registeredBusinessPartnerId = None,
+                                     registrationStatus = "REGISTRATION_NOT_CALLED"
+    )
+
   protected val incorporationDetails: IncorporationDetails =
     IncorporationDetails(testCompanyNumber,
                          testCompanyName,
                          testUtr,
                          testCompanyAddress,
                          incorporationRegistrationDetails
+    )
+
+  protected val unregisteredIncorporationDetails: IncorporationDetails =
+    IncorporationDetails(testCompanyNumber,
+                         testCompanyName,
+                         testUtr,
+                         testCompanyAddress,
+                         unregisteredIncorporationRegistrationDetails
+    )
+
+  protected val unregisteredSoleTraderDetails: SoleTraderIncorporationDetails =
+    SoleTraderIncorporationDetails(firstName = "Sole",
+                                   lastName = "Trader",
+                                   dateOfBirth = "12/12/1960",
+                                   nino = "1234",
+                                   sautr = Some("ABC"),
+                                   registration = unregisteredIncorporationRegistrationDetails
     )
 
   protected val soleTraderIncorporationDetails: SoleTraderIncorporationDetails =
@@ -173,12 +199,20 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     Seq(EmailStatus(emailAddress = "test@hmrc.com", verified = true, locked = false))
   )
 
-  protected def registeredUkOrgDetails(orgType: OrgType.Value): OrganisationDetails =
+  protected def registeredUkCompanyOrgDetails(): OrganisationDetails =
     OrganisationDetails(isBasedInUk = Some(true),
-                        organisationType = Some(orgType),
+                        organisationType = Some(UK_COMPANY),
                         businessRegisteredAddress = Some(testBusinessAddress),
                         safeNumber = Some(safeNumber),
                         incorporationDetails = Some(incorporationDetails)
+    )
+
+  protected def registeredSoleTraderDetails(): OrganisationDetails =
+    OrganisationDetails(isBasedInUk = Some(true),
+                        organisationType = Some(SOLE_TRADER),
+                        businessRegisteredAddress = Some(testBusinessAddress),
+                        safeNumber = Some(safeNumber),
+                        soleTraderDetails = Some(soleTraderIncorporationDetails)
     )
 
   protected def registeredGeneralPartnershipDetails(): OrganisationDetails =
@@ -197,8 +231,21 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                         partnershipDetails = Some(partnershipDetailsWithScottishPartnership)
     )
 
-  protected def unregisteredUkOrgDetails(orgType: OrgType.Value): OrganisationDetails =
-    OrganisationDetails(isBasedInUk = Some(true), organisationType = Some(orgType))
+  protected def unregisteredUkCompanyOrgDetails(): OrganisationDetails =
+    OrganisationDetails(isBasedInUk = Some(true),
+                        organisationType = Some(UK_COMPANY),
+                        businessRegisteredAddress = Some(testBusinessAddress),
+                        safeNumber = None,
+                        incorporationDetails = Some(unregisteredIncorporationDetails)
+    )
+
+  protected def unregisteredSoleTraderOrgDetails(): OrganisationDetails =
+    OrganisationDetails(isBasedInUk = Some(true),
+                        organisationType = Some(SOLE_TRADER),
+                        businessRegisteredAddress = Some(testBusinessAddress),
+                        safeNumber = None,
+                        soleTraderDetails = Some(unregisteredSoleTraderDetails)
+    )
 
   protected def unregisteredPartnershipDetails(
     partnershipType: PartnershipTypeEnum

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -207,7 +207,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                         incorporationDetails = Some(incorporationDetails)
     )
 
-  protected def registeredSoleTraderDetails(): OrganisationDetails =
+  protected def registeredSoleTraderOrgDetails(): OrganisationDetails =
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(SOLE_TRADER),
                         businessRegisteredAddress = Some(testBusinessAddress),
@@ -215,7 +215,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                         soleTraderDetails = Some(soleTraderIncorporationDetails)
     )
 
-  protected def registeredGeneralPartnershipDetails(): OrganisationDetails =
+  protected def registeredGeneralPartnershipOrgDetails(): OrganisationDetails =
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(PARTNERSHIP),
                         businessRegisteredAddress = Some(testBusinessAddress),
@@ -223,7 +223,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                         partnershipDetails = Some(partnershipDetails)
     )
 
-  protected def registeredScottishPartnershipDetails(): OrganisationDetails =
+  protected def registeredScottishPartnershipOrgDetails(): OrganisationDetails =
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(PARTNERSHIP),
                         businessRegisteredAddress = Some(testBusinessAddress),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandlerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandlerTest.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.config
 
 import base.unit.UnitViewSpec
-import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdControllerSpec.scala
@@ -18,14 +18,16 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.{verify, when}
 import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import play.api.http.Status.SEE_OTHER
+import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.i18n.Messages
+import play.api.mvc.Request
 import play.api.test.Helpers.{await, redirectLocation, status}
+import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{
   GENERAL_PARTNERSHIP,
   LIMITED_PARTNERSHIP,
@@ -36,12 +38,14 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   OrganisationDetails,
   Registration
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.business_registration_failure_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 class IncorpIdControllerSpec extends ControllerSpec {
 
-  private val mcc          = stubMessagesControllerComponents()
-  private val registration = aRegistration()
+  private val mcc           = stubMessagesControllerComponents()
+  private val mockErrorPage = mock[business_registration_failure_page]
+  private val registration  = aRegistration()
 
   private val controller =
     new IncorpIdController(authenticate = mockAuthAction,
@@ -51,23 +55,24 @@ class IncorpIdControllerSpec extends ControllerSpec {
                            mockSoleTraderConnector,
                            mockGeneralPartnershipConnector,
                            mockScottishPartnershipConnector,
+                           mockErrorPage,
                            mcc
     )(ec)
 
   private val unregisteredLimitedCompany = aRegistration(
-    withOrganisationDetails(unregisteredUkOrgDetails(OrgType.UK_COMPANY))
+    withOrganisationDetails(unregisteredUkCompanyOrgDetails())
   )
 
   private val registeredLimitedCompany = aRegistration(
-    withOrganisationDetails(registeredUkOrgDetails(OrgType.UK_COMPANY))
+    withOrganisationDetails(registeredUkCompanyOrgDetails())
   )
 
   private val unregisteredSoleTrader = aRegistration(
-    withOrganisationDetails(unregisteredUkOrgDetails(OrgType.SOLE_TRADER))
+    withOrganisationDetails(unregisteredSoleTraderOrgDetails())
   )
 
   private val registeredSoleTrader = aRegistration(
-    withOrganisationDetails(registeredUkOrgDetails(OrgType.SOLE_TRADER))
+    withOrganisationDetails(registeredUkCompanyOrgDetails())
   )
 
   private val unregisteredGeneralPartnership = aRegistration(
@@ -87,6 +92,8 @@ class IncorpIdControllerSpec extends ControllerSpec {
   )
 
   "incorpIdCallback" should {
+
+    when(mockErrorPage.apply()(any[Request[_]](), any[Messages]())).thenReturn(HtmlFormat.empty)
 
     "redirect to the registration page" when {
       "registering a UK Limited Company" in {
@@ -283,6 +290,16 @@ class IncorpIdControllerSpec extends ControllerSpec {
         }
       }
     }
+
+    "show error page" when {
+      "business partner id is absent" in {
+        authorizedUser()
+        val result = simulateUnregisteredLimitedCompanyCallback()
+
+        status(result) mustBe OK
+        verify(mockErrorPage).apply()(any[Request[_]](), any[Messages]())
+      }
+    }
   }
 
   private def simulateLimitedCompanyCallback() = {
@@ -290,6 +307,15 @@ class IncorpIdControllerSpec extends ControllerSpec {
     mockGetUkCompanyDetails(incorporationDetails)
     mockRegistrationFind(unregisteredLimitedCompany)
     mockRegistrationUpdate(registeredLimitedCompany)
+
+    controller.incorpIdCallback(registration.incorpJourneyId.get)(getRequest())
+  }
+
+  private def simulateUnregisteredLimitedCompanyCallback() = {
+    authorizedUser()
+    mockGetUkCompanyDetails(unregisteredIncorporationDetails)
+    mockRegistrationFind(unregisteredLimitedCompany)
+    mockRegistrationUpdate(unregisteredLimitedCompany)
 
     controller.incorpIdCallback(registration.incorpJourneyId.get)(getRequest())
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdControllerSpec.scala
@@ -84,11 +84,11 @@ class IncorpIdControllerSpec extends ControllerSpec {
   )
 
   private val registeredGeneralPartnership = aRegistration(
-    withOrganisationDetails(registeredGeneralPartnershipDetails())
+    withOrganisationDetails(registeredGeneralPartnershipOrgDetails())
   )
 
   private val registeredScottishPartnership = aRegistration(
-    withOrganisationDetails(registeredScottishPartnershipDetails())
+    withOrganisationDetails(registeredScottishPartnershipOrgDetails())
   )
 
   "incorpIdCallback" should {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationControllerSpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.OK
 import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.{
   ETMPSubscriptionStatus,
   SubscriptionStatus
@@ -64,7 +63,7 @@ class RegistrationControllerSpec extends ControllerSpec {
           mockRegistrationFind(
             aRegistration(
               withOrganisationDetails(organisationDetails =
-                registeredUkOrgDetails(OrgType.UK_COMPANY)
+                registeredUkCompanyOrgDetails()
               )
             )
           )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
@@ -22,6 +22,7 @@ import org.mockito.BDDMockito.`given`
 import org.mockito.Mockito.{reset, verify}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.http.Status.{OK, SEE_OTHER}
 import play.api.libs.json.JsObject
 import play.api.test.Helpers.{await, redirectLocation, status}
@@ -43,7 +44,7 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 import java.util.UUID
 
-class ReviewRegistrationControllerSpec extends ControllerSpec {
+class ReviewRegistrationControllerSpec extends ControllerSpec with TableDrivenPropertyChecks {
   private val page = mock[review_registration_page]
   private val mcc  = stubMessagesControllerComponents()
 
@@ -194,24 +195,38 @@ class ReviewRegistrationControllerSpec extends ControllerSpec {
       }
 
       "when form is submitted" in {
-        authorizedUser()
-        val completedRegistration =
-          aCompletedRegistration.copy(incorpJourneyId = Some(UUID.randomUUID().toString))
-        mockRegistrationFind(completedRegistration)
-        mockSubscriptionSubmit(subscriptionCreate)
 
-        val result = controller.submit()(postRequest(JsObject.empty))
+        val registrations = Table("Registration",
+                                  aCompletedUkCompanyRegistration,
+                                  aCompletedSoleTraderRegistration,
+                                  aCompletedGeneralPartnershipRegistration,
+                                  aCompletedScottishPartnershipRegistration
+        )
 
-        status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(routes.ConfirmationController.displayPage().url)
-        verify(mockSubscriptionsConnector).submitSubscription(
-          ArgumentMatchers.eq(safeNumber),
-          ArgumentMatchers.eq(completedRegistration.copy(userHeaders = Some(testUserHeaders)))
-        )(any[HeaderCarrier])
+        var submissionCount = 0
 
-        metricsMock.defaultRegistry.counter(
-          "ppt.registration.success.submission.counter"
-        ).getCount mustBe 1
+        forAll(registrations) { registration =>
+          authorizedUser()
+          val completedRegistration =
+            registration.copy(incorpJourneyId = Some(UUID.randomUUID().toString))
+          mockRegistrationFind(completedRegistration)
+          mockSubscriptionSubmit(subscriptionCreate)
+
+          val result = controller.submit()(postRequest(JsObject.empty))
+          submissionCount += 1
+
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.ConfirmationController.displayPage().url)
+          verify(mockSubscriptionsConnector).submitSubscription(
+            ArgumentMatchers.eq(safeNumber),
+            ArgumentMatchers.eq(completedRegistration.copy(userHeaders = Some(testUserHeaders)))
+          )(any[HeaderCarrier])
+
+          metricsMock.defaultRegistry.counter(
+            "ppt.registration.success.submission.counter"
+          ).getCount mustBe submissionCount
+        }
+
       }
     }
 
@@ -219,14 +234,14 @@ class ReviewRegistrationControllerSpec extends ControllerSpec {
       "submission of audit event" in {
         authorizedUser()
 
-        val completedRegistration = aCompletedRegistration
+        val completedRegistration = aCompletedUkCompanyRegistration
         mockRegistrationFind(completedRegistration)
         mockSubscriptionSubmit(subscriptionCreate)
 
         await(controller.submit()(postRequest(JsObject.empty)))
 
         val completedRegistrationWithNrsDetail = completedRegistration.copy(metaData =
-          aCompletedRegistration.metaData.copy(nrsDetails =
+          aCompletedUkCompanyRegistration.metaData.copy(nrsDetails =
             Some(
               NrsDetails(nrSubsmissionId = subscriptionCreate.nrsSubmissionId, failureReason = None)
             )
@@ -251,7 +266,7 @@ class ReviewRegistrationControllerSpec extends ControllerSpec {
 
       "user submits form and the submission fails" in {
         authorizedUser()
-        mockRegistrationFind(aCompletedRegistration)
+        mockRegistrationFind(aCompletedUkCompanyRegistration)
         mockSubscriptionSubmitFailure(new IllegalStateException("BANG!"))
         val result =
           controller.submit()(postRequest(JsObject.empty))
@@ -306,26 +321,49 @@ class ReviewRegistrationControllerSpec extends ControllerSpec {
     }
   }
 
-  private def aCompletedRegistration =
+  private def aCompletedUkCompanyRegistration =
     aRegistration(withOrganisationDetails(registeredUkCompanyOrgDetails()),
-                  withLiabilityDetails(
-                    LiabilityDetails(weight = Some(LiabilityWeight(Some(1000))), startDate = None)
-                  ),
-                  withPrimaryContactDetails(
-                    PrimaryContactDetails(fullName = Some(FullName("Jack", "Gatsby")),
-                                          jobTitle = Some("Developer"),
-                                          phoneNumber = Some("0203 4567 890"),
-                                          email = Some("test@test.com"),
-                                          address = Some(
-                                            Address(addressLine1 = "2 Scala Street",
-                                                    addressLine2 = Some("Soho"),
-                                                    townOrCity = "London",
-                                                    postCode = "W1T 2HN"
-                                            )
-                                          )
-                    )
-                  ),
+                  withLiabilityDetails(liabilityDetails),
+                  withPrimaryContactDetails(primaryContactDetails),
                   withMetaData(MetaData(registrationCompleted = true))
     )
+
+  private def aCompletedSoleTraderRegistration =
+    aRegistration(withOrganisationDetails(registeredSoleTraderOrgDetails()),
+                  withLiabilityDetails(liabilityDetails),
+                  withPrimaryContactDetails(primaryContactDetails),
+                  withMetaData(MetaData(registrationCompleted = true))
+    )
+
+  private def aCompletedGeneralPartnershipRegistration =
+    aRegistration(withOrganisationDetails(registeredGeneralPartnershipOrgDetails()),
+                  withLiabilityDetails(liabilityDetails),
+                  withPrimaryContactDetails(primaryContactDetails),
+                  withMetaData(MetaData(registrationCompleted = true))
+    )
+
+  private def aCompletedScottishPartnershipRegistration =
+    aRegistration(withOrganisationDetails(registeredScottishPartnershipOrgDetails()),
+                  withLiabilityDetails(liabilityDetails),
+                  withPrimaryContactDetails(primaryContactDetails),
+                  withMetaData(MetaData(registrationCompleted = true))
+    )
+
+  private val liabilityDetails =
+    LiabilityDetails(weight = Some(LiabilityWeight(Some(1000))), startDate = None)
+
+  private val primaryContactDetails = PrimaryContactDetails(
+    fullName = Some(FullName("Jack", "Gatsby")),
+    jobTitle = Some("Developer"),
+    phoneNumber = Some("0203 4567 890"),
+    email = Some("test@test.com"),
+    address = Some(
+      Address(addressLine1 = "2 Scala Street",
+              addressLine2 = Some("Soho"),
+              townOrCity = "London",
+              postCode = "W1T 2HN"
+      )
+    )
+  )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
@@ -34,12 +34,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
   SOLE_TRADER,
   UK_COMPANY
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{
-  Address,
-  FullName,
-  LiabilityWeight,
-  OrgType
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, FullName, LiabilityWeight}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.IncorporationDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.nrs.NrsDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration._
@@ -312,7 +307,7 @@ class ReviewRegistrationControllerSpec extends ControllerSpec {
   }
 
   private def aCompletedRegistration =
-    aRegistration(withOrganisationDetails(registeredUkOrgDetails(OrgType.UK_COMPANY)),
+    aRegistration(withOrganisationDetails(registeredUkCompanyOrgDetails()),
                   withLiabilityDetails(
                     LiabilityDetails(weight = Some(LiabilityWeight(Some(1000))), startDate = None)
                   ),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetailsSpec.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
+  OrgType,
+  PARTNERSHIP,
+  SOLE_TRADER,
+  UK_COMPANY
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{
+  GENERAL_PARTNERSHIP,
+  PartnershipTypeEnum,
+  SCOTTISH_PARTNERSHIP
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
+  GeneralPartnershipDetails,
+  IncorporationAddressDetails,
+  IncorporationDetails,
+  IncorporationRegistrationDetails,
+  PartnershipDetails,
+  ScottishPartnershipDetails,
+  SoleTraderIncorporationDetails
+}
+
+class OrganisationDetailsSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  val registeredOrgs = Table("Organisation Details",
+                             createOrg(UK_COMPANY, None, true),
+                             createOrg(SOLE_TRADER, None, true),
+                             createOrg(PARTNERSHIP, Some(GENERAL_PARTNERSHIP), true),
+                             createOrg(PARTNERSHIP, Some(SCOTTISH_PARTNERSHIP), true)
+  )
+
+  val unregisteredOrgs = Table("Organisation Details",
+                               createOrg(UK_COMPANY, None, false),
+                               createOrg(SOLE_TRADER, None, false),
+                               createOrg(PARTNERSHIP, Some(GENERAL_PARTNERSHIP), false),
+                               createOrg(PARTNERSHIP, Some(SCOTTISH_PARTNERSHIP), false)
+  )
+
+  "OrganisationDetails" should {
+    "identify that business partner id is present" in {
+      forAll(registeredOrgs) { organisationDetails =>
+        organisationDetails.businessPartnerIdPresent() mustBe true
+      }
+    }
+
+    "identify that business partner id is absent" in {
+      forAll(unregisteredOrgs) { organisationDetails =>
+        organisationDetails.businessPartnerIdPresent() mustBe false
+      }
+    }
+  }
+
+  private def createOrg(
+    orgType: OrgType,
+    partnershipType: Option[PartnershipTypeEnum],
+    registered: Boolean
+  ) =
+    orgType match {
+      case UK_COMPANY =>
+        OrganisationDetails(organisationType = Some(UK_COMPANY),
+                            incorporationDetails = Some(
+                              IncorporationDetails(companyNumber = "123",
+                                                   companyName = "Test",
+                                                   ctutr = "ABC",
+                                                   companyAddress = IncorporationAddressDetails(),
+                                                   registration =
+                                                     if (registered)
+                                                       IncorporationRegistrationDetails(
+                                                         registrationStatus = "REGISTERED",
+                                                         registeredBusinessPartnerId = Some("XP001")
+                                                       )
+                                                     else
+                                                       IncorporationRegistrationDetails(
+                                                         registrationStatus =
+                                                           "REGISTRATION_NOT_CALLED",
+                                                         registeredBusinessPartnerId = None
+                                                       )
+                              )
+                            )
+        )
+      case SOLE_TRADER =>
+        OrganisationDetails(organisationType = Some(SOLE_TRADER),
+                            soleTraderDetails = Some(
+                              SoleTraderIncorporationDetails(firstName = "Alan",
+                                                             lastName = "Johnson",
+                                                             dateOfBirth = "12/12/1960",
+                                                             nino = "ABC123",
+                                                             sautr = Some("12345678"),
+                                                             registration =
+                                                               if (registered)
+                                                                 IncorporationRegistrationDetails(
+                                                                   registrationStatus =
+                                                                     "REGISTERED",
+                                                                   registeredBusinessPartnerId =
+                                                                     Some("XP001")
+                                                                 )
+                                                               else
+                                                                 IncorporationRegistrationDetails(
+                                                                   registrationStatus =
+                                                                     "REGISTRATION_NOT_CALLED",
+                                                                   registeredBusinessPartnerId =
+                                                                     None
+                                                                 )
+                              )
+                            )
+        )
+      case PARTNERSHIP =>
+        partnershipType match {
+          case Some(GENERAL_PARTNERSHIP) =>
+            OrganisationDetails(organisationType = Some(PARTNERSHIP),
+                                partnershipDetails = Some(
+                                  PartnershipDetails(partnershipType = GENERAL_PARTNERSHIP,
+                                                     partnershipName =
+                                                       Some("Big Bad General Partners"),
+                                                     generalPartnershipDetails = Some(
+                                                       GeneralPartnershipDetails(sautr = "12345678",
+                                                                                 postcode =
+                                                                                   "BD19 3BD",
+                                                                                 registration = if (
+                                                                                   registered
+                                                                                 )
+                                                                                   IncorporationRegistrationDetails(
+                                                                                     registrationStatus =
+                                                                                       "REGISTERED",
+                                                                                     registeredBusinessPartnerId =
+                                                                                       Some("XP001")
+                                                                                   )
+                                                                                 else
+                                                                                   IncorporationRegistrationDetails(
+                                                                                     registrationStatus = "REGISTRATION_NOT_CALLED",
+                                                                                     registeredBusinessPartnerId =
+                                                                                       None
+                                                                                   )
+                                                       )
+                                                     ),
+                                                     scottishPartnershipDetails = None
+                                  )
+                                )
+            )
+          case Some(SCOTTISH_PARTNERSHIP) =>
+            OrganisationDetails(organisationType = Some(PARTNERSHIP),
+                                partnershipDetails = Some(
+                                  PartnershipDetails(partnershipType = SCOTTISH_PARTNERSHIP,
+                                                     partnershipName =
+                                                       Some("Big Bad Scottish Partners"),
+                                                     generalPartnershipDetails = None,
+                                                     scottishPartnershipDetails = Some(
+                                                       ScottishPartnershipDetails(
+                                                         sautr = "12345678",
+                                                         postcode = "BD19 3BD",
+                                                         registration =
+                                                           if (registered)
+                                                             IncorporationRegistrationDetails(
+                                                               registrationStatus = "REGISTERED",
+                                                               registeredBusinessPartnerId =
+                                                                 Some("XP001")
+                                                             )
+                                                           else
+                                                             IncorporationRegistrationDetails(
+                                                               registrationStatus =
+                                                                 "REGISTRATION_NOT_CALLED",
+                                                               registeredBusinessPartnerId = None
+                                                             )
+                                                       )
+                                                     )
+                                  )
+                                )
+            )
+          case _ => fail("Unsupported partnership type")
+        }
+      case _ => fail("Unsupported organisation type")
+    }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/BusinessRegistrationFailureViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/BusinessRegistrationFailureViewSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views
+
+import base.unit.UnitViewSpec
+import org.scalatest.matchers.must.Matchers
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.business_registration_failure_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class BusinessRegistrationFailureViewSpec extends UnitViewSpec with Matchers {
+
+  private val page: business_registration_failure_page =
+    instanceOf[business_registration_failure_page]
+
+  private def createView(): Html = page()(journeyRequest, messages)
+
+  "Business Registration Failure Page" should {
+
+    "have proper messages for labels" in {
+      messages must haveTranslationFor("businessEntityIdentification.failure.title")
+      messages must haveTranslationFor("businessEntityIdentification.failure.heading")
+      messages must haveTranslationFor("businessEntityIdentification.failure.detail")
+    }
+
+    val view: Html = createView()
+
+    "display title" in {
+      view.select("title").text() must include(
+        messages("businessEntityIdentification.failure.title")
+      )
+    }
+
+    "display heading" in {
+      view.select("h1").text() must include(
+        messages("businessEntityIdentification.failure.heading")
+      )
+    }
+
+    "display detail" in {
+      view.select("p.govuk-body").text() must include(
+        messages("businessEntityIdentification.failure.detail")
+      )
+    }
+  }
+}


### PR DESCRIPTION
We need to show the user that PPT registration cannot be completed when we are unable to find a business partner id.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A, no config changes
 - [ ] Links to dependencies have been included (BE/FE work) - N/A, FE only change
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave

Note

Acceptance tests are failing at the moment due to an error which has been introduced in the Sole Trader Identification service. We await a fix for this issue.