### PR TITLE
PPTP-1155 : Discrete error page URL for subscription failures

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandler.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.config
 
 import javax.inject.{Inject, Singleton}
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.Request
 import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_template
@@ -31,5 +31,20 @@ class ErrorHandler @Inject() (error_template: error_template, val messagesApi: M
     request: Request[_]
   ): Html =
     error_template(pageTitle, heading, List(message))
+
+  override def badRequestTemplate(implicit request: Request[_]): Html          = pptErrorTemplate()
+  override def notFoundTemplate(implicit request: Request[_]): Html            = pptErrorTemplate()
+  override def internalServerErrorTemplate(implicit request: Request[_]): Html = pptErrorTemplate()
+
+  private def pptErrorTemplate()(implicit request: Request[_]) =
+    customisedErrorTemplate(Messages("error.title"),
+                            Messages("error.title"),
+                            List(Messages("error.detail1"), Messages("error.detail2"))
+    )
+
+  private def customisedErrorTemplate(pageTitle: String, heading: String, messages: List[String])(
+    implicit request: Request[_]
+  ): Html =
+    error_template(pageTitle, heading, messages)
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/ErrorHandler.scala
@@ -30,6 +30,6 @@ class ErrorHandler @Inject() (error_template: error_template, val messagesApi: M
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(implicit
     request: Request[_]
   ): Html =
-    error_template(pageTitle, heading, message)
+    error_template(pageTitle, heading, List(message))
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorController.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_page
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class NotableErrorController @Inject() (mcc: MessagesControllerComponents, errorPage: error_page)
+    extends FrontendController(mcc) with I18nSupport {
+
+  def subscriptionFailure(): Action[AnyContent] =
+    Action { implicit request =>
+      Ok(errorPage())
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -138,7 +138,7 @@ class ReviewRegistrationController @Inject() (
             handleFailedSubscription(completedRegistration, failures)
         }
         .recoverWith {
-          case e: Throwable => Future.failed(handleFailedSubscription(completedRegistration, e))
+          case _ => Future.successful(handleFailedSubscription(completedRegistration))
         }
     }
 
@@ -170,19 +170,15 @@ class ReviewRegistrationController @Inject() (
     performFailedSubscriptionCommonTasks(registration)
     if (failures.head.isDuplicateSubscription)
       Ok(duplicateSubscriptionPage(registration.organisationDetails.businessName))
-    else {
-      val error = new IllegalStateException(
-        s"PPT subscription already exists for ${registration.organisationDetails.businessName}"
-      )
-      throw DownstreamServiceError(s"PPT subscription failed - ${error.getMessage}", error)
-    }
+    else
+      Redirect(routes.NotableErrorController.subscriptionFailure())
   }
 
-  private def handleFailedSubscription(registration: Registration, e: Throwable)(implicit
-    hc: HeaderCarrier
-  ): DownstreamServiceError = {
+  private def handleFailedSubscription(
+    registration: Registration
+  )(implicit hc: HeaderCarrier): Result = {
     performFailedSubscriptionCommonTasks(registration)
-    DownstreamServiceError(s"PPT subscription failed - ${e.getMessage}", e)
+    Redirect(routes.NotableErrorController.subscriptionFailure())
   }
 
   private def performFailedSubscriptionCommonTasks(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/error_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/error_page.scala.html
@@ -14,20 +14,19 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_template
 
-@this(govukLayout: main_template)
+@this(
+    errorTemplate: error_template
+)
 
-@(pageTitle: String, heading: String, messageFragments: List[String])(implicit request: Request[_], messages: Messages)
+@()(implicit request: Request[_], messages: Messages)
 
-@govukLayout(title = Title(pageTitle)) {
- <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-   <h1 class="govuk-heading-l" >@heading</h1>
-   @for(fragment <- messageFragments) {
-    <p class="govuk-body">@fragment</p>
-   }
-  </div>
- </div>
-}
+@errorTemplate(
+    pageTitle = "error.title",
+    heading = messages("error.title"),
+    messageFragments = List(
+        messages("error.detail1"),
+        messages("error.detail2")
+    )
+)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -71,6 +71,7 @@ GET        /review-registration     uk.gov.hmrc.plasticpackagingtax.registration
 POST       /review-registration     uk.gov.hmrc.plasticpackagingtax.registration.controllers.ReviewRegistrationController.submit()
 
 GET        /registration-submitted  uk.gov.hmrc.plasticpackagingtax.registration.controllers.ConfirmationController.displayPage()
+GET        /registration-failed     uk.gov.hmrc.plasticpackagingtax.registration.controllers.NotableErrorController.subscriptionFailure()
 
 GET        /sign-out                uk.gov.hmrc.plasticpackagingtax.registration.controllers.SignOutController.signOut(signOutReason: uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason)
 GET        /we-sign-you-out         uk.gov.hmrc.plasticpackagingtax.registration.controllers.SignOutController.sessionTimeoutSignedOut()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -33,6 +33,10 @@ date.month = Month
 date.year = Year
 date.empty.error = Error: {0} cannot be empty
 
+error.title = Sorry, there is a problem with the service
+error.detail1 = Try again later.
+error.detail2 = We saved your answers. They will be available for 30 days.
+
 startPage.title.sectionHeader = Guidance
 startPage.meta.title = Start a Plastic Packaging Tax registration
 startPage.title = Plastic Packaging Tax Service

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorControllerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers
+
+import base.unit.ControllerSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status.OK
+import play.api.test.Helpers.{contentAsString, status}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.error_page
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class NotableErrorControllerSpec extends ControllerSpec {
+
+  private val page = mock[error_page]
+  private val mcc  = stubMessagesControllerComponents()
+
+  private val controller =
+    new NotableErrorController(mcc = mcc, errorPage = page)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(page.apply()(any(), any())).thenReturn(HtmlFormat.raw("error page content"))
+  }
+
+  "NotableErrorController" should {
+    "present the generic error page on subscription failure" in {
+      val resp = controller.subscriptionFailure()(getRequest())
+
+      status(resp) mustBe OK
+      contentAsString(resp) mustBe "error page content"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationControllerSpec.scala
@@ -29,7 +29,6 @@ import play.api.libs.json.JsObject
 import play.api.test.Helpers.{await, redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
   PARTNERSHIP,
   SOLE_TRADER,
@@ -323,6 +322,9 @@ class ReviewRegistrationControllerSpec extends ControllerSpec with TableDrivenPr
 
         intercept[RuntimeException](status(result))
       }
+    }
+
+    "redirect to the error page" when {
 
       "user submits form and the submission fails with an exception" in {
         authorizedUser()
@@ -331,7 +333,11 @@ class ReviewRegistrationControllerSpec extends ControllerSpec with TableDrivenPr
         val result =
           controller.submit()(postRequest(JsObject.empty))
 
-        intercept[DownstreamServiceError](status(result))
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(
+          routes.NotableErrorController.subscriptionFailure().url
+        )
+
         metricsMock.defaultRegistry.counter(
           "ppt.registration.failed.submission.counter"
         ).getCount mustBe 1
@@ -353,7 +359,10 @@ class ReviewRegistrationControllerSpec extends ControllerSpec with TableDrivenPr
 
         val result = controller.submit()(postRequest(JsObject.empty))
 
-        intercept[DownstreamServiceError](status(result))
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(
+          routes.NotableErrorController.subscriptionFailure().url
+        )
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ErrorPageSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ErrorPageSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{error_page}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class ErrorPageSpec extends UnitViewSpec with Matchers {
+
+  private val page = instanceOf[error_page]
+
+  private def createView(): Document =
+    page()(journeyRequest, messages)
+
+  "Error page" should {
+
+    "have required messages" in {
+      messages must haveTranslationFor("error.title")
+      messages must haveTranslationFor("error.detail1")
+      messages must haveTranslationFor("error.detail2")
+    }
+
+    val view = createView()
+
+    "contain title" in {
+      view.select("title").text() must include(messages("error.title"))
+    }
+
+    "contain heading" in {
+      view.select("h1").text() mustBe messages("error.title")
+    }
+
+    "contain detail" in {
+      val detail = view.select("p").text()
+      detail must include(messages("error.detail1"))
+      detail must include(messages("error.detail2"))
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods() = {
+    page.f()(request, messages)
+    page.render(request, messages)
+  }
+
+}


### PR DESCRIPTION
I think our generic error page content might now have subtly diverged from that of this new discrete subscription failed error page. We might want to work out how we can align these in a future piece of work.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added - N/A
 - [x] Links to dependencies have been included (BE/FE work) - N/A
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
