### PR TITLE
PPTP-916 - fix sign-out url passed to GRS services

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -34,6 +34,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.config
 
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
@@ -47,7 +48,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   lazy val selfBaseUrl: String = config
     .getOptional[String]("platform.frontend.host")
-    .getOrElse("http://localhost:9250")
+    .getOrElse("http://localhost:8503")
 
   lazy val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
 
@@ -59,6 +60,9 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   lazy val loginUrl         = config.get[String]("urls.login")
   lazy val loginContinueUrl = config.get[String]("urls.loginContinue")
+
+  lazy val externalSignOutLink =
+    s"$selfBaseUrl${routes.SignOutController.signOut(uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason.UserAction).url}"
 
   lazy val incorpIdHost: String =
     servicesConfig.baseUrl("incorporated-entity-identification-frontend")

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/OrganisationDetailsTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/OrganisationDetailsTypeController.scala
@@ -106,7 +106,7 @@ class OrganisationDetailsTypeController @Inject() (
       SoleTraderGrsCreateRequest(appConfig.grsCallbackUrl,
                                  Some(request2Messages(request)("service.name")),
                                  appConfig.serviceIdentifier,
-                                 appConfig.exitSurveyUrl
+                                 appConfig.externalSignOutLink
       )
     )
 
@@ -117,7 +117,7 @@ class OrganisationDetailsTypeController @Inject() (
       UkCompanyGrsCreateRequest(appConfig.grsCallbackUrl,
                                 Some(request2Messages(request)("service.name")),
                                 appConfig.serviceIdentifier,
-                                appConfig.exitSurveyUrl
+                                appConfig.externalSignOutLink
       )
     )
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/PartnershipTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/PartnershipTypeController.scala
@@ -113,7 +113,7 @@ class PartnershipTypeController @Inject() (
       PartnershipGrsCreateRequest(appConfig.grsCallbackUrl,
                                   Some(request2Messages(request)("service.name")),
                                   appConfig.serviceIdentifier,
-                                  appConfig.exitSurveyUrl
+                                  appConfig.externalSignOutLink
       )
     )
 
@@ -124,7 +124,7 @@ class PartnershipTypeController @Inject() (
       PartnershipGrsCreateRequest(appConfig.grsCallbackUrl,
                                   Some(request2Messages(request)("service.name")),
                                   appConfig.serviceIdentifier,
-                                  appConfig.exitSurveyUrl
+                                  appConfig.externalSignOutLink
       )
     )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/NotLiableViewSpec.scala
@@ -96,7 +96,7 @@ class NotLiableViewSpec extends UnitViewSpec with Matchers {
         "http://localhost:9250/contact/beta-feedback"
       )
       view.getElementById("feedback-link") must haveHref(
-        "http://localhost:9250/contact/beta-feedback?service=plastic-packaging-tax&backUrl=http://localhost:9250/"
+        "http://localhost:9250/contact/beta-feedback?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
       )
     }
 
@@ -104,7 +104,7 @@ class NotLiableViewSpec extends UnitViewSpec with Matchers {
 
       val unauthenticatedView = page()(FakeRequest(), messages)
       unauthenticatedView.getElementById("feedback-link") must haveHref(
-        "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax&backUrl=http://localhost:9250/"
+        "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
       )
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/OrganisationTypeNotSupportedViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/OrganisationTypeNotSupportedViewSpec.scala
@@ -66,7 +66,7 @@ class OrganisationTypeNotSupportedViewSpec extends UnitViewSpec with Matchers {
     "display feedback link for authenticated users" in {
 
       view.getElementsByClass("govuk-link").get(2) must haveHref(
-        "http://localhost:9250/contact/beta-feedback?service=plastic-packaging-tax&backUrl=http://localhost:9250/"
+        "http://localhost:9250/contact/beta-feedback?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
       )
       view.getElementsByClass("govuk-link").get(2) must containMessage(
         "organisationDetails.feedback.link"
@@ -77,7 +77,7 @@ class OrganisationTypeNotSupportedViewSpec extends UnitViewSpec with Matchers {
 
       val unauthenticatedView = page()(FakeRequest(), messages)
       unauthenticatedView.getElementsByClass("govuk-link").get(1) must haveHref(
-        "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax&backUrl=http://localhost:9250/"
+        "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
       )
       unauthenticatedView.getElementsByClass("govuk-link").get(1) must containMessage(
         "organisationDetails.feedback.link"

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
@@ -36,12 +36,12 @@ class PhaseBannerSpec extends UnitViewSpec with Matchers {
   private val authenticatedLink =
     "http://localhost:9250/contact/beta-feedback?" +
       "service=plastic-packaging-tax&" +
-      "backUrl=http://localhost:9250/plastic-packaging-tax/some-page"
+      "backUrl=http://localhost:8503/plastic-packaging-tax/some-page"
 
   private val unauthenticatedLink =
     "http://localhost:9250/contact/beta-feedback-unauthenticated?" +
       "service=plastic-packaging-tax&" +
-      "backUrl=http://localhost:9250/plastic-packaging-tax/some-page"
+      "backUrl=http://localhost:8503/plastic-packaging-tax/some-page"
 
   override def beforeEach(): Unit = {
     super.beforeEach()


### PR DESCRIPTION
Pass sign-out url to GRS services (rather than feedback link)

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
