### PR TITLE
PPTP-1211 - Handle check sub status - Already subscribed

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/RegistrationController.scala
@@ -22,7 +22,11 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.SubscriptionsConnector
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.registration_page
+import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.ETMPSubscriptionStatus.SUCCESSFUL
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
+  duplicate_subscription_page,
+  registration_page
+}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -32,7 +36,8 @@ class RegistrationController @Inject() (
   authenticate: AuthAction,
   journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
-  registration_page: registration_page,
+  registrationPage: registration_page,
+  duplicateSubscriptionPage: duplicate_subscription_page,
   subscriptionsConnector: SubscriptionsConnector
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
@@ -44,9 +49,11 @@ class RegistrationController @Inject() (
           for {
             subscriptionStatus <- subscriptionsConnector.getSubscriptionStatus(safeNumber)
           } yield subscriptionStatus.subscriptionStatus match {
-            case _ => Ok(registration_page(request.registration))
+            case SUCCESSFUL =>
+              Ok(duplicateSubscriptionPage(request.registration.organisationDetails.businessName))
+            case _ => Ok(registrationPage(request.registration))
           }
-        case None => Future.successful(Ok(registration_page(request.registration)))
+        case None => Future.successful(Ok(registrationPage(request.registration)))
       }
     }
 


### PR DESCRIPTION
### Description of Work carried through

If subscription status is "SUCCESSFUL" then display the existing "Your organisation is already registered" page.

![image](https://user-images.githubusercontent.com/46934286/135047240-ef5856fe-8398-4808-8389-77e3dcc696dd.png)


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
