### PR TITLE
PPTP-1148 : Email passcode and confirmation page refactor

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/continue.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/continue.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.Continue
+
+@this(govukButton: GovukButton)
+
+@(messageKey: String = "site.button.continue")(implicit messages: Messages)
+
+@govukButton(Button(
+    content = Text(messages(messageKey)),
+    classes = "govuk-!-margin-right-1",
+    attributes = Map("id" -> "submit", "name" -> Continue.toString)))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_confirmation_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_confirmation_page.scala.html
@@ -17,7 +17,6 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
-@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.Continue
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 
 @this(
@@ -29,10 +28,9 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   appConfig: AppConfig,
-  formHelper: FormWithCSRF
+  formHelper: FormWithCSRF,
+  continueButton: continue
 )
-
-
 @()(implicit request: Request[_], messages: Messages)
 
 @hmrcPrivacyLink = {<a href="@appConfig.hmrcPrivacyUrl">@messages("primaryContactDetails.emailAddress.passcode.confirmation.privacyNotice.link")</a>}
@@ -41,19 +39,14 @@
   title = Title("primaryContactDetails.emailAddress.passcode.confirmation.title"),
   backButton = Some(BackButton(messages("site.back"), pptRoutes.ContactDetailsEmailAddressPasscodeController.displayPage(), messages("site.back.hiddenText")))) {
 
-  @sectionHeader(messages("primaryContactDetails.sectionHeader"))
+    @sectionHeader(messages("primaryContactDetails.sectionHeader"))
 
-  @pageHeading(messages("primaryContactDetails.emailAddress.passcode.confirmation.title"))
+    @pageHeading(messages("primaryContactDetails.emailAddress.passcode.confirmation.title"))
 
-  @formHelper(action = pptRoutes.ContactDetailsEmailAddressPasscodeConfirmationController.submit(), 'autoComplete -> "off") {
+    @formHelper(action = pptRoutes.ContactDetailsEmailAddressPasscodeConfirmationController.submit(), 'autoComplete -> "off") {
 
-  @paragraphBody(message = messages("primaryContactDetails.emailAddress.passcode.confirmation"), id = Some("email-address-passcode-confirmation-id"))
+        @paragraphBody(message = messages("primaryContactDetails.emailAddress.passcode.confirmation.detail"), id = Some("email-address-passcode-confirmation-id"))
 
-  @paragraphBody(message = messages("primaryContactDetails.emailAddress.passcode.confirmation.privacyNotice", hmrcPrivacyLink))
-
-  @govukButton(Button(
-          content = Text(messages("site.button.continue")),
-          classes = "govuk-!-margin-right-1",
-          attributes = Map("id" -> "submit", "name" -> Continue.toString)))
+        @continueButton()
     }
-  }
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_passcode_page.scala.html
@@ -29,7 +29,8 @@
   errorSummary: errorSummary,
   paragraphBody: paragraphBody,
   appConfig: AppConfig,
-  formHelper: FormWithCSRF
+  formHelper: FormWithCSRF,
+  continueButton: continue
 )
 
 
@@ -66,10 +67,6 @@
                 errorMessage = errorMessages)
             )
 
-    @paragraphBody(message = messages("primaryContactDetails.emailAddress.passcode.privacyNotice", hmrcPrivacyLink))
-  @govukButton(Button(
-      content = Text(messages("site.button.continue")),
-      classes = "govuk-!-margin-right-1",
-      attributes = Map("id" -> "submit", "name" -> Continue.toString)))
+    @continueButton()
   }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -36,11 +36,11 @@ POST       /main-contact-job-title    uk.gov.hmrc.plasticpackagingtax.registrati
 GET        /main-contact-email   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressController.displayPage()
 POST       /main-contact-email   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressController.submit()
 
-GET        /primary-contact-email-passcode   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeController.displayPage()
-POST       /primary-contact-email-passcode   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeController.submit()
+GET        /confirm-email-code   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeController.displayPage()
+POST       /confirm-email-code   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeController.submit()
 
-GET        /primary-contact-email-passcode-confirmation   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeConfirmationController.displayPage()
-POST       /primary-contact-email-passcode-confirmation   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeConfirmationController.submit()
+GET        /email-confirmed   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeConfirmationController.displayPage()
+POST       /email-confirmed   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsEmailAddressPasscodeConfirmationController.submit()
 
 GET        /incorrect-passcode   uk.gov.hmrc.plasticpackagingtax.registration.controllers.ContactDetailsTooManyAttemptsPasscodeController.displayPage()
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -141,16 +141,10 @@ primaryContactDetails.emailAddress.format.error = Enter an email address in the 
 
 primaryContactDetails.emailAddress.passcode.title = Enter the code to confirm the email address
 primaryContactDetails.emailAddress.passcode.hint = For example, DNCLRK
