### PR TITLE
BAU - auth error handling

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandler.scala
@@ -18,30 +18,18 @@ package uk.gov.hmrc.plasticpackagingtax.registration.config
 
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Request, RequestHeader, Result, Results}
+import play.api.mvc.Request
 import play.twirl.api.Html
-import uk.gov.hmrc.auth.core.{InsufficientEnrolments, NoActiveSession}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_template
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 
 @Singleton
-class ErrorHandler @Inject() (error_template: error_template, val messagesApi: MessagesApi)(implicit
-  appConfig: AppConfig
-) extends FrontendErrorHandler {
+class ErrorHandler @Inject() (error_template: error_template, val messagesApi: MessagesApi)
+    extends FrontendErrorHandler {
 
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit
     request: Request[_]
   ): Html =
     error_template(pageTitle, heading, message)
-
-  override def resolveError(rh: RequestHeader, ex: Throwable): Result =
-    ex match {
-      case _: NoActiveSession =>
-        Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
-      case _: InsufficientEnrolments =>
-        Results.Redirect(routes.UnauthorisedController.onPageLoad())
-      case _ => super.resolveError(rh, ex)
-    }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -92,7 +92,7 @@ class AuthActionImpl @Inject() (
       } recover {
       case _: NoActiveSession =>
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
-      case _: InsufficientEnrolments =>
+      case _: AuthorisationException =>
         Results.Redirect(routes.UnauthorisedController.onPageLoad())
 
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -89,7 +89,13 @@ class AuthActionImpl @Inject() (
           )
 
           executeRequest(request, block, identityData, email.getOrElse(""), allEnrolments)
-      }
+      } recover {
+      case _: NoActiveSession =>
+        Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
+      case _: InsufficientEnrolments =>
+        Results.Redirect(routes.UnauthorisedController.onPageLoad())
+
+    }
   }
 
   private def executeRequest[A](

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -240,4 +240,8 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
       )(any(), any())
     ).thenReturn(Future.failed(new RuntimeException))
 
+  def whenAuthFailsWith(exc: AuthorisationException): Unit =
+    when(mockAuthConnector.authorise(any(), any())(any(), any()))
+      .thenReturn(Future.failed(exc))
+
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandlerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandlerTest.scala
@@ -17,23 +17,17 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.config
 
 import base.unit.UnitViewSpec
-import org.mockito.Mockito.when
 import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
-import play.api.http.Status.SEE_OTHER
 import play.api.test.DefaultAwaitTimeout
-import play.api.test.Helpers.{redirectLocation, status, stubMessagesApi}
-import uk.gov.hmrc.auth.core.{InsufficientEnrolments, NoActiveSession}
-import uk.gov.hmrc.hmrcfrontend.views.Utils.urlEncode
+import play.api.test.Helpers.stubMessagesApi
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_template
-
-import scala.concurrent.Future
 
 class ErrorHandlerTest
     extends UnitViewSpec with Matchers with DefaultAwaitTimeout with OptionValues {
 
   private val errorPage    = instanceOf[error_template]
-  private val errorHandler = new ErrorHandler(errorPage, stubMessagesApi())(appConfig)
+  private val errorHandler = new ErrorHandler(errorPage, stubMessagesApi())
 
   "ErrorHandlerSpec" should {
 
@@ -47,29 +41,5 @@ class ErrorHandlerTest
       result must include("message")
     }
 
-    "handle no active session authorisation exception" in {
-
-      when(appConfig.loginUrl).thenReturn("http://localhost:9949/auth-login-stub/gg-sign-in")
-      when(appConfig.loginContinueUrl).thenReturn(
-        "http://localhost:8503/plastic-packaging-tax/registration"
-      )
-
-      val error            = new NoActiveSession("A user is not logged in") {}
-      val result           = Future.successful(errorHandler.resolveError(journeyRequest, error))
-      val encodedTargetUrl = urlEncode("http://localhost:8503/plastic-packaging-tax/registration")
-      val expectedLocation =
-        s"http://localhost:9949/auth-login-stub/gg-sign-in?continue=$encodedTargetUrl"
-
-      status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some(expectedLocation)
-    }
-    "handle insufficient enrolments authorisation exception" in {
-
-      val error  = InsufficientEnrolments("HMRC-PPT-ORG")
-      val result = Future.successful(errorHandler.resolveError(journeyRequest, error))
-
-      status(result) mustBe SEE_OTHER
-      redirectLocation(result).value must endWith("/unauthorised")
-    }
   }
 }


### PR DESCRIPTION
### Description of Work carried through

Change the way we handle "authorisation" errors to stop them getting logged as exceptions

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
