### PR TITLE
BAU BAU removed unused safe id in domain object so only registeredBusinessPartnerId is used

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/IncorpIdController.scala
@@ -69,7 +69,7 @@ class IncorpIdController @Inject() (
           case Right(registration) =>
             if (registration.organisationDetails.businessVerificationFailed)
               Ok(business_verification_failure_page())
-            else if (registration.organisationDetails.businessPartnerIdPresent())
+            else if (registration.organisationDetails.businessPartnerId().isDefined)
               Redirect(routes.RegistrationController.displayPage())
             else
               Ok(business_registration_failure_page())

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationController.scala
@@ -39,7 +39,7 @@ class RegistrationController @Inject() (
 
   def displayPage(): Action[AnyContent] =
     (authenticate andThen journeyAction).async { implicit request =>
-      request.registration.organisationDetails.safeNumber match {
+      request.registration.organisationDetails.businessPartnerId() match {
         case Some(safeNumber) =>
           for {
             subscriptionStatus <- subscriptionsConnector.getSubscriptionStatus(safeNumber)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
@@ -58,11 +58,11 @@ case class OrganisationDetails(
   def businessPartnerId(): Option[String] =
     organisationType match {
       case Some(UK_COMPANY) =>
-        incorporationDetails.fold[Option[String]](None)(_.registration.registeredBusinessPartnerId)
+        incorporationDetails.flatMap(details => details.registration.registeredBusinessPartnerId)
       case Some(SOLE_TRADER) =>
-        soleTraderDetails.fold[Option[String]](None)(_.registration.registeredBusinessPartnerId)
+        soleTraderDetails.flatMap(details => details.registration.registeredBusinessPartnerId)
       case Some(PARTNERSHIP) =>
-        partnershipDetails.fold[Option[String]](None) { pd =>
+        partnershipDetails.flatMap { pd =>
           pd.partnershipType match {
             case GENERAL_PARTNERSHIP =>
               partnershipDetails.get.generalPartnershipDetails.get.registration.registeredBusinessPartnerId

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
@@ -39,7 +39,6 @@ case class OrganisationDetails(
   isBasedInUk: Option[Boolean] = None,
   organisationType: Option[OrgType] = None,
   businessRegisteredAddress: Option[Address] = None,
-  safeNumber: Option[String] = None,
   soleTraderDetails: Option[SoleTraderIncorporationDetails] = None,
   incorporationDetails: Option[IncorporationDetails] = None,
   partnershipDetails: Option[PartnershipDetails] = None
@@ -47,7 +46,7 @@ case class OrganisationDetails(
 
   def status: TaskStatus =
     if (isBasedInUk.isEmpty) TaskStatus.NotStarted
-    else if (businessPartnerIdPresent()) TaskStatus.Completed
+    else if (businessPartnerId().isDefined) TaskStatus.Completed
     else TaskStatus.InProgress
 
   val businessVerificationFailed: Boolean =
@@ -56,21 +55,23 @@ case class OrganisationDetails(
         details.registration.registrationStatus == "REGISTRATION_NOT_CALLED" && details.businessVerificationStatus == "FAIL"
     )
 
-  def businessPartnerIdPresent(): Boolean =
+  def businessPartnerId(): Option[String] =
     organisationType match {
       case Some(UK_COMPANY) =>
-        incorporationDetails.exists(_.registration.registeredBusinessPartnerId.isDefined)
+        incorporationDetails.fold[Option[String]](None)(_.registration.registeredBusinessPartnerId)
       case Some(SOLE_TRADER) =>
-        soleTraderDetails.exists(_.registration.registeredBusinessPartnerId.isDefined)
+        soleTraderDetails.fold[Option[String]](None)(_.registration.registeredBusinessPartnerId)
       case Some(PARTNERSHIP) =>
-        partnershipDetails.exists(_.partnershipType match {
-          case GENERAL_PARTNERSHIP =>
-            partnershipDetails.get.generalPartnershipDetails.get.registration.registeredBusinessPartnerId.isDefined
-          case SCOTTISH_PARTNERSHIP =>
-            partnershipDetails.get.scottishPartnershipDetails.get.registration.registeredBusinessPartnerId.isDefined
-          case _ => false
-        })
-      case _ => false
+        partnershipDetails.fold[Option[String]](None) { pd =>
+          pd.partnershipType match {
+            case GENERAL_PARTNERSHIP =>
+              partnershipDetails.get.generalPartnershipDetails.get.registration.registeredBusinessPartnerId
+            case SCOTTISH_PARTNERSHIP =>
+              partnershipDetails.get.scottishPartnershipDetails.get.registration.registeredBusinessPartnerId
+            case _ => None
+          }
+        }
+      case _ => None
     }
 
 }

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -218,7 +218,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(UK_COMPANY),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = Some(safeNumber),
                         incorporationDetails = Some(incorporationDetails)
     )
 
@@ -226,7 +225,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(SOLE_TRADER),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = Some(safeNumber),
                         soleTraderDetails = Some(soleTraderIncorporationDetails)
     )
 
@@ -234,7 +232,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(PARTNERSHIP),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = Some(safeNumber),
                         partnershipDetails = Some(partnershipDetails)
     )
 
@@ -242,7 +239,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(PARTNERSHIP),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = Some(safeNumber),
                         partnershipDetails = Some(partnershipDetailsWithScottishPartnership)
     )
 
@@ -250,7 +246,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(UK_COMPANY),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = None,
                         incorporationDetails = Some(unregisteredIncorporationDetails)
     )
 
@@ -258,7 +253,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(SOLE_TRADER),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = None,
                         soleTraderDetails = Some(unregisteredSoleTraderDetails)
     )
 
@@ -274,7 +268,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     OrganisationDetails(isBasedInUk = Some(true),
                         organisationType = Some(UK_COMPANY),
                         businessRegisteredAddress = Some(testBusinessAddress),
-                        safeNumber = Some(safeNumber),
                         incorporationDetails = Some(verificationFailedIncorporationDetails)
     )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetailsSpec.scala
@@ -75,13 +75,13 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers with TableDriven
 
     "identify that business partner id is present" in {
       forAll(registeredOrgs) { organisationDetails =>
-        organisationDetails.businessPartnerIdPresent() mustBe true
+        organisationDetails.businessPartnerId() mustBe Some("XP001")
       }
     }
 
     "identify that business partner id is absent" in {
       forAll(unregisteredOrgs) { organisationDetails =>
-        organisationDetails.businessPartnerIdPresent() mustBe false
+        organisationDetails.businessPartnerId() mustBe None
       }
     }
 
@@ -89,7 +89,7 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers with TableDriven
       "organisation type is unsupported" in {
         OrganisationDetails(organisationType =
           Some(CHARITY_OR_NOT_FOR_PROFIT)
-        ).businessPartnerIdPresent() mustBe false
+        ).businessPartnerId() mustBe None
       }
 
       "partnership type is unsupported" in {
@@ -97,7 +97,7 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers with TableDriven
                             partnershipDetails = Some(
                               PartnershipDetails(partnershipType = LIMITED_LIABILITY_PARTNERSHIP)
                             )
-        ).businessPartnerIdPresent() mustBe false
+        ).businessPartnerId() mustBe None
       }
     }
   }


### PR DESCRIPTION
Two safeIds are modelled in the Organisation domain object. Removed `safeNumber` at the top level and used the embedded registeredBusinessPartnerId for checks on whether a safeId is present or not