### PR TITLE
BAU - use validating message api for tests

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/inputText.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/inputText.scala.html
@@ -25,12 +25,13 @@
 )(implicit messages: Messages)
 
 @inputTextLabel = @{
+    val label = if(labelKey.isEmpty) "" else messages(labelKey)
     if(labelHiddenKey.isDefined) {
         Label(content = HtmlContent(Html(
-            s"""${messages(labelKey)}<span class="govuk-visually-hidden">${labelHiddenKey.map(messages(_)).getOrElse("")}</span>""")
+            s"""$label<span class="govuk-visually-hidden">${labelHiddenKey.map(messages(_)).getOrElse("")}</span>""")
         ), classes = labelClasses)
     } else {
-        Label(content = Text(messages(labelKey)), classes = labelClasses)
+        Label(content = Text(label), classes = labelClasses)
     }
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
@@ -221,6 +221,6 @@
     <h2 id="send-your-application" class="govuk-heading-m">@messages("reviewRegistration.sendYourApplication.title")</h2>
     @paragraphBody(messages("reviewRegistration.sendYourApplication.body"))
 
-    @saveAndContinue(messages("site.button.acceptAndSend"))
+    @saveAndContinue("site.button.acceptAndSend")
     }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ConfirmOrganisationBasedInUkViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ConfirmOrganisationBasedInUkViewSpec.scala
@@ -110,9 +110,10 @@ class ConfirmOrganisationBasedInUkViewSpec extends UnitViewSpec with Matchers {
 
         val form = ConfirmOrganisationBasedInUk
           .form()
-          .fillAndValidate(ConfirmOrganisationBasedInUk(None))
+          .bind(emptyFormData)
         val view = createView(form)
 
+        view must haveGovukFieldError("answer", "This field is required")
         view must haveGovukGlobalErrorSummary
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityExpectToExceedThresholdWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityExpectToExceedThresholdWeightViewSpec.scala
@@ -132,9 +132,10 @@ class LiabilityExpectToExceedThresholdWeightViewSpec extends UnitViewSpec with M
       "no radio button checked" in {
 
         val form = ExpectToExceedThresholdWeight.form()
-          .fillAndValidate(ExpectToExceedThresholdWeight(None))
+          .bind(emptyFormData)
         val view = createView(form)
 
+        view must haveGovukFieldError("answer", "This field is required")
         view must haveGovukGlobalErrorSummary
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityLiableDateViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/LiabilityLiableDateViewSpec.scala
@@ -126,9 +126,10 @@ class LiabilityLiableDateViewSpec extends UnitViewSpec with Matchers {
       "no radio button checked" in {
 
         val form = LiabilityLiableDate.form()
-          .fillAndValidate(LiabilityLiableDate(None))
+          .bind(emptyFormData)
         val view = createView(form)
 
+        view must haveGovukFieldError("answer", "This field is required")
         view must haveGovukGlobalErrorSummary
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/OrganisationDetailsTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/OrganisationDetailsTypeViewSpec.scala
@@ -122,9 +122,10 @@ class OrganisationDetailsTypeViewSpec extends UnitViewSpec with Matchers {
 
         val form = OrganisationType
           .form()
-          .fillAndValidate(OrganisationType(""))
+          .bind(emptyFormData)
         val view = createView(form)
 
+        view must haveGovukFieldError("answer", "This field is required")
         view must haveGovukGlobalErrorSummary
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/PartnershipTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/PartnershipTypeViewSpec.scala
@@ -130,9 +130,10 @@ class PartnershipTypeViewSpec extends UnitViewSpec with Matchers {
 
         val form = PartnershipType
           .form()
-          .fillAndValidate(PartnershipType(""))
+          .bind(emptyFormData)
         val view = createView(form)
 
+        view must haveGovukFieldError("answer", "This field is required")
         view must haveGovukGlobalErrorSummary
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/model/TitleSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/model/TitleSpec.scala
@@ -26,16 +26,14 @@ class TitleSpec extends UnitViewSpec with Matchers {
   "Title" should {
 
     "format title without section" in {
-      Title("declaration.declarationType.title").toString(messages) must equal(
-        s"${messages("declaration.declarationType.title")} - $serviceName - GOV.UK"
+      Title("notLiable.pageTitle").toString(messages) must equal(
+        s"${messages("notLiable.pageTitle")} - $serviceName - GOV.UK"
       )
     }
 
     "format title with section" in {
-      Title("declaration.declarationType.title",
-            "declaration.declarationType.header.supplementary"
-      ).toString(messages) must equal(
-        s"${messages("declaration.declarationType.title")} - ${messages("declaration.declarationType.header.supplementary")} - $serviceName - GOV.UK"
+      Title("startPage.title", "startPage.title.sectionHeader").toString(messages) must equal(
+        s"${messages("startPage.title")} - ${messages("startPage.title.sectionHeader")} - $serviceName - GOV.UK"
       )
     }
   }


### PR DESCRIPTION

The `AllMessageKeysAreMandatoryMessages` version of the message api will fail if there is an attempt to translate a message that does not exist in the messages.en file.   Therefore all you need to do it render a view and you don't need tests like this 
```
    "have proper messages for labels" in {
      messages must haveTranslationFor("organisationDetails.sectionHeader")
      messages must haveTranslationFor("organisationDetails.basedInUk.title")
      messages must haveTranslationFor("organisationDetails.basedInUk.empty.error")
    }
```

In addition, it will detect when a message has been "double translated".   E.g. when a component expects a message key but has been provided with a translated message by the view resulting in the following code - `message(message(key))`