-primaryContactDetails.emailAddress.passcode.details= We have sent a code to : {0}
 primaryContactDetails.emailAddress.passcode.empty.error = Enter a passcode
-primaryContactDetails.emailAddress.passcode.info= If you use a browser to access your email, you may need to open a new window or tab to see the code.
-primaryContactDetails.emailAddress.passcode.privacyNotice = Full details of how we use your information are in the {0}.
-primaryContactDetails.emailAddress.passcode.privacyNotice.link = HMRC Privacy Notice (opens in a new tab)
 
 primaryContactDetails.emailAddress.passcode.confirmation.title = Email address confirmed
-primaryContactDetails.emailAddress.passcode.confirmation= This will enable us to help you get the most from this service
-primaryContactDetails.emailAddress.passcode.confirmation.privacyNotice = Full details of how we use your information are in the {0}.
-primaryContactDetails.emailAddress.passcode.confirmation.privacyNotice.link = HMRC Privacy Notice (opens in a new tab)
+primaryContactDetails.emailAddress.passcode.confirmation.detail = Your email address is now confirmed.
 
 primaryContactDetails.tooManyAttempts.passcode.title = You have entered an incorrect passcode too many times - Register for the Plastic Packaging Tax and submit returns - GOV.UK
 primaryContactDetails.tooManyAttempts.passcode.1 = You have entered an incorrect passcode too many times

--- a/tampermonkey/PPT_AutoComplete.js
+++ b/tampermonkey/PPT_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PPT Registration AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      14.8
+// @version      14.9
 // @description
 // @author       pmonteiro
 // @match        http*://*/plastic-packaging-tax*
@@ -380,15 +380,16 @@ const primaryContactEmailAddress = () => {
 }
 
 const primaryContactEmailAddressPasscode = () => {
-    if (currentPageIs('/plastic-packaging-tax/primary-contact-email-passcode')) {
+    if (currentPageIs('/plastic-packaging-tax/confirm-email-code')) {
         var passcode = getPasscode()
 
         document.getElementById('value').value = passcode
         document.getElementsByClassName('govuk-button')[0].click()
     }
 }
+
 const primaryContactEmailAddressPasscodeConfirmation = () => {
-    if (currentPageIs('/plastic-packaging-tax/primary-contact-email-passcode-confirmation')) {
+    if (currentPageIs('/plastic-packaging-tax/email-confirmed')) {
         document.getElementsByClassName('govuk-button')[0].click()
     }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ContactDetailsEmailAddressPasscodeConfirmationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ContactDetailsEmailAddressPasscodeConfirmationViewSpec.scala
@@ -50,24 +50,6 @@ class ContactDetailsEmailAddressPasscodeConfirmationViewSpec extends UnitViewSpe
       )
     }
 
-    "display hint" in {
-
-      view.getElementById("email-address-passcode-confirmation-id").text() must include(
-        messages("primaryContactDetails.emailAddress.passcode.confirmation")
-      )
-    }
-
-    "display 'Privacy' Notice" in {
-
-      view.getElementsByClass("govuk-body").get(1).text() must include(
-        messages("primaryContactDetails.emailAddress.passcode.confirmation.privacyNotice",
-                 messages(
-                   "primaryContactDetails.emailAddress.passcode.confirmation.privacyNotice.link"
-                 )
-        )
-      )
-    }
-
     "display 'Continue' button" in {
       view.getElementById("submit").text() mustBe "Continue"
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ContactDetailsEmailAddressPasscodeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ContactDetailsEmailAddressPasscodeViewSpec.scala
@@ -80,7 +80,7 @@ class ContactDetailsEmailAddressPasscodeViewSpec extends UnitViewSpec with Match
       )
     }
 
-    "display email address passcode  question" in {
+    "display email address passcode question" in {
 
       view.getElementsByAttributeValueMatching("for", "value").text() must include(
         messages("primaryContactDetails.emailAddress.passcode.title")
@@ -90,15 +90,6 @@ class ContactDetailsEmailAddressPasscodeViewSpec extends UnitViewSpec with Match
     "display email address passcode input box" in {
 
       view must containElementWithID("value")
-    }
-
-    "display 'Privacy' Notice" in {
-
-      view.getElementsByClass("govuk-body").get(0).text() must include(
-        messages("primaryContactDetails.emailAddress.passcode.privacyNotice",
-                 messages("primaryContactDetails.emailAddress.passcode.privacyNotice.link")
-        )
-      )
     }
 
     "display 'Continue' button" in {


### PR DESCRIPTION
I created a continue button component to aid effort for UI consistency

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave

![image](https://user-images.githubusercontent.com/87077443/136750765-e1ee9de9-8a2b-4801-9690-9dcae1c061c2.png)

![image](https://user-images.githubusercontent.com/87077443/136750819-0f4b11dc-cfa1-4170-b79c-9c7344fc7d78.png)
