### PR TITLE
PPTP-1201 - Nav landmarks not distinguishable on Start Registration screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ sm -s
 # Stop the microservice in service manager 
 sm --stop PLASTIC_PACKAGING_TAX_REGISTRATION_FRONTEND
 
-# Run the microservice using sbt
+# Run the microservice using sbt  (script run_local-sh)
 sbt -Dapplication.router=testOnlyDoNotUseInAppConf.Routes run
+
+
 ```
 
 ### Login/Access

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/bulletList.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/bulletList.scala.html
@@ -18,13 +18,11 @@
 
 @(title: Option[String] = None, elements: Seq[Html])
 
-<nav>
-    @title.map(paragraphBody(_, "govuk-body"))
-    <ul class="govuk-list govuk-list--bullet">
-        @elements.map { element =>
-            <li class="dashed-list-item">
-                @element
-            </li>
-        }
-    </ul>
-</nav>
+@title.map(paragraphBody(_, "govuk-body"))
+<ul class="govuk-list govuk-list--bullet">
+    @elements.map { element =>
+        <li class="dashed-list-item">
+            @element
+        </li>
+    }
+</ul>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/navList.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/navList.scala.html
@@ -16,10 +16,10 @@
 
 @this(paragraphBody: paragraphBody)
 
-@(title: Option[String] = None, elements: Seq[Html])
+@(title: String, elements: Seq[Html])
 
-<nav class="govuk-!-margin-bottom-8">
-    @title.map(paragraphBody(_, "dashed-list-title"))
+<nav class="govuk-!-margin-bottom-8" aria-labelledby="nav-title">
+    @paragraphBody(title, "govuk-body dashed-list-title", Some("nav-title"))
     <ul class="dashed-list">
         @elements.map { element =>
             <li class="dashed-list-item">

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/start_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/start_page.scala.html
@@ -19,7 +19,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.bulletList
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.dashList
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.navList
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.pageTitle
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.sectionHeader
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.paragraphBody
@@ -31,7 +31,7 @@ pageTitle: pageTitle,
 sectionHeader: sectionHeader,
 paragraphBody: paragraphBody,
 link: link,
-dashList: dashList,
+navList: navList,
 bulletList: bulletList,
 govukInsetText: GovukInsetText,
 govukButton: GovukButton
@@ -52,8 +52,8 @@ govukButton: GovukButton
 <div class="govuk-!-width-two-thirds">
 
     <div id="contents">
-        @dashList(
-            title = Some(messages("startPage.contents.header")),
+        @navList(
+            title = messages("startPage.contents.header"),
             elements = Seq(
                 link(text = messages("startPage.overview.header"), call = Call("GET", "#overview")),
                 link(text = messages("startPage.informationYouNeed.header"), call = Call("GET", "#information-you-need")),

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sbt -Dapplication.router=testOnlyDoNotUseInAppConf.Routes run

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/StartViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/StartViewSpec.scala
@@ -110,7 +110,7 @@ class StartViewSpec extends UnitViewSpec with Matchers {
 
     "display 'Use this service to' section" in {
 
-      view.getElementsByClass("govuk-body").get(0) must containMessage(
+      view.getElementsByClass("govuk-body").get(1) must containMessage(
         "startPage.useThisServiceTo.header"
       )
 
@@ -144,7 +144,7 @@ class StartViewSpec extends UnitViewSpec with Matchers {
         "startPage.informationYouNeed.header"
       )
 
-      view.getElementsByClass("govuk-body").get(4) must containMessage(
+      view.getElementsByClass("govuk-body").get(5) must containMessage(
         "startPage.informationYouNeed.line.1"
       )
 


### PR DESCRIPTION
### Description of Work carried through

Added `aria-labelledby` attribute to `<nav>` as suggested by Axe tool
- renamed `dashList` > `navList` to make intention clearer
- removed `<nav>` from `bulletList` (it's not a navigation element)
- added script to run service locally as I keep forgetting the test routes which cause the ATs to fail

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
