### PR TITLE
PPT-1087 - Contact details - Amend to single input field

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsFullNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsFullNameController.scala
@@ -46,8 +46,8 @@ class ContactDetailsFullNameController @Inject() (
 
   def displayPage(): Action[AnyContent] =
     (authenticate andThen journeyAction) { implicit request =>
-      request.registration.primaryContactDetails.fullName match {
-        case Some(data) => Ok(page(FullName.form().fill(data)))
+      request.registration.primaryContactDetails.name match {
+        case Some(data) => Ok(page(FullName.form().fill(FullName(data))))
         case _          => Ok(page(FullName.form()))
       }
     }
@@ -76,7 +76,7 @@ class ContactDetailsFullNameController @Inject() (
   )(implicit req: JourneyRequest[AnyContent]): Future[Either[ServiceError, Registration]] =
     update { registration =>
       val updatedPrimaryContactDetails =
-        registration.primaryContactDetails.copy(fullName = Some(formData))
+        registration.primaryContactDetails.copy(name = Some(formData.value))
       registration.copy(primaryContactDetails = updatedPrimaryContactDetails)
     }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/FullName.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/FullName.scala
@@ -29,7 +29,6 @@ object FullName extends CommonFormValidators {
 
   private val fullName = "value"
 
-
   private val mapping = Forms.mapping(
     fullName ->
       text()

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/FullName.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/FullName.scala
@@ -20,30 +20,22 @@ import play.api.data.Forms.text
 import play.api.data.{Form, Forms}
 import play.api.libs.json.{Json, OFormat}
 
-case class FullName(firstName: String, lastName: String)
+case class FullName(value: String)
 
 object FullName extends CommonFormValidators {
   implicit val format: OFormat[FullName] = Json.format[FullName]
 
   val allowedChars: Option[String] = Some(".-'")
 
-  private val firstName = "firstName"
+  private val fullName = "value"
 
-  private val lastName = "lastName"
 
   private val mapping = Forms.mapping(
-    firstName ->
+    fullName ->
       text()
-        .verifying(emptyError(firstName), isNonEmpty)
-        .verifying(lengthError(firstName), isNotExceedingMaxLength(_, 20))
-        .verifying(nonAlphabeticError(firstName),
-                   containsOnlyAlphaAndWhitespacesAnd(_, allowedChars)
-        ),
-    lastName ->
-      text()
-        .verifying(emptyError(lastName), isNonEmpty)
-        .verifying(lengthError(lastName), isNotExceedingMaxLength(_, 20))
-        .verifying(nonAlphabeticError(lastName),
+        .verifying(emptyError(fullName), isNonEmpty)
+        .verifying(lengthError(fullName), isNotExceedingMaxLength(_, 160))
+        .verifying(nonAlphabeticError(fullName),
                    containsOnlyAlphaAndWhitespacesAnd(_, allowedChars)
         )
   )(FullName.apply)(FullName.unapply)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetails.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, FullName}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 case class PrimaryContactDetails(
-  fullName: Option[FullName] = None,
+  name: Option[String] = None,
   jobTitle: Option[String] = None,
   email: Option[String] = None,
   phoneNumber: Option[String] = None,
@@ -36,10 +36,10 @@ case class PrimaryContactDetails(
     else TaskStatus.NotStarted
 
   def isCompleted: Boolean =
-    fullName.isDefined && jobTitle.isDefined && email.isDefined && phoneNumber.isDefined && address.isDefined
+    name.isDefined && jobTitle.isDefined && email.isDefined && phoneNumber.isDefined && address.isDefined
 
   def isInProgress: Boolean =
-    fullName.isDefined || jobTitle.isDefined || email.isDefined || phoneNumber.isDefined || address.isDefined
+    name.isDefined || jobTitle.isDefined || email.isDefined || phoneNumber.isDefined || address.isDefined
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetails.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, FullName}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 case class PrimaryContactDetails(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_primary_contact_details_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_primary_contact_details_page.scala.html
@@ -81,7 +81,7 @@
         @govukSummaryList(
             SummaryList(
                 rows = Seq(
-                    row("primaryContactDetails.check.fullName", registration.primaryContactDetails.fullName.map(n => s"${n.firstName} ${n.lastName}"), pptRoutes.ContactDetailsFullNameController.displayPage()),
+                    row("primaryContactDetails.check.fullName", registration.primaryContactDetails.name, pptRoutes.ContactDetailsFullNameController.displayPage()),
                     row("primaryContactDetails.check.jobTitle", registration.primaryContactDetails.jobTitle, pptRoutes.ContactDetailsJobTitleController.displayPage()),
                     row("primaryContactDetails.check.address", registration.primaryContactDetails.address.map(extractAddress), pptRoutes.ContactDetailsConfirmAddressController.displayPage()),
                     row("primaryContactDetails.check.phoneNumber", registration.primaryContactDetails.phoneNumber, pptRoutes.ContactDetailsTelephoneNumberController.displayPage()),

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/full_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/full_name_page.scala.html
@@ -38,8 +38,7 @@
 
 @(form: Form[FullName])(implicit request: Request[_], messages: Messages)
 
-@firstNameField = @{form("firstName")}
-@lastNameField = @{form("lastName")}
+@fullNameField = @{form("value")}
 
 @fieldSetBody = {
 
@@ -48,26 +47,16 @@
     ))
 
     @govukInput(Input(
-        id    = firstNameField.name,
-        name  = firstNameField.name,
-        value = firstNameField.value,
+        id    = fullNameField.name,
+        name  = fullNameField.name,
+        value = fullNameField.value,
         classes = "govuk-!-width-two-thirds",
-        errorMessage = firstNameField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+        errorMessage = fullNameField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
         label = Label(
-            content = Text(messages("primaryContactDetails.fullNamePage.firstName")),
+            content = Text(messages("primaryContactDetails.fullNamePage.value")),
             classes = s"govuk-label--s"),
     ))
 
-    @govukInput(Input(
-        id    = lastNameField.name,
-        name  = lastNameField.name,
-        value = lastNameField.value,
-        classes = "govuk-!-width-two-thirds",
-        errorMessage = lastNameField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
-        label = Label(
-            content = Text(messages("primaryContactDetails.fullNamePage.lastName")),
-            classes = s"govuk-label--s"),
-    ))
 }
 
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/full_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/full_name_page.scala.html
@@ -53,7 +53,7 @@
         classes = "govuk-!-width-two-thirds",
         errorMessage = fullNameField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
         label = Label(
-            content = Text(messages("primaryContactDetails.fullNamePage.value")),
+            content = Text(messages("primaryContactDetails.fullNamePage.label")),
             classes = s"govuk-label--s"),
     ))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
@@ -210,7 +210,7 @@
     @govukSummaryList(
         SummaryList(
             rows = Seq(
-                    row("primaryContactDetails.check.fullName", registration.primaryContactDetails.fullName.map(n => s"${n.firstName} ${n.lastName}"), Some(pptRoutes.ContactDetailsFullNameController.displayPage())),
+                    row("primaryContactDetails.check.fullName", registration.primaryContactDetails.name, Some(pptRoutes.ContactDetailsFullNameController.displayPage())),
                     row("primaryContactDetails.check.jobTitle", registration.primaryContactDetails.jobTitle, Some(pptRoutes.ContactDetailsJobTitleController.displayPage())),
                     row("primaryContactDetails.check.address", registration.primaryContactDetails.address.map(extractAddress), Some(pptRoutes.ContactDetailsConfirmAddressController.displayPage())),
                     row("primaryContactDetails.check.phoneNumber", registration.primaryContactDetails.phoneNumber, Some(pptRoutes.ContactDetailsTelephoneNumberController.displayPage())),

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -107,14 +107,10 @@ primaryContactDetails.sectionHeader = Primary contact details
 
 primaryContactDetails.fullNamePage.title = Who is the primary contact?
 primaryContactDetails.fullNamePage.hint = This is the name of the person who will manage the Plastic Packaging Tax account and submit returns.
-primaryContactDetails.fullNamePage.firstName = First name
-primaryContactDetails.fullNamePage.firstName.error.empty = Enter a first name
-primaryContactDetails.fullNamePage.firstName.error.length = First name cannot be more than 20 characters long
-primaryContactDetails.fullNamePage.firstName.error.specialCharacters = Enter a first name in the correct format
-primaryContactDetails.fullNamePage.lastName = Last name
-primaryContactDetails.fullNamePage.lastName.error.empty = Enter a last name
-primaryContactDetails.fullNamePage.lastName.error.length = Last name cannot be more than 20 characters long
-primaryContactDetails.fullNamePage.lastName.error.specialCharacters = Enter a last name in the correct format
+primaryContactDetails.fullNamePage.value = Name
+primaryContactDetails.fullNamePage.value.error.empty = Enter a name
+primaryContactDetails.fullNamePage.value.error.length = Name cannot be more than 160 characters long
+primaryContactDetails.fullNamePage.value.error.specialCharacters = Enter a name in the correct format
 
 primaryContactDetails.jobTitlePage.title = What is the primary contact’s job title?
 primaryContactDetails.jobTitle.empty.error = Enter a job title

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -107,7 +107,7 @@ primaryContactDetails.sectionHeader = Primary contact details
 
 primaryContactDetails.fullNamePage.title = Who is the primary contact?
 primaryContactDetails.fullNamePage.hint = This is the name of the person who will manage the Plastic Packaging Tax account and submit returns.
-primaryContactDetails.fullNamePage.value = Name
+primaryContactDetails.fullNamePage.label = Name
 primaryContactDetails.fullNamePage.value.error.empty = Enter a name
 primaryContactDetails.fullNamePage.value.error.length = Name cannot be more than 160 characters long
 primaryContactDetails.fullNamePage.value.error.specialCharacters = Enter a name in the correct format

--- a/tampermonkey/PPT_AutoComplete.js
+++ b/tampermonkey/PPT_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PPT Registration AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      14.1
+// @version      14.2
 // @description
 // @author       pmonteiro
 // @match        http*://*/plastic-packaging-tax*
@@ -356,8 +356,7 @@ const liabilityCheckYourAnswers = () => {
 
 const primaryContactFullName = () => {
     if (currentPageIs('/plastic-packaging-tax/primary-contact-name')) {
-        document.getElementById('firstName').value = 'Jack'
-        document.getElementById('lastName').value = 'Gatsby'
+        document.getElementById('value').value = 'Jack Gatsby'
 
         document.getElementsByClassName('govuk-button')[0].click()
     }

--- a/test/builders/RegistrationBuilder.scala
+++ b/test/builders/RegistrationBuilder.scala
@@ -16,8 +16,10 @@
 
 package builders
 
+import java.util.UUID
+
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{PARTNERSHIP, UK_COMPANY}
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, Date, FullName, LiabilityWeight}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, Date, LiabilityWeight}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.EmailStatus
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   IncorporationAddressDetails,
@@ -26,8 +28,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   PartnershipDetails
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration._
-
-import java.util.UUID
 
 //noinspection ScalaStyle
 trait RegistrationBuilder {
@@ -46,19 +46,19 @@ trait RegistrationBuilder {
                                                      isLiable = Some(true),
                                                      expectToExceedThresholdWeight = Some(true)
                  ),
-                 primaryContactDetails = PrimaryContactDetails(
-                   fullName = Some(FullName(firstName = "Jack", lastName = "Gatsby")),
-                   jobTitle = Some("Developer"),
-                   email = Some("test@test.com"),
-                   phoneNumber = Some("0203 4567 890"),
-                   address = Some(
-                     Address(addressLine1 = "2 Scala Street",
-                             addressLine2 = Some("Soho"),
-                             townOrCity = "London",
-                             postCode = "W1T 2HN"
-                     )
-                   ),
-                   journeyId = Some("journey-id")
+                 primaryContactDetails = PrimaryContactDetails(name = Some("Jack Gatsby"),
+                                                               jobTitle = Some("Developer"),
+                                                               email = Some("test@test.com"),
+                                                               phoneNumber = Some("0203 4567 890"),
+                                                               address = Some(
+                                                                 Address(
+                                                                   addressLine1 = "2 Scala Street",
+                                                                   addressLine2 = Some("Soho"),
+                                                                   townOrCity = "London",
+                                                                   postCode = "W1T 2HN"
+                                                                 )
+                                                               ),
+                                                               journeyId = Some("journey-id")
                  ),
                  organisationDetails = OrganisationDetails(isBasedInUk = Some(true),
                                                            organisationType = Some(UK_COMPANY),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsConfirmAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsConfirmAddressControllerSpec.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
   SOLE_TRADER,
   UK_COMPANY
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, ConfirmAddress, FullName}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, ConfirmAddress}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.IncorporationAddressDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   OrganisationDetails,
@@ -57,7 +57,7 @@ class ContactDetailsConfirmAddressControllerSpec extends ControllerSpec {
 
   private val registrationWithoutPrimaryContactAddress = aRegistration(
     withPrimaryContactDetails(
-      PrimaryContactDetails(fullName = Some(FullName(firstName = "Jack", lastName = "Gatsby")),
+      PrimaryContactDetails(name = Some("Jack Gatsby"),
                             jobTitle = Some("Developer"),
                             email = Some("test@test.com"),
                             phoneNumber = Some("0203 4567 890"),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressControllerSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
   DownstreamServiceError,
   ServiceError
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, EmailAddress, FullName}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, EmailAddress}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.{
   CreateEmailVerificationRequest,
   EmailStatus,
@@ -348,8 +348,8 @@ class ContactDetailsEmailAddressControllerSpec extends ControllerSpec with Defau
               )
             ),
             withPrimaryContactDetails(primaryContactDetails =
-              PrimaryContactDetails(fullName =
-                                      Some(FullName(firstName = "Jack", lastName = "Gatsby")),
+              PrimaryContactDetails(name =
+                                      Some("Jack Gatsby"),
                                     jobTitle = Some("Developer"),
                                     phoneNumber = Some("0203 4567 890"),
                                     address = Some(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressPasscodeControllerSpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
   DownstreamServiceError,
   ServiceError
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, EmailAddressPasscode, FullName}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, EmailAddressPasscode}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.EmailVerificationJourneyStatus.{
   COMPLETE,
   INCORRECT_PASSCODE,
@@ -193,8 +193,8 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
         "user submits passcode" in {
           val reg = aRegistration(
             withPrimaryContactDetails(primaryContactDetails =
-              PrimaryContactDetails(fullName =
-                                      Some(FullName(firstName = "Jack", lastName = "Gatsby")),
+              PrimaryContactDetails(name =
+                                      Some("Jack Gatsby"),
                                     jobTitle = Some("Developer"),
                                     phoneNumber = Some("0203 4567 890"),
                                     address = Some(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsFullNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsFullNameControllerSpec.scala
@@ -103,67 +103,29 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
       }
 
       "return 400 (BAD_REQUEST) for " + formAction._1 when {
-        "user does not enter" when {
-          "first name" in {
-            authorizedUser()
-            val result =
-              controller.submit()(postRequestEncoded("LastName", formAction))
+        "user does not enter name" in {
 
-            status(result) mustBe BAD_REQUEST
-          }
+          authorizedUser()
+          val result = controller.submit()(postRequestEncoded(FullName(""), formAction))
 
-          "last name" in {
-            authorizedUser()
-            val result =
-              controller.submit()(postRequestEncoded("FirstName", formAction))
-
-            status(result) mustBe BAD_REQUEST
-          }
-
-          "both first name and last name" in {
-            authorizedUser()
-            val result = controller.submit()(postRequestEncoded("", formAction))
-
-            status(result) mustBe BAD_REQUEST
-          }
+          status(result) mustBe BAD_REQUEST
         }
 
-        "user enters a long" when {
-          "first name" in {
-            authorizedUser()
-            val result = controller.submit()(
-              postRequestEncoded("averyveryveryveryverylongname LastName", formAction)
-            )
+        "user enters a long name" in {
+          authorizedUser()
+          val result = controller.submit()(postRequestEncoded(FullName("abced" * 40), formAction))
 
-            status(result) mustBe BAD_REQUEST
-          }
-
-          "last name" in {
-            authorizedUser()
-            val result = controller.submit()(
-              postRequestEncoded("FirstName averyveryveryveryverylongname", formAction)
-            )
-
-            status(result) mustBe BAD_REQUEST
-          }
+          status(result) mustBe BAD_REQUEST
         }
 
-        "user enters non-alphabetic characters" when {
-          "first name" in {
-            authorizedUser()
-            val result =
-              controller.submit()(postRequestEncoded("FirstNam807980234£$ LastName", formAction))
+        "user enters non-alphabetic characters" in {
+          authorizedUser()
+          val result =
+            controller.submit()(
+              postRequestEncoded(FullName("FirstNam807980234£$ LastName"), formAction)
+            )
 
-            status(result) mustBe BAD_REQUEST
-          }
-
-          "last name" in {
-            authorizedUser()
-            val result =
-              controller.submit()(postRequestEncoded("FirstName F!!!m807980234£$", formAction))
-
-            status(result) mustBe BAD_REQUEST
-          }
+          status(result) mustBe BAD_REQUEST
         }
       }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsFullNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsFullNameControllerSpec.scala
@@ -68,9 +68,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
         authorizedUser()
         mockRegistrationFind(
           aRegistration(
-            withPrimaryContactDetails(
-              PrimaryContactDetails(fullName = Some(FullName("FirstName", "LastName")))
-            )
+            withPrimaryContactDetails(PrimaryContactDetails(name = Some("FirstName LastName")))
           )
         )
         val result = controller.displayPage()(getRequest())
@@ -87,13 +85,11 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           mockRegistrationUpdate(aRegistration())
 
           val result =
-            controller.submit()(postRequestEncoded(FullName("FirstName", "LastName"), formAction))
+            controller.submit()(postRequestEncoded(FullName("FirstName LastName"), formAction))
 
           status(result) mustBe SEE_OTHER
 
-          modifiedRegistration.primaryContactDetails.fullName mustBe Some(
-            FullName("FirstName", "LastName")
-          )
+          modifiedRegistration.primaryContactDetails.name mustBe Some("FirstName LastName")
 
           formAction._1 match {
             case "SaveAndContinue" =>
@@ -111,7 +107,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           "first name" in {
             authorizedUser()
             val result =
-              controller.submit()(postRequestEncoded(FullName("", "LastName"), formAction))
+              controller.submit()(postRequestEncoded("LastName", formAction))
 
             status(result) mustBe BAD_REQUEST
           }
@@ -119,14 +115,14 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           "last name" in {
             authorizedUser()
             val result =
-              controller.submit()(postRequestEncoded(FullName("FirstName", ""), formAction))
+              controller.submit()(postRequestEncoded("FirstName", formAction))
 
             status(result) mustBe BAD_REQUEST
           }
 
           "both first name and last name" in {
             authorizedUser()
-            val result = controller.submit()(postRequestEncoded(FullName("", ""), formAction))
+            val result = controller.submit()(postRequestEncoded("", formAction))
 
             status(result) mustBe BAD_REQUEST
           }
@@ -136,7 +132,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           "first name" in {
             authorizedUser()
             val result = controller.submit()(
-              postRequestEncoded(FullName("averyveryveryveryverylongname", "LastName"), formAction)
+              postRequestEncoded("averyveryveryveryverylongname LastName", formAction)
             )
 
             status(result) mustBe BAD_REQUEST
@@ -145,7 +141,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           "last name" in {
             authorizedUser()
             val result = controller.submit()(
-              postRequestEncoded(FullName("FirstName", "averyveryveryveryverylongname"), formAction)
+              postRequestEncoded("FirstName averyveryveryveryverylongname", formAction)
             )
 
             status(result) mustBe BAD_REQUEST
@@ -156,9 +152,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           "first name" in {
             authorizedUser()
             val result =
-              controller.submit()(
-                postRequestEncoded(FullName("FirstNam807980234£$", "LastName"), formAction)
-              )
+              controller.submit()(postRequestEncoded("FirstNam807980234£$ LastName", formAction))
 
             status(result) mustBe BAD_REQUEST
           }
@@ -166,9 +160,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           "last name" in {
             authorizedUser()
             val result =
-              controller.submit()(
-                postRequestEncoded(FullName("FirstName", "F!!!m807980234£$"), formAction)
-              )
+              controller.submit()(postRequestEncoded("FirstName F!!!m807980234£$", formAction))
 
             status(result) mustBe BAD_REQUEST
           }
@@ -188,7 +180,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           authorizedUser()
           mockRegistrationUpdateFailure()
           val result =
-            controller.submit()(postRequestEncoded(FullName("FirstName", "LastName"), formAction))
+            controller.submit()(postRequestEncoded(FullName("FirstName LastName"), formAction))
 
           intercept[DownstreamServiceError](status(result))
         }
@@ -197,7 +189,7 @@ class ContactDetailsFullNameControllerSpec extends ControllerSpec {
           authorizedUser()
           mockRegistrationException()
           val result =
-            controller.submit()(postRequestEncoded(FullName("FirstName", "LastName"), formAction))
+            controller.submit()(postRequestEncoded(FullName("FirstName LastName"), formAction))
 
           intercept[RuntimeException](status(result))
         }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
+import java.util.UUID
+
 import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito.`given`
@@ -35,14 +37,12 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
   UK_COMPANY
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, FullName, LiabilityWeight}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, LiabilityWeight}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.IncorporationDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.nrs.NrsDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration._
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.review_registration_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
-
-import java.util.UUID
 
 class ReviewRegistrationControllerSpec extends ControllerSpec with TableDrivenPropertyChecks {
   private val page = mock[review_registration_page]
@@ -351,18 +351,18 @@ class ReviewRegistrationControllerSpec extends ControllerSpec with TableDrivenPr
   private val liabilityDetails =
     LiabilityDetails(weight = Some(LiabilityWeight(Some(1000))), startDate = None)
 
-  private val primaryContactDetails = PrimaryContactDetails(
-    fullName = Some(FullName("Jack", "Gatsby")),
-    jobTitle = Some("Developer"),
-    phoneNumber = Some("0203 4567 890"),
-    email = Some("test@test.com"),
-    address = Some(
-      Address(addressLine1 = "2 Scala Street",
-              addressLine2 = Some("Soho"),
-              townOrCity = "London",
-              postCode = "W1T 2HN"
-      )
-    )
+  private val primaryContactDetails = PrimaryContactDetails(name = Some("Jack Gatsby"),
+                                                            jobTitle = Some("Developer"),
+                                                            phoneNumber = Some("0203 4567 890"),
+                                                            email = Some("test@test.com"),
+                                                            address = Some(
+                                                              Address(addressLine1 =
+                                                                        "2 Scala Street",
+                                                                      addressLine2 = Some("Soho"),
+                                                                      townOrCity = "London",
+                                                                      postCode = "W1T 2HN"
+                                                              )
+                                                            )
   )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetailsSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, FullName}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
@@ -35,21 +35,21 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
     "be IN_PROGRESS " when {
       "primary contact details when only 'FullName' is complete" in {
         val contactDetails =
-          PrimaryContactDetails(fullName = Some(FullName("firstName", "lastName")))
+          PrimaryContactDetails(name = Some("firstName lastName"))
         contactDetails.status mustBe TaskStatus.InProgress
       }
 
       "primary contact details when only 'FullName' and 'JobTitle' are complete" in {
-        val contactDetails = PrimaryContactDetails(fullName =
-                                                     Some(FullName("firstName", "lastName")),
+        val contactDetails = PrimaryContactDetails(name =
+                                                     Some("firstName lastName"),
                                                    jobTitle = Some("Dev")
         )
         contactDetails.status mustBe TaskStatus.InProgress
       }
 
       "primary contact details when only 'FullName', 'JobTitle' and 'Email' are complete" in {
-        val contactDetails = PrimaryContactDetails(fullName =
-                                                     Some(FullName("firstName", "lastName")),
+        val contactDetails = PrimaryContactDetails(name =
+                                                     Some("firstName lastName"),
                                                    jobTitle = Some("Dev"),
                                                    email = Some("test@test.com")
         )
@@ -57,8 +57,8 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
       }
 
       "primary contact details when only 'FullName', 'JobTitle', 'Email' and 'phoneNumber' are complete" in {
-        val contactDetails = PrimaryContactDetails(fullName =
-                                                     Some(FullName("firstName", "lastName")),
+        val contactDetails = PrimaryContactDetails(name =
+                                                     Some("firstName lastName"),
                                                    jobTitle = Some("Dev"),
                                                    email = Some("test@test.com"),
                                                    phoneNumber = Some("0203 12345 678")
@@ -70,7 +70,7 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
     "be COMPLETED " when {
       "primary contact details are all filled in" in {
         val contactDetails =
-          PrimaryContactDetails(fullName = Some(FullName("FirstName", "LastName")),
+          PrimaryContactDetails(name = Some("FirstName LastName"),
                                 jobTitle = Some("Developer"),
                                 email = Some("test@test.com"),
                                 phoneNumber = Some("07712345678"),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckContactDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckContactDetailsAnswersViewSpec.scala
@@ -20,7 +20,7 @@ import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Address, FullName}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   PrimaryContactDetails,
   Registration
@@ -35,7 +35,7 @@ class CheckContactDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
   private val registration = aRegistration(
     withPrimaryContactDetails(
-      PrimaryContactDetails(fullName = Some(FullName("Jack", "Gatsby")),
+      PrimaryContactDetails(name = Some("Jack Gatsby"),
                             jobTitle = Some("Developer"),
                             phoneNumber = Some("0203 4567 890"),
                             email = Some("test@test.com"),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ContactDetailsFullNameViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ContactDetailsFullNameViewSpec.scala
@@ -40,8 +40,7 @@ class ContactDetailsFullNameViewSpec extends UnitViewSpec with Matchers {
       messages must haveTranslationFor("primaryContactDetails.sectionHeader")
       messages must haveTranslationFor("primaryContactDetails.fullNamePage.title")
       messages must haveTranslationFor("primaryContactDetails.fullNamePage.hint")
-      messages must haveTranslationFor("primaryContactDetails.fullNamePage.firstName")
-      messages must haveTranslationFor("primaryContactDetails.fullNamePage.lastName")
+      messages must haveTranslationFor("primaryContactDetails.fullNamePage.label")
     }
 
     val view = createView()
@@ -89,10 +88,9 @@ class ContactDetailsFullNameViewSpec extends UnitViewSpec with Matchers {
       )
     }
 
-    "display first name and last name text input boxes" in {
+    "display full name text input boxes" in {
 
-      view must containElementWithID("firstName")
-      view must containElementWithID("lastName")
+      view must containElementWithID("value")
     }
 
     "display 'Save and Continue' button" in {
@@ -112,68 +110,56 @@ class ContactDetailsFullNameViewSpec extends UnitViewSpec with Matchers {
 
       val form = FullName
         .form()
-        .fill(FullName("FirstName", "LastName"))
+        .fill(FullName("FirstName LastName"))
       val view = createView(form)
 
-      view.getElementById("firstName").attr("value") mustBe "FirstName"
-      view.getElementById("lastName").attr("value") mustBe "LastName"
+      view.getElementById("value").attr("value") mustBe "FirstName LastName"
     }
 
     "allow whitespace and special chars" in {
 
       val form = FullName
         .form()
-        .fill(FullName("First Name " + allowedChars.get, "Last Name " + allowedChars.get))
+        .fill(FullName("First Name " + allowedChars.get + " Last Name " + allowedChars.get))
       val view = createView(form)
 
-      view.getElementById("firstName").attr("value") mustBe "First Name .-'"
-      view.getElementById("lastName").attr("value") mustBe "Last Name .-'"
+      view.getElementById("value").attr("value") mustBe "First Name .-' Last Name .-'"
     }
   }
 
   "display error" when {
 
-    "user did not enter first name or last name" in {
+    "user did not enter name" in {
       val form = FullName
         .form()
-        .fillAndValidate(FullName("", ""))
+        .fillAndValidate(FullName(""))
       val view = createView(form)
 
       view must haveGovukGlobalErrorSummary
 
-      view must haveGovukFieldError("firstName", "Enter a first name")
-      view must haveGovukFieldError("lastName", "Enter a last name")
-
+      view must haveGovukFieldError("value", "Enter a name")
     }
 
-    "user did entered non-alphabetic characters" in {
+    "user entered non-alphabetic characters" in {
       val form = FullName
         .form()
-        .fillAndValidate(FullName("123", "321"))
+        .fillAndValidate(FullName("123 321"))
       val view = createView(form)
 
       view must haveGovukGlobalErrorSummary
 
-      view must haveGovukFieldError("firstName", "Enter a first name in the correct format")
-      view must haveGovukFieldError("lastName", "Enter a last name in the correct format")
-
+      view must haveGovukFieldError("value", "Enter a name in the correct format")
     }
 
-    "user did entered more than 20 characters" in {
+    "user entered more than 160 characters" in {
       val form = FullName
         .form()
-        .fillAndValidate(
-          FullName("averyveryveryveryverylongfirst", "averyveryveryveryverylonglast")
-        )
+        .fillAndValidate(FullName("abcde" * 40))
       val view = createView(form)
 
       view must haveGovukGlobalErrorSummary
 
-      view must haveGovukFieldError("firstName",
-                                    "First name cannot be more than 20 characters long"
-      )
-      view must haveGovukFieldError("lastName", "Last name cannot be more than 20 characters long")
-
+      view must haveGovukFieldError("value", "Name cannot be more than 160 characters long")
     }
   }
 }


### PR DESCRIPTION
### Description of Work carried through

Change ContactDetails "Who is the primary contact?" page to have single input field for name
Depends on 
- BE change - https://github.com/hmrc/plastic-packaging-tax-registration/pull/51
- AT change - https://github.com/hmrc/plastic-packaging-tax-acceptance/pull/52

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
