### PR TITLE
PPTP-1204 - User already subscribed - Redirect users to PPT home

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -99,7 +99,9 @@ class AuthActionImpl @Inject() (
     email: String,
     allEnrolments: Enrolments
   ) =
-    if (allowedUsers.isAllowed(email))
+    if (allEnrolments.getEnrolment("HMRC-PPT-ORG").isDefined)
+      Future.successful(Results.Redirect(appConfig.pptAccountUrl))
+    else if (allowedUsers.isAllowed(email))
       block(
         new AuthenticatedRequest(
           request,


### PR DESCRIPTION
### Description of Work carried through

Check user for presence of `HMRC-PPT-ORG` enrolment and redirect to "accounts" service if found

Requires AT changes - https://github.com/hmrc/plastic-packaging-tax-acceptance/pull/53

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
