### PR TITLE
PPTP-1308 - Organisation type labels on registration journey 

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/OrganisationType.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/OrganisationType.scala
@@ -18,17 +18,23 @@ package uk.gov.hmrc.plasticpackagingtax.registration.forms
 
 import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
+import play.api.i18n.Messages
 import play.api.libs.json.{Format, Reads, Writes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.OrgType
 
 object OrgType extends Enumeration {
   type OrgType = Value
-  val UK_COMPANY: Value                        = Value("UK limited or unlimited company")
-  val SOLE_TRADER: Value                       = Value("Sole trader")
+  val UK_COMPANY: Value                        = Value("UkCompany")
+  val SOLE_TRADER: Value                       = Value("SoleTrader")
   val PARTNERSHIP: Value                       = Value("Partnership")
-  val CHARITY_OR_NOT_FOR_PROFIT: Value         = Value("Charity, Not for Profit, Trust or Society")
-  val OVERSEAS_COMPANY: Value                  = Value("Overseas company")
+  val CHARITY_OR_NOT_FOR_PROFIT: Value         = Value("RegisteredSociety")
+  val OVERSEAS_COMPANY: Value                  = Value("OverseasCompany")
   def withNameOpt(name: String): Option[Value] = values.find(_.toString == name)
+
+  def displayName(orgType: OrgType)(implicit messages: Messages): String =
+    messages(s"organisationDetails.type.$orgType")
+
+  implicit def value(orgType: OrgType): String = orgType.toString
 
   implicit val format: Format[OrgType] =
     Format(Reads.enumNameReads(OrgType), Writes.enumNameWrites)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/PartnershipType.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/PartnershipType.scala
@@ -18,18 +18,25 @@ package uk.gov.hmrc.plasticpackagingtax.registration.forms
 
 import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
+import play.api.i18n.Messages
 import play.api.libs.json.{Format, Reads, Writes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.PartnershipTypeEnum
 
 object PartnershipTypeEnum extends Enumeration {
   type PartnershipTypeEnum = Value
-  val GENERAL_PARTNERSHIP: Value           = Value("General partnership")
-  val LIMITED_LIABILITY_PARTNERSHIP: Value = Value("Limited liability partnership")
-  val LIMITED_PARTNERSHIP: Value           = Value("Limited partnership")
-  val SCOTTISH_PARTNERSHIP: Value          = Value("Scottish partnership")
-  val SCOTTISH_LIMITED_PARTNERSHIP: Value  = Value("Scottish limited partnership")
+  val GENERAL_PARTNERSHIP: Value           = Value("GeneralPartnership")
+  val LIMITED_LIABILITY_PARTNERSHIP: Value = Value("LimitedLiabilityPartnership")
+  val LIMITED_PARTNERSHIP: Value           = Value("LimitedPartnership")
+  val SCOTTISH_PARTNERSHIP: Value          = Value("ScottishPartnership")
+  val SCOTTISH_LIMITED_PARTNERSHIP: Value  = Value("ScottishLimitedPartnership")
 
   def withNameOpt(name: String): Option[Value] = values.find(_.toString == name)
+
+  def displayName(partnershipTypeEnum: PartnershipTypeEnum)(implicit messages: Messages): String =
+    messages(s"partnership.type.$partnershipTypeEnum")
+
+  implicit def value(partnershipTypeEnum: PartnershipTypeEnum): String =
+    partnershipTypeEnum.toString
 
   implicit val format: Format[PartnershipTypeEnum] =
     Format(Reads.enumNameReads(PartnershipTypeEnum), Writes.enumNameWrites)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation_type.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation_type.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrganisationType
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.displayName
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{UK_COMPANY, SOLE_TRADER, PARTNERSHIP, CHARITY_OR_NOT_FOR_PROFIT, OVERSEAS_COMPANY}
 
 @this(
@@ -55,11 +56,11 @@
                 idPrefix = Some(form("answer").name),
                 name = form("answer").name,
                 items = Seq(
-                    RadioItem(content = Text(UK_COMPANY.toString), value = Some(UK_COMPANY.toString), checked = form("answer").value.contains(UK_COMPANY.toString)),
-                    RadioItem(content = Text(SOLE_TRADER.toString), value = Some(SOLE_TRADER.toString), checked = form("answer").value.contains(SOLE_TRADER.toString)),
-                    RadioItem(content = Text(PARTNERSHIP.toString), value = Some(PARTNERSHIP.toString), checked = form("answer").value.contains(PARTNERSHIP.toString)),
-                    RadioItem(content = Text(CHARITY_OR_NOT_FOR_PROFIT.toString), value = Some(CHARITY_OR_NOT_FOR_PROFIT.toString), checked = form("answer").value.contains(CHARITY_OR_NOT_FOR_PROFIT.toString)),
-                    RadioItem(content = Text(OVERSEAS_COMPANY.toString), value = Some(OVERSEAS_COMPANY.toString), checked = form("answer").value.contains(OVERSEAS_COMPANY.toString))
+                    RadioItem(content = Text(displayName(UK_COMPANY)), value = Some(UK_COMPANY), checked = form("answer").value.contains(UK_COMPANY)),
+                    RadioItem(content = Text(displayName(SOLE_TRADER)), value = Some(SOLE_TRADER), checked = form("answer").value.contains(SOLE_TRADER)),
+                    RadioItem(content = Text(displayName(PARTNERSHIP)), value = Some(PARTNERSHIP), checked = form("answer").value.contains(PARTNERSHIP)),
+                    RadioItem(content = Text(displayName(CHARITY_OR_NOT_FOR_PROFIT)), value = Some(CHARITY_OR_NOT_FOR_PROFIT), checked = form("answer").value.contains(CHARITY_OR_NOT_FOR_PROFIT)),
+                    RadioItem(content = Text(displayName(OVERSEAS_COMPANY)), value = Some(OVERSEAS_COMPANY), checked = form("answer").value.contains(OVERSEAS_COMPANY))
                 ),
                 classes = "govuk-radios",
                 errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message)))),

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partnership_type.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partnership_type.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipType
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.displayName
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{GENERAL_PARTNERSHIP, LIMITED_LIABILITY_PARTNERSHIP, LIMITED_PARTNERSHIP, SCOTTISH_PARTNERSHIP, SCOTTISH_LIMITED_PARTNERSHIP}
 
 @this(
@@ -56,11 +57,11 @@
                 idPrefix = Some(form("answer").name),
                 name = form("answer").name,
                 items = Seq(
-                    RadioItem(content = Text(GENERAL_PARTNERSHIP.toString), value = Some(GENERAL_PARTNERSHIP.toString), checked = form("answer").value.contains(GENERAL_PARTNERSHIP.toString)),
-                    RadioItem(content = Text(LIMITED_LIABILITY_PARTNERSHIP.toString), value = Some(LIMITED_LIABILITY_PARTNERSHIP.toString), checked = form("answer").value.contains(LIMITED_LIABILITY_PARTNERSHIP.toString)),
-                    RadioItem(content = Text(LIMITED_PARTNERSHIP.toString), value = Some(LIMITED_PARTNERSHIP.toString), checked = form("answer").value.contains(LIMITED_PARTNERSHIP.toString)),
-                    RadioItem(content = Text(SCOTTISH_PARTNERSHIP.toString), value = Some(SCOTTISH_PARTNERSHIP.toString), checked = form("answer").value.contains(SCOTTISH_PARTNERSHIP.toString)),
-                    RadioItem(content = Text(SCOTTISH_LIMITED_PARTNERSHIP.toString), value = Some(SCOTTISH_LIMITED_PARTNERSHIP.toString), checked = form("answer").value.contains(SCOTTISH_LIMITED_PARTNERSHIP.toString))
+                    RadioItem(content = Text(displayName(GENERAL_PARTNERSHIP)), value = Some(GENERAL_PARTNERSHIP), checked = form("answer").value.contains(GENERAL_PARTNERSHIP)),
+                    RadioItem(content = Text(displayName(LIMITED_LIABILITY_PARTNERSHIP)), value = Some(LIMITED_LIABILITY_PARTNERSHIP), checked = form("answer").value.contains(LIMITED_LIABILITY_PARTNERSHIP)),
+                    RadioItem(content = Text(displayName(LIMITED_PARTNERSHIP)), value = Some(LIMITED_PARTNERSHIP.toString), checked = form("answer").value.contains(LIMITED_PARTNERSHIP)),
+                    RadioItem(content = Text(displayName(SCOTTISH_PARTNERSHIP)), value = Some(SCOTTISH_PARTNERSHIP), checked = form("answer").value.contains(SCOTTISH_PARTNERSHIP)),
+                    RadioItem(content = Text(displayName(SCOTTISH_LIMITED_PARTNERSHIP)), value = Some(SCOTTISH_LIMITED_PARTNERSHIP), checked = form("answer").value.contains(SCOTTISH_LIMITED_PARTNERSHIP))
                 ),
                 classes = "govuk-radios",
                 errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message)))),

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/review_registration_page.scala.html
@@ -24,6 +24,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.helpers.LiabilityLinkHelper
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.Address
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType
 @import java.time.format.DateTimeFormatter
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
@@ -160,7 +161,7 @@
     SummaryList(
         rows = Seq(
             row("reviewRegistration.organisationDetails.registeredBusinessAddress", registration.organisationDetails.businessRegisteredAddress.map(extractAddress)),
-            row("reviewRegistration.organisationDetails.organisationType", registration.organisationDetails.organisationType.map(_.toString)),
+            row("reviewRegistration.organisationDetails.organisationType", registration.organisationDetails.organisationType.map(OrgType.displayName)),
             row("reviewRegistration.organisationDetails.businessRegistrationNumber", Some(incorporationDetails.get.companyNumber)),
             row("reviewRegistration.organisationDetails.uniqueTaxpayerReference", Some(incorporationDetails.get.ctutr))
             ).filterNot(_.value.content == Empty)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -223,8 +223,20 @@ organisationDetails.basedInUk.empty.error = Choose an option
 organisationDetails.type.title = What is your organisation type?
 organisationDetails.type.empty.error = Value must be selected
 
+organisationDetails.type.UkCompany = UK limited or unlimited company
+organisationDetails.type.SoleTrader = Sole trader
+organisationDetails.type.Partnership = Partnership
+organisationDetails.type.RegisteredSociety = Charity, Not for Profit, Trust or Society
+organisationDetails.type.OverseasCompany = Overseas company
+
 partnership.type.title = What type of partnership are you registering?
 partnership.type.empty.error = Value must be selected
+
+partnership.type.GeneralPartnership = General partnership
+partnership.type.LimitedLiabilityPartnership = Limited liability partnership
+partnership.type.LimitedPartnership = Limited partnership
+partnership.type.ScottishPartnership = Scottish partnership
+partnership.type.ScottishLimitedPartnership = Scottish limited partnership
 
 unauthorised.heading = You must be registered to use this service
 unauthorised.paragraph.1 = You need to {0} to use this service

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/OrganisationDetailsTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/OrganisationDetailsTypeViewSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
   SOLE_TRADER,
   UK_COMPANY
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrganisationType
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{OrgType, OrganisationType}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrganisationType.form
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation_type
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
@@ -75,15 +75,19 @@ class OrganisationDetailsTypeViewSpec extends UnitViewSpec with Matchers {
     "display radio inputs" in {
 
       view.getElementById("answer").attr("value").text() mustBe UK_COMPANY.toString
-      view.getElementsByClass("govuk-label").first().text() mustBe UK_COMPANY.toString
+      view.getElementsByClass("govuk-label").first().text() mustBe OrgType.displayName(UK_COMPANY)
       view.getElementById("answer-2").attr("value").text() mustBe SOLE_TRADER.toString
-      view.getElementsByClass("govuk-label").get(1).text() mustBe SOLE_TRADER.toString
+      view.getElementsByClass("govuk-label").get(1).text() mustBe OrgType.displayName(SOLE_TRADER)
       view.getElementById("answer-3").attr("value").text() mustBe PARTNERSHIP.toString
-      view.getElementsByClass("govuk-label").get(2).text() mustBe PARTNERSHIP.toString
+      view.getElementsByClass("govuk-label").get(2).text() mustBe OrgType.displayName(PARTNERSHIP)
       view.getElementById("answer-4").attr("value").text() mustBe CHARITY_OR_NOT_FOR_PROFIT.toString
-      view.getElementsByClass("govuk-label").get(3).text() mustBe CHARITY_OR_NOT_FOR_PROFIT.toString
+      view.getElementsByClass("govuk-label").get(3).text() mustBe OrgType.displayName(
+        CHARITY_OR_NOT_FOR_PROFIT
+      )
       view.getElementById("answer-5").attr("value").text() mustBe OVERSEAS_COMPANY.toString
-      view.getElementsByClass("govuk-label").get(4).text() mustBe OVERSEAS_COMPANY.toString
+      view.getElementsByClass("govuk-label").get(4).text() mustBe OrgType.displayName(
+        OVERSEAS_COMPANY
+      )
     }
 
     "display 'Save And Continue' button" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/PartnershipTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/PartnershipTypeViewSpec.scala
@@ -21,7 +21,7 @@ import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
 import play.api.data.Form
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipType
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{PartnershipType, PartnershipTypeEnum}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipType.form
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.PartnershipTypeEnum.{
   GENERAL_PARTNERSHIP,
@@ -77,23 +77,29 @@ class PartnershipTypeViewSpec extends UnitViewSpec with Matchers {
     "display radio inputs" in {
 
       view.getElementById("answer").attr("value").text() mustBe GENERAL_PARTNERSHIP.toString
-      view.getElementsByClass("govuk-label").first().text() mustBe GENERAL_PARTNERSHIP.toString
+      view.getElementsByClass("govuk-label").first().text() mustBe PartnershipTypeEnum.displayName(
+        GENERAL_PARTNERSHIP
+      )
       view.getElementById("answer-2").attr(
         "value"
       ).text() mustBe LIMITED_LIABILITY_PARTNERSHIP.toString
-      view.getElementsByClass("govuk-label").get(
-        1
-      ).text() mustBe LIMITED_LIABILITY_PARTNERSHIP.toString
+      view.getElementsByClass("govuk-label").get(1).text() mustBe PartnershipTypeEnum.displayName(
+        LIMITED_LIABILITY_PARTNERSHIP
+      )
       view.getElementById("answer-3").attr("value").text() mustBe LIMITED_PARTNERSHIP.toString
-      view.getElementsByClass("govuk-label").get(2).text() mustBe LIMITED_PARTNERSHIP.toString
+      view.getElementsByClass("govuk-label").get(2).text() mustBe PartnershipTypeEnum.displayName(
+        LIMITED_PARTNERSHIP
+      )
       view.getElementById("answer-4").attr("value").text() mustBe SCOTTISH_PARTNERSHIP.toString
-      view.getElementsByClass("govuk-label").get(3).text() mustBe SCOTTISH_PARTNERSHIP.toString
+      view.getElementsByClass("govuk-label").get(3).text() mustBe PartnershipTypeEnum.displayName(
+        SCOTTISH_PARTNERSHIP
+      )
       view.getElementById("answer-5").attr(
         "value"
       ).text() mustBe SCOTTISH_LIMITED_PARTNERSHIP.toString
-      view.getElementsByClass("govuk-label").get(
-        4
-      ).text() mustBe SCOTTISH_LIMITED_PARTNERSHIP.toString
+      view.getElementsByClass("govuk-label").get(4).text() mustBe PartnershipTypeEnum.displayName(
+        SCOTTISH_LIMITED_PARTNERSHIP
+      )
     }
 
     "display 'Save And Continue' button" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
@@ -29,7 +29,8 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.OrgType.{
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.{
   Date,
   LiabilityExpectedWeight,
-  LiabilityWeight
+  LiabilityWeight,
+  OrgType
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   IncorporationDetails,
@@ -149,7 +150,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers {
                     organisationAddressKey,
                     ukCompanyView
         ) mustBe "2 Scala Street Soho London W1T 2HN"
-        getValueFor(organisationSection, organisationTypeKey) mustBe UK_COMPANY.toString
+        getValueFor(organisationSection, organisationTypeKey) mustBe OrgType.displayName(UK_COMPANY)
         getValueFor(organisationSection,
                     organisationCnrKey,
                     ukCompanyView


### PR DESCRIPTION
- created message file entries for all org and partnership types
- redefined enum values (to ensure compatibility with create subscription API)

Depends on BE enum definition change - https://github.com/hmrc/plastic-packaging-tax-registration/pull/67

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
![image](https://user-images.githubusercontent.com/46934286/136919782-f9fa9921-bc55-4d10-9a2f-e377a21034f4.png)

![image](https://user-images.githubusercontent.com/46934286/136919857-60aa9290-ed1f-41f9-ab7a-cd1b07eeb3d2.png)

