### PR TITLE
PPTP-1223 Fixed validation rules for email address and postcode

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/Address.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/Address.scala
@@ -37,7 +37,8 @@ object Address extends CommonFormValidators {
 
   private val validatePostcode: Int => String => Boolean =
     (length: Int) =>
-      (input: String) => isNotExceedingMaxLength(input, length) && isValidPostcode(input)
+      (input: String) =>
+        isNotExceedingMaxLength(input, length) && isValidPostcode(input.toUpperCase)
 
   private val addressFieldMaxSize = 35
 
@@ -63,6 +64,7 @@ object Address extends CommonFormValidators {
       .verifying(emptyError(townOrCity), isNonEmpty)
       .verifying(notValidError(townOrCity), validateAddressField(addressFieldMaxSize)),
     postCode -> text()
+      .transform[String](postCode => postCode.toUpperCase, postCode => postCode)
       .verifying(emptyError(postCode), isNonEmpty)
       .verifying(notValidError(postCode), validatePostcode(10))
   )(Address.apply)(Address.unapply)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/EmailAddress.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/EmailAddress.scala
@@ -31,7 +31,7 @@ object EmailAddress {
   lazy val emailAddressEmptyError            = "primaryContactDetails.emailAddress.empty.error"
   lazy val emailAddressFormatError           = "primaryContactDetails.emailAddress.format.error"
 
-  val maxLength    = 241
+  val maxLength    = 132
   val emailAddress = "value"
 
   private val mapping = Forms.mapping(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/AddressSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/AddressSpec.scala
@@ -56,6 +56,17 @@ class AddressSpec extends AnyWordSpec with Matchers with CommonTestUtils {
         val form = Address.form().bind(input)
         form.errors.size mustBe 0
       }
+
+      "address mandatory fields with lower case post code are valid " in {
+
+        val input = Map(addressLine1 -> "Address Line 1 .'-&",
+                        townOrCity -> "Town or City .'-&",
+                        postCode   -> "ls4 1rh"
+        )
+
+        val form = Address.form().bind(input)
+        form.errors.size mustBe 0
+      }
     }
 
     "return errors" when {
@@ -87,6 +98,20 @@ class AddressSpec extends AnyWordSpec with Matchers with CommonTestUtils {
               FormError(townOrCity, "primaryContactDetails.address.townOrCity.format.error"),
               FormError(postCode, "primaryContactDetails.address.postCode.format.error")
           )
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
+
+      "contains invalid postcode" in {
+
+        val input = Map(addressLine1 -> "Address Line 1",
+                        addressLine2 -> "Address Line 2",
+                        addressLine3 -> "Address Line 3",
+                        townOrCity   -> "Town ",
+                        postCode     -> "LSA41RH"
+        )
+        val expectedErrors =
+          Seq(FormError(postCode, "primaryContactDetails.address.postCode.format.error"))
 
         testFailedValidationErrors(input, expectedErrors)
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/CommonFormValidatorsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/CommonFormValidatorsSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.forms
 
 import base.unit.CommonTestUtils
+import org.scalatest.Inspectors.forAll
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -130,6 +131,31 @@ class CommonFormValidatorsSpec
       "is not valid postcode" in {
 
         isValidPostcode("LS5 7THHHHH") must be(false)
+      }
+    }
+
+    forAll(
+      Seq("AA9A 9AA",
+          "A9A 9AA",
+          "A9 9AA",
+          "A99 9AA",
+          "AA99AA",
+          "aa9a 9aa",
+          "a9a 9aa",
+          "a9 9aa",
+          "a99 9aa",
+          "aa9 9aa",
+          "aa9a9aa",
+          "a9a9aa",
+          "a99aa",
+          "a999aa",
+          "aa99aa"
+      )
+    ) { postcode =>
+      "return true for " + postcode when {
+        "valid" in {
+          isValidPostcode(postcode.toUpperCase) must be(true)
+        }
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/EmailAddressSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/EmailAddressSpec.scala
@@ -65,6 +65,16 @@ class EmailAddressSpec extends AnyWordSpec with Matchers with CommonTestUtils {
 
         testFailedValidationErrors(input, expectedErrors)
       }
+
+      "exceeds the max length" in {
+
+        val input = Map(
+          emailAddress -> "aasdasdfsdaadsdfsfklgjfdlgjdflgdfjkndflfgjflgjfdlgjdfkgdfkghflkghslkgjhighkdngkngflgdioldlndndkgndfjkgkgdfgkdfgkdhgkdhgkdhgdfkgh@test.com"
+        )
+        val expectedErrors = Seq(FormError(emailAddress, emailAddressFormatError))
+
+        testFailedValidationErrors(input, expectedErrors)
+      }
     }
   }
 


### PR DESCRIPTION
### Description of Work carried through

- Postcode now converted to uppercase before validation
- Email address max length reduced from 241 to 132

Brief description of what/why/how.

#### Check list 
 - [X] `./precheck` was executed (Integration/Component/Unit tests)
 - [X] `sbt scalafmt test:scalafmt` was executed
 - [X] User Acceptance Tests (UAT) were run locally and have passed.
