### PR TITLE
PPTP-1210 - Update application library dependencies

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
@@ -27,7 +26,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
 
 @this(
-  formHelper: formWithCSRF,
+  formHelper: FormWithCSRF,
   govukLayout: main_template,
   govukButton: GovukButton,
   inputText: inputText,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_liability_details_answers_page.scala.html
@@ -1,19 +1,19 @@
 @*
-* Copyright 2021 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.pageTitle
@@ -27,7 +27,7 @@
 @import java.time.format.DateTimeFormatter
 
 @this(
-        formHelper: formWithCSRF,
+        formHelper: FormWithCSRF,
         govukLayout: main_template,
         govukButton: GovukButton,
         govukSummaryList: GovukSummaryList,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_primary_contact_details_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/check_primary_contact_details_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
@@ -27,7 +26,7 @@
 @import play.twirl.api.HtmlFormat
 
 @this(
-  formHelper: formWithCSRF,
+  formHelper: FormWithCSRF,
   govukLayout: main_template,
   govukSummaryList: GovukSummaryList,
   pageTitle: pageTitle,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2021 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this()
 
 @(text: String, textHidden: Option[String] = None, call: Call, newTab: Boolean = false, id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/confirm_address.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/confirm_address.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
@@ -31,7 +30,7 @@
 @import play.twirl.api.HtmlFormat
 
 @this(
-  formHelper: formWithCSRF,
+  formHelper: FormWithCSRF,
   govukLayout: main_template,
   govukButton: GovukButton,
   govukRadios : GovukRadios,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/confirm_organisation_based_in_uk.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/confirm_organisation_based_in_uk.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
@@ -28,7 +27,7 @@
 @import play.twirl.api.HtmlFormat
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukRadios : GovukRadios,
     sectionHeader: sectionHeader,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
@@ -35,7 +34,7 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   appConfig: AppConfig,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 @(form: Form[EmailAddress])(implicit request: Request[_], messages: Messages)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_confirmation_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_confirmation_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{errorSummary, paragraphBody, sectionHeader}
@@ -30,7 +29,7 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   appConfig: AppConfig,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_page.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.EmailAddressPasscode
@@ -32,7 +31,7 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   appConfig: AppConfig,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/full_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/full_name_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
@@ -25,7 +24,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.FullName
 
 @this(
-  formHelper: formWithCSRF,
+  formHelper: FormWithCSRF,
   govukLayout: main_template,
   govukButton: GovukButton,
   govukInput: GovukInput,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/job_title_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/job_title_page.scala.html
@@ -14,10 +14,7 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.govukFieldset
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
@@ -32,7 +29,7 @@
   govukInput: GovukInput,
   sectionHeader: sectionHeader,
   errorSummary: errorSummary,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 @(form: Form[JobTitle])(implicit request: Request[_], messages: Messages)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_expect_to_exceed_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_expect_to_exceed_threshold_weight_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
@@ -30,7 +29,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.pageHeading
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
         pageHeading: pageHeading,
         paragraph: paragraph,
         link: link,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_liable_date_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_liable_date_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
@@ -27,7 +26,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityLiableDate.no
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukRadios : GovukRadios,
     sectionHeader: sectionHeader,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_start_date_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_start_date_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.sectionHeader
@@ -25,7 +24,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.saveButtons
 
 @this(
-  formHelper: formWithCSRF,
+  formHelper: FormWithCSRF,
   govukLayout: main_template,
   saveAndContinue: saveAndContinue,
   govukDateInput : GovukDateInput,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability_weight_page.scala.html
@@ -1,20 +1,20 @@
 @*
-* Copyright 2021 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
-@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukButton, GovukInput, govukFieldset}
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityWeight
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components._
@@ -25,12 +25,10 @@
         pageHeading: pageHeading,
         paragraph: paragraph,
         link: link,
-        govukButton: GovukButton,
         govukInput: GovukInput,
         sectionHeader: sectionHeader,
-        govukFieldset: govukFieldset,
         errorSummary: errorSummary,
-        formHelper: formWithCSRF,
+        formHelper: FormWithCSRF,
         saveButtons: saveButtons,
         govukInsetText: GovukInsetText,
 )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/main_template.scala.html
@@ -21,7 +21,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.timeoutDialog
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.TimeoutDialogConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
-@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.hmrcStandardFooter
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcStandardFooter
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcTrackingConsentSnippet
 
 @this(
@@ -34,7 +34,7 @@
         hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
         siteHeader: siteHeader,
         phaseBanner: phaseBanner,
-        hmrcFooter: hmrcStandardFooter
+        hmrcFooter: HmrcStandardFooter
 )
 @(title: Title,
   backButton: Option[BackButton] = None,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/not_liable.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/not_liable.scala.html
@@ -1,22 +1,21 @@
 @*
-* Copyright 2021 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.govukFieldset
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components._
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
@@ -32,9 +31,8 @@
         govukButton: GovukButton,
         govukInput: GovukInput,
         sectionHeader: sectionHeader,
-        govukFieldset: govukFieldset,
         errorSummary: errorSummary,
-        formHelper: formWithCSRF,
+        formHelper: FormWithCSRF,
         saveButtons: saveButtons,
         govukInsetText : GovukInsetText,
         appConfig: AppConfig

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation_type.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation_type.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
@@ -26,7 +25,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{UK_COMPANY, SOLE_TRADER, PARTNERSHIP, CHARITY_OR_NOT_FOR_PROFIT, OVERSEAS_COMPANY}
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukRadios : GovukRadios,
     sectionHeader: sectionHeader,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partnership_type.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partnership_type.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
@@ -26,7 +25,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{GENERAL_PARTNERSHIP, LIMITED_LIABILITY_PARTNERSHIP, LIMITED_PARTNERSHIP, SCOTTISH_PARTNERSHIP, SCOTTISH_LIMITED_PARTNERSHIP}
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukRadios : GovukRadios,
     sectionHeader: sectionHeader,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/phone_number_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/phone_number_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
@@ -30,7 +29,7 @@
   govukInput: GovukInput,
   sectionHeader: sectionHeader,
   errorSummary: errorSummary,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 @(form: Form[PhoneNumber])(implicit request: Request[_], messages: Messages)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.BackButton
@@ -34,7 +33,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
 
 @this(
-    formHelper: formWithCSRF,
+    formHelper: FormWithCSRF,
     govukLayout: main_template,
     govukSummaryList: GovukSummaryList,
     pageTitle: pageTitle,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/too_many_attempts_passcode_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/too_many_attempts_passcode_page.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{errorSummary, paragraphBody, sectionHeader}
@@ -30,7 +29,7 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   appConfig: AppConfig,
-  formHelper: formWithCSRF
+  formHelper: FormWithCSRF
 )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,7 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test,
     TwirlKeys.templateImports        ++= Seq(
       "uk.gov.hmrc.hmrcfrontend.views.html.components._",
-      "uk.gov.hmrc.govukfrontend.views.html.components._",
-      "uk.gov.hmrc.govukfrontend.views.html.helpers._"),
+      "uk.gov.hmrc.govukfrontend.views.html.components._"),
 
     // ***************
     // Use the silencer plugin to suppress warnings

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,9 +23,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided
@@ -35,7 +35,6 @@ play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters"
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
@@ -46,7 +45,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.plasticpackagingtax.registration.config.ErrorHandler"
 
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com www.googletagmanager.com tagmanager.google.com data:"
+play.filters.csp.CSPFilter = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 www.google-analytics.com www.googletagmanager.com tagmanager.google.com data:"
 
 # Play Modules
 # ~~~~

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,14 +6,13 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.2.0",
-    "uk.gov.hmrc"             %% "play-frontend-govuk"        % "0.71.0-play-28",
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "0.60.0-play-28",
+    "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.14.0",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.11.0-play-28",
     "org.webjars.npm"         %  "govuk-frontend"             % "3.11.0",
     "org.webjars.npm"         %  "hmrc-frontend"              % "1.32.0"
   )
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.2.0"                 % Test,
+    "uk.gov.hmrc"             %% "bootstrap-test-play-28"     % "5.14.0"                 % Test,
     "org.scalatest"           %% "scalatest"                  % "3.2.5"                 % Test,
     "org.jsoup"               %  "jsoup"                      % "1.13.1"                % Test,
     "com.typesafe.play"       %% "play-test"                  % current                 % Test,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
 

--- a/test/base/Stubs.scala
+++ b/test/base/Stubs.scala
@@ -39,67 +39,16 @@ import play.api.http.{DefaultFileMimeTypes, FileMimeTypes, FileMimeTypesConfigur
 import play.api.i18n.{Langs, MessagesApi}
 import play.api.mvc._
 import play.api.test.Helpers._
-import uk.gov.hmrc.govukfrontend.views.html.components
-import uk.gov.hmrc.govukfrontend.views.html.components.{GovukHeader, Footer => _, _}
-import uk.gov.hmrc.hmrcfrontend.config.{AccessibilityStatementConfig, TrackingConsentConfig}
-import uk.gov.hmrc.hmrcfrontend.views.html.components.{
-  HmrcFooter,
-  HmrcHeader,
-  HmrcReportTechnicalIssue
-}
-import uk.gov.hmrc.hmrcfrontend.views.html.helpers.{
-  hmrcStandardFooter,
-  HmrcFooterItems,
-  HmrcTrackingConsentSnippet
-}
-import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, TimeoutDialogConfig}
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.{phaseBanner, siteHeader}
+import uk.gov.hmrc.govukfrontend.views.html.components.{Footer => _}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.ExecutionContext
 
 trait Stubs {
 
-  val gdsGovukLayout = new GovukLayout(new components.GovukTemplate(govukHeader = new GovukHeader(),
-                                                                    govukFooter = new GovukFooter(),
-                                                                    new GovukSkipLink()
-                                       ),
-                                       new GovukHeader(),
-                                       new GovukFooter(),
-                                       new GovukBackLink()
-  )
-
-  val hmrcFooter = new hmrcStandardFooter(
-    new HmrcFooter(),
-    new HmrcFooterItems(new AccessibilityStatementConfig(Configuration(minimalConfig)))
-  )
-
-  val hmrcTrackingConsentSnippet = new HmrcTrackingConsentSnippet(
-    new TrackingConsentConfig(Configuration(minimalConfig))
-  )
-
   val appConfig =
     new AppConfig(Configuration(minimalConfig), servicesConfig(Configuration(minimalConfig)))
-
-  val hmrcReportTechnicalIssue = new HmrcReportTechnicalIssue()
-  val govukHeader              = new GovukHeader()
-  val sHeader                  = new siteHeader(HmrcHeader)
-  val govPBanner               = new GovukPhaseBanner(new govukTag())
-  val pBanner                  = new phaseBanner(govPBanner, appConfig)
-  val timeoutDialogConfig      = new TimeoutDialogConfig(servicesConfig(Configuration(minimalConfig)))
-
-  val gdsMainTemplate = new main_template(govukHeader = govukHeader,
-                                          govukLayout = gdsGovukLayout,
-                                          govukBackLink = new components.GovukBackLink(),
-                                          siteHeader = sHeader,
-                                          timeoutDialogConfig = timeoutDialogConfig,
-                                          govukPhaseBanner = govPBanner,
-                                          hmrcFooter = hmrcFooter,
-                                          phaseBanner = pBanner,
-                                          hmrcTrackingConsentSnippet = hmrcTrackingConsentSnippet,
-                                          hmrcReportTechnicalIssue = hmrcReportTechnicalIssue
-  )
 
   private val minimalConfig: Config =
     ConfigFactory.parseString("""

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/audit/AuditorSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/audit/AuditorSpec.scala
@@ -131,11 +131,7 @@ class AuditorSpec extends ConnectorISpec with Injector with ScalaFutures with Re
                |                    "clientPort": "-"
                |                  },
                |                  "detail": $body,
-               |                  "generatedAt": "$${json-unit.any-string}",
-               |                  "metadata": {
-               |                    "sendAttemptAt": "$${json-unit.any-string}",
-               |                    "instanceID": "$${json-unit.any-string}",
-               |                    "sequence": "$${json-unit.any-number}"
+               |                  "generatedAt": "$${json-unit.any-string}"
                |                  }
                |                }""".stripMargin, true, true))
       )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -23,8 +23,7 @@ import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import play.api.mvc.{AnyContent, Call}
 import play.twirl.api.TwirlHelperImports.twirlJavaCollectionToScala
-import uk.gov.hmrc.govukfrontend.views.html.components.{GovukButton, GovukSummaryList}
-import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukButton, GovukSummaryList}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
@@ -38,13 +37,12 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
   main_template
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
-
 import java.time.format.DateTimeFormatter
 
 @ViewTest
 class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
 
-  private val formHelper       = instanceOf[formWithCSRF]
+  private val formHelper       = instanceOf[FormWithCSRF]
   private val govukLayout      = instanceOf[main_template]
   private val govukButton      = instanceOf[GovukButton]
   private val govukSummaryList = instanceOf[GovukSummaryList]

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
@@ -19,8 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.views
 import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
-import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
-import uk.gov.hmrc.govukfrontend.views.html.helpers.formWithCSRF
+import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukSummaryList}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
@@ -53,7 +52,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 @ViewTest
 class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers {
 
-  private val formHelper       = instanceOf[formWithCSRF]
+  private val formHelper       = instanceOf[FormWithCSRF]
   private val govukLayout      = instanceOf[main_template]
   private val govukSummaryList = instanceOf[GovukSummaryList]
   private val pageTitle        = instanceOf[pageTitle]


### PR DESCRIPTION
### Description of Work carried through

Update versions in AppDependencies.scala and plugins.sbt
- removed play-frontend-govuk lib (pulled in by play-frontend-hmrc)
Code changes due to 
- removal of static helpers in play-frontend-govuk
- change in auditing message structure

Fixed config warnings
```
2021-09-23 08:16:00,305 level=[WARN] logger=[uk.gov.hmrc.play.bootstrap.config.DeprecatedConfigChecker] thread=[pool-1-thread-1] rid=[] user=[] message=[The key 'play.modules.enabled' is configured with value 'uk.gov.hmrc.play.bootstrap.AuditModule', which is deprecated. Please use 'uk.gov.hmrc.play.audit.AuditModule' instead.] 


2021-09-23 08:16:02,958 level=[WARN] logger=[play.filters.headers.SecurityHeadersConfig] thread=[pool-1-thread-1] rid=[] user=[] message=[play.filters.headers.contentSecurityPolicy is deprecated in 2.7.0.  Please use play.filters.csp.CSPFilter instead.] 


2021-09-23 08:16:02,965 level=[WARN] logger=[uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters] thread=[pool-1-thread-1] rid=[] user=[] message=[play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilter" is no longer required and can be removed. Filters are configured using play's default filter system: https://www.playframework.com/documentation/2.7.x/Filters#Default-Filters] 
```

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
