### PR TITLE
BAU : Disable the JUnit XML report plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,8 @@ lazy val microservice = Project(appName, file("."))
   .settings(scoverageSettings)
   .settings(silencerSettings)
 
+  .disablePlugins(sbt.plugins.JUnitXmlReportPlugin)
+
 lazy val scoverageSettings: Seq[Setting[_]] = Seq(
   coverageExcludedPackages := List(
     "<empty>",


### PR DESCRIPTION
There is a known issue where JUnit reporters can mangle test output files when jobs are run in parallel.
