### PR TITLE
PPTP-1204 - allow enrolled user to access confirmation page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationController.scala
@@ -19,15 +19,13 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
-import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAllowEnrolmentAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.confirmation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 @Singleton
 class ConfirmationController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
+  authenticate: AuthAllowEnrolmentAction,
   mcc: MessagesControllerComponents,
   page: confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationController.scala
@@ -19,13 +19,13 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAllowEnrolmentAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.confirmation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 @Singleton
 class ConfirmationController @Inject() (
-  authenticate: AuthAllowEnrolmentAction,
+  authenticate: AuthNoEnrolmentCheckAction,
   mcc: MessagesControllerComponents,
   page: confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/SignOutController.scala
@@ -20,7 +20,7 @@ import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAllowEnrolmentAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.session_timed_out
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import scala.concurrent.Future
 
 class SignOutController @Inject() (
-  authenticate: AuthAllowEnrolmentAction,
+  authenticate: AuthNoEnrolmentCheckAction,
   appConfig: AppConfig,
   sessionTimedOut: session_timed_out,
   mcc: MessagesControllerComponents

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/SignOutController.scala
@@ -16,19 +16,19 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
+import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAllowEnrolmentAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.session_timed_out
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-import javax.inject.Inject
 import scala.concurrent.Future
 
 class SignOutController @Inject() (
-  authenticate: AuthAction,
+  authenticate: AuthAllowEnrolmentAction,
   appConfig: AppConfig,
   sessionTimedOut: session_timed_out,
   mcc: MessagesControllerComponents

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -45,14 +45,14 @@ class AuthActionImpl @Inject() (
   override val checkAlreadyEnrolled: Boolean = true
 }
 
-class AuthAllowEnrolmentActionImpl @Inject() (
+class AuthNoEnrolmentCheckActionImpl @Inject() (
   override val authConnector: AuthConnector,
   allowedUsers: AllowedUsers,
   metrics: Metrics,
   mcc: MessagesControllerComponents,
   appConfig: AppConfig
 ) extends AuthActionBase(authConnector, allowedUsers, metrics, mcc, appConfig)
-    with AuthAllowEnrolmentAction {
+    with AuthNoEnrolmentCheckAction {
   override val checkAlreadyEnrolled: Boolean = false
 }
 
@@ -153,7 +153,7 @@ trait AuthAction
     extends ActionBuilder[AuthenticatedRequest, AnyContent]
     with ActionFunction[Request, AuthenticatedRequest]
 
-@ImplementedBy(classOf[AuthAllowEnrolmentActionImpl])
-trait AuthAllowEnrolmentAction
+@ImplementedBy(classOf[AuthNoEnrolmentCheckActionImpl])
+trait AuthNoEnrolmentCheckAction
     extends ActionBuilder[AuthenticatedRequest, AnyContent]
     with ActionFunction[Request, AuthenticatedRequest]

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
   AllowedUsers,
   AuthActionImpl,
-  AuthAllowEnrolmentActionImpl
+  AuthNoEnrolmentCheckActionImpl
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 
@@ -50,7 +50,7 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
                                           appConfig
   )
 
-  val mockAuthAllowEnrolmentAction = new AuthAllowEnrolmentActionImpl(
+  val mockAuthAllowEnrolmentAction = new AuthNoEnrolmentCheckActionImpl(
     mockAuthConnector,
     new AllowedUsers(Seq.empty),
     metricsMock,

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -31,7 +31,8 @@ import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
   AllowedUsers,
-  AuthActionImpl
+  AuthActionImpl,
+  AuthAllowEnrolmentActionImpl
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 
@@ -47,6 +48,14 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
                                           metricsMock,
                                           stubMessagesControllerComponents(),
                                           appConfig
+  )
+
+  val mockAuthAllowEnrolmentAction = new AuthAllowEnrolmentActionImpl(
+    mockAuthConnector,
+    new AllowedUsers(Seq.empty),
+    metricsMock,
+    stubMessagesControllerComponents(),
+    appConfig
   )
 
   val nrsGroupIdentifierValue = Some("groupIdentifierValue")

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
+import base.PptTestData
 import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito.`given`
@@ -24,6 +25,7 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.OK
 import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.confirmation_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -32,11 +34,7 @@ class ConfirmationControllerSpec extends ControllerSpec {
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new ConfirmationController(authenticate = mockAuthAction,
-                               mockJourneyAction,
-                               mcc = mcc,
-                               page = page
-    )
+    new ConfirmationController(authenticate = mockAuthAllowEnrolmentAction, mcc = mcc, page = page)
 
   private val registration = aRegistration()
 
@@ -58,11 +56,24 @@ class ConfirmationControllerSpec extends ControllerSpec {
 
       "user is authorised and display page method is invoked" in {
         authorizedUser()
+
         mockRegistrationUpdate(aRegistration())
         val result = controller.displayPage()(getRequest())
 
         status(result) mustBe OK
       }
+
+      "user is already enrolled and display page method is invoked" in {
+        val user =
+          PptTestData.newUser().copy(enrolments = Enrolments(Set(Enrolment("HMRC-PPT-ORG"))))
+        authorizedUser(user)
+
+        mockRegistrationUpdate(aRegistration())
+        val result = controller.displayPage()(getRequest())
+
+        status(result) mustBe OK
+      }
+
     }
 
     "return an error" when {


### PR DESCRIPTION
- solves the potential race condition where subscription request completes before confirmation page is displayed
- creates a second version of AuthAction which does not check enrolments


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
