### PR TITLE
BAU - autocomplete and inputType added to contact details pages

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address_page.scala.html
@@ -45,12 +45,14 @@
 
     @inputText(
         field    = form("addressLine1"),
-        labelKey  = "primaryContactDetails.address.addressLine1"
+        labelKey  = "primaryContactDetails.address.addressLine1",
+        autocomplete = Some("address-line1")
     )
 
     @inputText(
         field    = form("addressLine2"),
-        labelKey  = "primaryContactDetails.address.addressLine2"
+        labelKey  = "primaryContactDetails.address.addressLine2",
+        autocomplete = Some("address-line2")
     )
 
     @inputText(
@@ -60,13 +62,15 @@
 
     @inputText(
         field    = form("townOrCity"),
-        labelKey  = "primaryContactDetails.address.townOrCity"
-    )
+        labelKey  = "primaryContactDetails.address.townOrCity",
+        autocomplete = Some("address-level2")
+)
 
     @inputText(
         field    = form("postCode"),
         labelKey  = "primaryContactDetails.address.postCode",
-        classes = Some("govuk-input govuk-input--width-5")
+        classes = Some("govuk-input govuk-input--width-5"),
+        autocomplete = Some("address-level2")
     )
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/inputText.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/inputText.scala.html
@@ -21,7 +21,8 @@
         labelKey: String = "",
         labelClasses: String = "govuk-label--s",
         labelHiddenKey: Option[String] = None,
-        classes: Option[String] = None
+        classes: Option[String] = None,
+        autocomplete: Option[String] = None
 )(implicit messages: Messages)
 
 @inputTextLabel = @{
@@ -41,5 +42,6 @@
     value = field.value,
     classes = classes.map(clazz => s" $clazz").getOrElse("govuk-!-width-two-thirds"),
     errorMessage = field.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
-    label = inputTextLabel
+    label = inputTextLabel,
+    autocomplete = autocomplete
 ))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/email_address_page.scala.html
@@ -58,6 +58,7 @@
             name = emailAddressField.name,
             value = emailAddressField.value,
             hint = Some(Hint(content = Text(messages("primaryContactDetails.emailAddress.hint")))),
+            inputType = "email",
             label = Label(
                 isPageHeading = true,
                 classes = gdsLabelPageHeading,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/phone_number_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/phone_number_page.scala.html
@@ -46,6 +46,8 @@
             value = phoneNumberField.value,
             hint = Some(Hint(content = HtmlContent(Html( messages("primaryContactDetails.phoneNumber.hint"))))),
             errorMessage = phoneNumberField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+            autocomplete = Some("tel"),
+            inputType = "tel",
             label = Label(
                 isPageHeading = false,
                 classes = s"govuk-label govuk-visually-hidden",


### PR DESCRIPTION
Set autocomplete and type attributes for 
- telephone number
- email
- address


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave


![image](https://user-images.githubusercontent.com/46934286/137344682-13a3480f-4b02-4595-9981-5eac6127b1c5.png)

![image](https://user-images.githubusercontent.com/46934286/137344720-dfe1bc4a-4ae9-439f-b157-e0c3fadf0f7f.png)

![image](https://user-images.githubusercontent.com/46934286/137344764-88d17fb8-d8d0-47d9-819e-05784fd16449.png)
