### PR TITLE
PPTP-1204 - fix config for PPT accounts FE service

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -90,7 +90,9 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
     servicesConfig.baseUrl("email-verification")
 
   lazy val pptAccountHost: String =
-    servicesConfig.baseUrl("ppt-account-frontend")
+    config.getOptional[String]("platform.frontend.host").getOrElse(
+      servicesConfig.baseUrl("ppt-account-frontend")
+    )
 
   lazy val feedbackAuthenticatedLink: String = config.get[String]("urls.feedback.authenticatedLink")
 


### PR DESCRIPTION
### Description of Work carried through

Host for PPT accounts FE service is simply `platform.frontend.host` for all MDTP environments.  Only localhost needs to use the value defined in application.config

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
