### PR TITLE
PPTP-1118 - Links vulnerable to reverse tabnabbing

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
@@ -15,13 +15,13 @@
 *@
 @this()
 
-@(text: String, textHidden: Option[String] = None, call: Call, target: String = "_self", id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
+@(text: String, textHidden: Option[String] = None, call: Call, newTab: Boolean = false, id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
 
 @hasHint = @{
     textHidden.exists(_.nonEmpty)
 }
 
-<a class="@classes" href="@call" target=@target @id.map { id => id="@id"}><span @if(hasHint) {
+<a class="@classes" href="@call" @if(newTab) { target="_blank" rel="noopener noreferrer" } @id.map { id => id="@id"}><span @if(hasHint) {
     aria-hidden="true"}>@text</span>@if(hasHint) {
     <span class="govuk-visually-hidden">@{
         textHidden.getOrElse("")

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_expect_to_exceed_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_expect_to_exceed_threshold_weight_page.scala.html
@@ -59,7 +59,7 @@
 @pptGuidanceLink = {
 @link(
     id = Some("guidance-link"),
-    target = "_blank",
+    newTab = true,
     text = messages("liabilityExpectToExceedThresholdWeightPage.guidance.description"),
     call = Call(
         method = "GET",

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
@@ -54,7 +54,7 @@
 @pptGuidanceLink = {
     @link(
         id = Some("guidance-link"),
-        target = "_blank",
+        newTab = true,
         text = messages("liabilityWeightPage.guidance.description"),
         call = Call(
             method = "GET",

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/not_liable.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/not_liable.scala.html
@@ -68,7 +68,7 @@
 @guidanceLink = @{
     link(
         id = Some("guidance-link"),
-        target = "_blank",
+        newTab = true,
         text = messages("notLiable.guidance.link.description"),
         call = Call(
             method = "GET",

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityExpectToExceedThresholdWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityExpectToExceedThresholdWeightViewSpec.scala
@@ -96,6 +96,14 @@ class LiabilityExpectToExceedThresholdWeightViewSpec extends UnitViewSpec with M
       view.getElementsByClass("govuk-label").get(1).text() mustBe "No"
     }
 
+    "display guidance link" in {
+
+      val link = view.getElementById("guidance-link")
+      link must haveHref(messages("liabilityExpectToExceedThresholdWeightPage.guidance.href"))
+      link.attr("target") mustBe "_blank"
+      link.attr("rel") mustBe "noopener noreferrer"
+    }
+
     "display 'Save And Continue' button" in {
 
       view must containElementWithID("submit")

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityWeightViewSpec.scala
@@ -97,9 +97,10 @@ class LiabilityWeightViewSpec extends UnitViewSpec with Matchers {
 
     "display liability weight information link" in {
 
-      view.getElementById("guidance-link") must haveHref(
-        messages("liabilityWeightPage.guidance.href")
-      )
+      val link = view.getElementById("guidance-link")
+      link must haveHref(messages("liabilityWeightPage.guidance.href"))
+      link.attr("target") mustBe "_blank"
+      link.attr("rel") mustBe "noopener noreferrer"
     }
 
     "display total weight label" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
@@ -76,9 +76,12 @@ class NotLiableViewSpec extends UnitViewSpec with Matchers {
 
     "display guidance text" in {
 
-      view.getElementById("guidance-text").text() must include(
+      val link = view.getElementById("guidance-text")
+      link.text() must include(
         messages("notLiable.guidance", messages("notLiable.guidance.link.description"))
       )
+      link.attr("target") mustBe "_blank"
+      link.attr("rel") mustBe "noopener noreferrer"
     }
 
     "display guidance link" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
@@ -76,17 +76,18 @@ class NotLiableViewSpec extends UnitViewSpec with Matchers {
 
     "display guidance text" in {
 
-      val link = view.getElementById("guidance-text")
-      link.text() must include(
+      view.getElementById("guidance-text").text() must include(
         messages("notLiable.guidance", messages("notLiable.guidance.link.description"))
       )
-      link.attr("target") mustBe "_blank"
-      link.attr("rel") mustBe "noopener noreferrer"
     }
 
     "display guidance link" in {
+      val link = view.getElementById("guidance-link")
 
-      view.getElementById("guidance-link") must haveHref(messages("notLiable.guidance.link.href"))
+      link must haveHref(messages("notLiable.guidance.link.href"))
+
+      link.attr("target") mustBe "_blank"
+      link.attr("rel") mustBe "noopener noreferrer"
     }
 
     "display feedback subheading" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/UnauthorisedViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/UnauthorisedViewSpec.scala
@@ -52,7 +52,7 @@ class UnauthorisedViewSpec extends UnitViewSpec with Matchers {
 
       link must containMessage("unauthorised.paragraph.1.link")
       link must haveHref(routes.StartController.displayStartPage().url)
-      link.attr("target") mustBe "_self"
+      link.attributes().hasKey("target") mustBe false
     }
 
     "display ppt guidance link" in {
@@ -62,7 +62,6 @@ class UnauthorisedViewSpec extends UnitViewSpec with Matchers {
       link must haveHref(
         "https://www.gov.uk/government/publications/introduction-of-plastic-packaging-tax/plastic-packaging-tax"
       )
-      link.attr("target") mustBe "_self"
     }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/UnauthorisedViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/UnauthorisedViewSpec.scala
@@ -62,6 +62,7 @@ class UnauthorisedViewSpec extends UnitViewSpec with Matchers {
       link must haveHref(
         "https://www.gov.uk/government/publications/introduction-of-plastic-packaging-tax/plastic-packaging-tax"
       )
+      link.attributes().hasKey("target") mustBe false
     }
   }
 }


### PR DESCRIPTION
- remove `target` attribute from links where not needed
- add `rel="noopener noreferrer"` where target is "_blank" (open in new tab)

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
