### PR TITLE
PPTP-1205 : Alert of Duplicate Subscriptions

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
@@ -73,6 +73,12 @@ case class OrganisationDetails(
       case _ => false
     }
 
+  val businessName: Option[String] = organisationType match {
+    case Some(UK_COMPANY)  => incorporationDetails.map(_.companyName)
+    case Some(SOLE_TRADER) => soleTraderDetails.map(st => s"${st.firstName} ${st.lastName}")
+    case _                 => None
+  }
+
 }
 
 object OrganisationDetails {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/subscriptions/SubscriptionCreateResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/subscriptions/SubscriptionCreateResponse.scala
@@ -20,7 +20,9 @@ import play.api.libs.json.{Json, OFormat}
 
 import java.time.ZonedDateTime
 
-case class SubscriptionCreateResponse(
+trait SubscriptionCreateResponse
+
+case class SubscriptionCreateResponseSuccess(
   pptReference: String,
   processingDate: ZonedDateTime,
   formBundleNumber: String,
@@ -28,11 +30,32 @@ case class SubscriptionCreateResponse(
   nrsSubmissionId: Option[String],
   nrsFailureReason: Option[String],
   enrolmentInitiatedSuccessfully: Boolean
-)
+) extends SubscriptionCreateResponse
 
-object SubscriptionCreateResponse {
+object SubscriptionCreateResponseSuccess {
 
-  implicit val format: OFormat[SubscriptionCreateResponse] =
-    Json.format[SubscriptionCreateResponse]
+  implicit val format: OFormat[SubscriptionCreateResponseSuccess] =
+    Json.format[SubscriptionCreateResponseSuccess]
+
+}
+
+case class EisError(code: String, reason: String) {
+  val isDuplicateSubscription: Boolean = code == "ACTIVE_SUBSCRIPTION_EXISTS"
+}
+
+object EisError {
+
+  implicit val format: OFormat[EisError] =
+    Json.format[EisError]
+
+}
+
+case class SubscriptionCreateResponseFailure(failures: Seq[EisError])
+    extends SubscriptionCreateResponse
+
+object SubscriptionCreateResponseFailure {
+
+  implicit val format: OFormat[SubscriptionCreateResponseFailure] =
+    Json.format[SubscriptionCreateResponseFailure]
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/subscriptions/SubscriptionCreateResponse.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/subscriptions/SubscriptionCreateResponse.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.EisError.DUPLICATE_SUBSCRIPTION_ERROR_CODES
 
 import java.time.ZonedDateTime
 
@@ -40,13 +41,19 @@ object SubscriptionCreateResponseSuccess {
 }
 
 case class EisError(code: String, reason: String) {
-  val isDuplicateSubscription: Boolean = code == "ACTIVE_SUBSCRIPTION_EXISTS"
+  val isDuplicateSubscription: Boolean = DUPLICATE_SUBSCRIPTION_ERROR_CODES.contains(code)
 }
 
 object EisError {
 
   implicit val format: OFormat[EisError] =
     Json.format[EisError]
+
+  private val DUPLICATE_SUBSCRIPTION_ERROR_CODES = List("ACTIVE_SUBSCRIPTION_EXISTS",
+                                                        "BUSINESS_VALIDATION",
+                                                        "ACTIVE_GROUP_SUBSCRIPTION_EXISTS",
+                                                        "CANNOT_CREATE_PARTNERSHIP_SUBSCRIPTION"
+  )
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/link.scala.html
@@ -15,15 +15,6 @@
 *@
 @this()
 
-@(text: String, textHidden: Option[String] = None, call: Call, target: String = "_self", id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
+@(text: String, call: Call, target: String = "_self", id: Option[String] = None, classes: String = "govuk-link govuk-link--no-visited-state")
 
-@hasHint = @{
-    textHidden.exists(_.nonEmpty)
-}
-
-<a class="@classes" href="@call" target=@target @id.map { id => id="@id"}><span @if(hasHint) {
-    aria-hidden="true"}>@text</span>@if(hasHint) {
-    <span class="govuk-visually-hidden">@{
-        textHidden.getOrElse("")
-    }</span>
-}</a>
+<a class="@classes" href="@call" target="@target" @id.map{id => id="@id"}>@text</a>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/stackedContentWithLabel.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/stackedContentWithLabel.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(label: String, classes: String = "govuk-body", content: String, contentClasses: String = "govuk-!-font-weight-bold", id: Option[String] = None)
+
+<p class="@classes">
+ @label<br/>
+ <strong class="@contentClasses" @id.map{id => id="@id"}>@content</strong>
+</p>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/stackedContentWithLabel.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/stackedContentWithLabel.scala.html
@@ -16,9 +16,9 @@
 
 @this()
 
-@(label: String, classes: String = "govuk-body", content: String, contentClasses: String = "govuk-!-font-weight-bold", id: Option[String] = None)
+@(label: String, classes: String = "govuk-body", content: String, contentClasses: String = "govuk-!-font-weight-bold")
 
 <p class="@classes">
  @label<br/>
- <strong class="@contentClasses" @id.map{id => id="@id"}>@content</strong>
+ <strong class="@contentClasses">@content</strong>
 </p>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/duplicate_subscription_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/duplicate_subscription_page.scala.html
@@ -1,0 +1,31 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+
+@this(govukLayout: main_template)
+
+@(businessName: Option[String])(implicit request: Request[_], messages: Messages)
+
+@govukLayout(title = Title("duplicateSubscription.title")) {
+ <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+   <h1 class="govuk-heading-xl" >@messages("duplicateSubscription.heading")</h1>
+   <p class="govuk-body">@messages("duplicateSubscription.detail", businessName.getOrElse("<missing-business-name>"))</p>
+  </div>
+ </div>
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/duplicate_subscription_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/duplicate_subscription_page.scala.html
@@ -1,31 +1,36 @@
 @*
- * Copyright 2021 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
+* Copyright 2021 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.pageHeading
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.paragraphBody
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.pptHelplineDetails
 
-@this(govukLayout: main_template)
+@this(
+        govukLayout: main_template,
+        pageHeading: pageHeading,
+        paragraphBody: paragraphBody,
+        pptHelplineDetails: pptHelplineDetails
+)
 
 @(businessName: Option[String])(implicit request: Request[_], messages: Messages)
 
 @govukLayout(title = Title("duplicateSubscription.title")) {
- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-   <h1 class="govuk-heading-xl" >@messages("duplicateSubscription.heading")</h1>
-   <p class="govuk-body">@messages("duplicateSubscription.detail", businessName.getOrElse("<missing-business-name>"))</p>
-  </div>
- </div>
+    @pageHeading(text = messages("duplicateSubscription.heading"))
+    @paragraphBody(message = messages("duplicateSubscription.detail", businessName.getOrElse("<missing-business-name>")))
+    @pptHelplineDetails()
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/pptHelplineDetails.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/pptHelplineDetails.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.paragraphBody
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.stackedContentWithLabel
+
+@this(
+    paragraphBody: paragraphBody,
+    stackedContentWithLabel: stackedContentWithLabel
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@paragraphBody(message = messages("pptHelpline.intro"))
+
+@stackedContentWithLabel(
+ label = messages("pptHelpline.telephone.title"),
+ content = messages("pptHelpline.telephone.detail")
+)
+
+@stackedContentWithLabel(
+ label = messages("pptHelpline.textphone.title"),
+ content = messages("pptHelpline.textphone.detail")
+)
+
+@stackedContentWithLabel(
+ label = messages("pptHelpline.telephone.outsideUK.title"),
+ content = messages("pptHelpline.telephone.outsideUK.detail")
+)
+
+@stackedContentWithLabel(
+ label = messages("pptHelpline.openingTimes.title"),
+ content = messages("pptHelpline.openingTimes.detail.1")
+)
+
+@paragraphBody(message = messages("pptHelpline.openingTimes.detail.2"))

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,9 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     "features\\..*",
     "test\\..*",
     ".*(BuildInfo|Routes|Options).*",
-    "logger.*\\(.*\\)"
+    "logger.*\\(.*\\)",
+    ".*views.html.components\\..*",
+    ".*views.html.partials\\..*"
   ).mkString(";"),
   coverageMinimum := 96,
   coverageFailOnMinimum := true,

--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     "features\\..*",
     "test\\..*",
     ".*(BuildInfo|Routes|Options).*",
-    "logger.*\\(.*\\)",
-    ".*views.html.components\\..*",
-    ".*views.html.partials\\..*"
+    "logger.*\\(.*\\)"
   ).mkString(";"),
   coverageMinimum := 96,
   coverageFailOnMinimum := true,

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -264,6 +264,18 @@ businessEntityVerification.failure.title = We have been unable to verify your or
 businessEntityVerification.failure.heading = We have been unable to verify your organisation
 businessEntityVerification.failure.detail = TODO: content to assist user to go here
 
-duplicateSubscription.title = Active subscription already exists
-duplicateSubscription.heading = Active subscription already exists
-duplicateSubscription.detail = We have detected that there is already an active PPT registration for {0}.
+duplicateSubscription.title = Your organisation is already registered
+duplicateSubscription.heading = Your organisation is already registered
+duplicateSubscription.detail = Someone has already submitted a PPT registration for {0}.
+
+pptHelpline.intro = Contact the Plastic Packaging Helpline if you have any questions.
+pptHelpline.telephone.title = Telephone:
+pptHelpline.telephone.detail = 0300 300 3000
+pptHelpline.textphone.title = Textphone:
+pptHelpline.textphone.detail = 0300 300 3001
+pptHelpline.telephone.outsideUK.title = Outside UK:
+pptHelpline.telephone.outsideUK.detail = +44 0300 300 3002
+pptHelpline.openingTimes.title = Opening times:
+pptHelpline.openingTimes.detail.1 = Monday to Friday: 8am to 8pm
+pptHelpline.openingTimes.detail.2 = Closed Easter Sunday, Christmas Day, Boxing Day and New Year’s Day.
+

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -263,3 +263,7 @@ businessEntityIdentification.failure.detail = TODO: content to assist user to go
 businessEntityVerification.failure.title = We have been unable to verify your organisation
 businessEntityVerification.failure.heading = We have been unable to verify your organisation
 businessEntityVerification.failure.detail = TODO: content to assist user to go here
+
+duplicateSubscription.title = Active subscription already exists
+duplicateSubscription.heading = Active subscription already exists
+duplicateSubscription.detail = We have detected that there is already an active PPT registration for {0}.

--- a/test/base/unit/MockConnectors.scala
+++ b/test/base/unit/MockConnectors.scala
@@ -26,6 +26,8 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration._
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.{
   SubscriptionCreateResponse,
+  SubscriptionCreateResponseFailure,
+  SubscriptionCreateResponseSuccess,
   SubscriptionStatus
 }
 
@@ -132,7 +134,7 @@ trait MockConnectors extends MockitoSugar with RegistrationBuilder with BeforeAn
     )
 
   protected def mockSubscriptionSubmit(
-    subscription: SubscriptionCreateResponse
+    subscription: SubscriptionCreateResponseSuccess
   ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
     when(mockSubscriptionsConnector.submitSubscription(any(), any())(any())).thenReturn(
       Future.successful(subscription)
@@ -143,6 +145,13 @@ trait MockConnectors extends MockitoSugar with RegistrationBuilder with BeforeAn
   ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
     when(mockSubscriptionsConnector.submitSubscription(any(), any())(any())).thenReturn(
       Future.failed(ex)
+    )
+
+  protected def mockSubscriptionSubmitFailure(
+    failureResponse: SubscriptionCreateResponseFailure
+  ): OngoingStubbing[Future[SubscriptionCreateResponse]] =
+    when(mockSubscriptionsConnector.submitSubscription(any(), any())(any())).thenReturn(
+      Future.successful(failureResponse)
     )
 
   override protected def beforeEach(): Unit = {

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -44,7 +44,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.{
   ETMPSubscriptionStatus,
-  SubscriptionCreateResponse,
+  SubscriptionCreateResponseSuccess,
   SubscriptionStatus
 }
 import utils.FakeRequestCSRFSupport.CSRFFakeRequest
@@ -197,16 +197,16 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
 
   protected val nrsSubmissionId = "nrs-id-999"
 
-  protected val subscriptionCreate: SubscriptionCreateResponse = SubscriptionCreateResponse(
-    pptReference = "XXPPTP123456789",
-    processingDate =
-      ZonedDateTime.now(ZoneOffset.UTC),
-    formBundleNumber = "123456789",
-    nrsNotifiedSuccessfully = true,
-    nrsSubmissionId = Some(nrsSubmissionId),
-    nrsFailureReason = None,
-    enrolmentInitiatedSuccessfully = true
-  )
+  protected val subscriptionCreate: SubscriptionCreateResponseSuccess =
+    SubscriptionCreateResponseSuccess(pptReference = "XXPPTP123456789",
+                                      processingDate =
+                                        ZonedDateTime.now(ZoneOffset.UTC),
+                                      formBundleNumber = "123456789",
+                                      nrsNotifiedSuccessfully = true,
+                                      nrsSubmissionId = Some(nrsSubmissionId),
+                                      nrsFailureReason = None,
+                                      enrolmentInitiatedSuccessfully = true
+    )
 
   protected val emailVerification: VerificationStatus = VerificationStatus(
     Seq(EmailStatus(emailAddress = "test@hmrc.com", verified = true, locked = false))

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetailsSpec.scala
@@ -100,6 +100,21 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers with TableDriven
         ).businessPartnerIdPresent() mustBe false
       }
     }
+
+    "report business name" when {
+      "incorporated business" in {
+        val corp = createOrg(UK_COMPANY, None, true)
+        corp.businessName mustBe Some(corp.incorporationDetails.get.companyName)
+      }
+
+      "sole trader" in {
+        val soleTrader        = createOrg(SOLE_TRADER, None, true)
+        val soleTraderDetails = soleTrader.soleTraderDetails.get
+        soleTrader.businessName mustBe Some(
+          s"${soleTraderDetails.firstName} ${soleTraderDetails.lastName}"
+        )
+      }
+    }
   }
 
   private def createOrg(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/subscriptions/SubscriptionCreateResponseSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/subscriptions/SubscriptionCreateResponseSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions
+
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class SubscriptionCreateResponseSpec extends AnyWordSpecLike with TableDrivenPropertyChecks {
+
+  "EisError" should {
+    "identify duplicate subscription errors" in {
+      val duplicateSubscriptionErrorCodes = Table("Error code",
+                                                  "ACTIVE_SUBSCRIPTION_EXISTS",
+                                                  "BUSINESS_VALIDATION",
+                                                  "ACTIVE_GROUP_SUBSCRIPTION_EXISTS",
+                                                  "CANNOT_CREATE_PARTNERSHIP_SUBSCRIPTION"
+      )
+
+      forAll(duplicateSubscriptionErrorCodes) { errorCode =>
+        EisError(errorCode, "xxx").isDuplicateSubscription mustBe true
+      }
+    }
+    "identify non duplicate subscription errors" in {
+      val nonDuplicateSubscriptionErrorCodes =
+        Table("Error code", "INVALID_REGIME", "INVALID_SAFEID")
+
+      forAll(nonDuplicateSubscriptionErrorCodes) { errorCode =>
+        EisError(errorCode, "xxx").isDuplicateSubscription mustBe false
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/DuplicateSubscriptionViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/DuplicateSubscriptionViewSpec.scala
@@ -31,6 +31,20 @@ class DuplicateSubscriptionViewSpec extends UnitViewSpec with Matchers {
   private val page: duplicate_subscription_page =
     instanceOf[duplicate_subscription_page]
 
+  private def pageParagraphMessageKeys =
+    List("duplicateSubscription.detail",
+         "pptHelpline.intro",
+         "pptHelpline.telephone.title",
+         "pptHelpline.telephone.detail",
+         "pptHelpline.textphone.title",
+         "pptHelpline.textphone.detail",
+         "pptHelpline.telephone.outsideUK.title",
+         "pptHelpline.telephone.outsideUK.detail",
+         "pptHelpline.openingTimes.title",
+         "pptHelpline.openingTimes.detail.1",
+         "pptHelpline.openingTimes.detail.2"
+    )
+
   private def createView(): Html = page(Some("Plastic Packaging Ltd"))(journeyRequest, messages)
 
   "Duplicate Subscription Page" should {
@@ -38,7 +52,10 @@ class DuplicateSubscriptionViewSpec extends UnitViewSpec with Matchers {
     "have proper messages for labels" in {
       messages must haveTranslationFor("duplicateSubscription.title")
       messages must haveTranslationFor("duplicateSubscription.heading")
-      messages must haveTranslationFor("duplicateSubscription.detail")
+
+      pageParagraphMessageKeys.foreach { messageKey =>
+        messages must haveTranslationFor(messageKey)
+      }
     }
 
     val view: Html = createView()
@@ -53,8 +70,19 @@ class DuplicateSubscriptionViewSpec extends UnitViewSpec with Matchers {
 
     "display detail" in {
       view.select("p.govuk-body").text() must include(
-        messages("duplicateSubscription.detail", "Plastic Packaging Ltd")
+        messages(pageParagraphMessageKeys.head, "Plastic Packaging Ltd")
       )
+    }
+
+    "display ppt helpline detail" in {
+      pageParagraphMessageKeys.tail.foreach { messageKey =>
+        view.select("p.govuk-body").text must include(messages(messageKey))
+      }
+    }
+
+    "validate other rendering methods" in {
+      page.f(Some("Test Company"))(journeyRequest, messages)
+      page.render(Some("Test Company"), journeyRequest, messages)
     }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/DuplicateSubscriptionViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/DuplicateSubscriptionViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views
+
+import base.unit.UnitViewSpec
+import org.scalatest.matchers.must.Matchers
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
+  business_registration_failure_page,
+  duplicate_subscription_page
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class DuplicateSubscriptionViewSpec extends UnitViewSpec with Matchers {
+
+  private val page: duplicate_subscription_page =
+    instanceOf[duplicate_subscription_page]
+
+  private def createView(): Html = page(Some("Plastic Packaging Ltd"))(journeyRequest, messages)
+
+  "Duplicate Subscription Page" should {
+
+    "have proper messages for labels" in {
+      messages must haveTranslationFor("duplicateSubscription.title")
+      messages must haveTranslationFor("duplicateSubscription.heading")
+      messages must haveTranslationFor("duplicateSubscription.detail")
+    }
+
+    val view: Html = createView()
+
+    "display title" in {
+      view.select("title").text() must include(messages("duplicateSubscription.title"))
+    }
+
+    "display heading" in {
+      view.select("h1").text() must include(messages("duplicateSubscription.heading"))
+    }
+
+    "display detail" in {
+      view.select("p.govuk-body").text() must include(
+        messages("duplicateSubscription.detail", "Plastic Packaging Ltd")
+      )
+    }
+  }
+}


### PR DESCRIPTION
We need to inform the user of duplicate subscription failures when we attempt to create the PPT subscription. The back end now communicates EIS subscription failure responses so that we can spot failures due to duplicate subscriptions.

Associated BE change: https://github.com/hmrc/plastic-packaging-tax-registration/pull/55

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
