### PR TITLE
BAU - tactical fix for service header link for enrolment pages

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/check_answers_page.scala.html
@@ -34,7 +34,8 @@
 
 @govukLayout(
     title = Title("enrolment.checkAnswers.title"),
-    backButton = Some(BackButton(messages("site.back"), pptRoutes.RegistrationDateController.displayPage(), messages("site.back.hiddenText")))) {
+    backButton = Some(BackButton(messages("site.back"), pptRoutes.RegistrationDateController.displayPage(), messages("site.back.hiddenText"))),
+    siteHeaderLink = pptRoutes.PptReferenceController.displayPage()) {
 
     @pageHeading(messages("enrolment.checkAnswers.title"))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/confirmation_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/confirmation_page.scala.html
@@ -17,6 +17,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment.{routes => pptRoutes}
 
 @this(
     govukLayout: main_template,
@@ -29,7 +30,7 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@govukLayout(title = Title("enrolment.confirmation.title")) {
+@govukLayout(title = Title("enrolment.confirmation.title"), siteHeaderLink = pptRoutes.PptReferenceController.displayPage()) {
 
   @govukPanel(Panel(
     title = Text(messages("enrolment.confirmation.title"))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/is_uk_address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/is_uk_address_page.scala.html
@@ -36,7 +36,8 @@
 
 @govukLayout(
   title = Title("enrolment.isUkAddress.title"),
-  backButton = Some(BackButton(messages("site.back"), pptRoutes.PptReferenceController.displayPage(), messages("site.back.hiddenText")))) {
+  backButton = Some(BackButton(messages("site.back"), pptRoutes.PptReferenceController.displayPage(), messages("site.back.hiddenText"))),
+  siteHeaderLink = pptRoutes.PptReferenceController.displayPage()) {
 
     @errorSummary(form.errors)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/postcode_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/postcode_page.scala.html
@@ -35,7 +35,9 @@
 
 @govukLayout(
   title = Title("enrolment.postcode.title"),
-  backButton = Some(BackButton(messages("site.back"), pptRoutes.IsUkAddressController.displayPage(), messages("site.back.hiddenText")))) {
+  backButton = Some(BackButton(messages("site.back"), pptRoutes.IsUkAddressController.displayPage(), messages("site.back.hiddenText"))),
+  siteHeaderLink = pptRoutes.PptReferenceController.displayPage()
+) {
 
     @errorSummary(form.errors)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/ppt_reference_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/ppt_reference_page.scala.html
@@ -34,7 +34,7 @@
 @pptReferenceField = @{form("value")}
 
 @govukLayout(
-  title = Title("enrolment.pptReference.title")) {
+  title = Title("enrolment.pptReference.title"), siteHeaderLink = pptRoutes.PptReferenceController.displayPage()) {
     @errorSummary(form.errors)
 
     @formHelper(action = pptRoutes.PptReferenceController.submit(), 'autoComplete -> "off") {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/registration_date_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/enrolment/registration_date_page.scala.html
@@ -37,7 +37,8 @@
 
 @govukLayout(
   title = Title("enrolment.registrationDate.title"),
-  backButton = Some(BackButton(messages("site.back"), previousPage, messages("site.back.hiddenText")))) {
+  backButton = Some(BackButton(messages("site.back"), previousPage, messages("site.back.hiddenText"))),
+  siteHeaderLink = pptRoutes.PptReferenceController.displayPage()) {
     @if(form.errors.nonEmpty) {
         @errorSummary(ErrorSummary().withFormErrorsAsText(form, mapping = Map("date" -> "date.day")))
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/main_template.scala.html
@@ -36,7 +36,8 @@
 )
 @(title: Title,
   backButton: Option[BackButton] = None,
-  useCustomContentWidth: Boolean = false
+  useCustomContentWidth: Boolean = false,
+  siteHeaderLink: Call = pptRoutes.StartController.displayStartPage,
 )(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @useTimeoutDialog = @{request.isInstanceOf[AuthenticatedRequest[_]]}
@@ -102,6 +103,6 @@
     beforeContentBlock = Some(beforeContentBlock),
     bodyEndBlock = None,
     scriptsBlock = Some(scripts),
-    headerBlock = Some(siteHeader()),
+    headerBlock = Some(siteHeader(siteHeaderLink)),
     footerBlock = Some(hmrcFooter())
 )(content)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/siteHeader.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/siteHeader.scala.html
@@ -26,7 +26,7 @@
 @this(hmrcHeader: HmrcHeader)
 
 
-@()(implicit request: Request[_], messages: Messages)
+@(serviceUrl: Call)(implicit request: Request[_], messages: Messages)
 
 @signOutHref = @{
     if (request.isInstanceOf[AuthenticatedRequest[_]] || request.isInstanceOf[JourneyRequest[_]])
@@ -38,7 +38,7 @@
 @hmrcHeader(Header(
     homepageUrl = "https://www.gov.uk",
     serviceName = Some(messages("service.name")),
-    serviceUrl = pptRoutes.StartController.displayStartPage.url,
+    serviceUrl = serviceUrl.url,
     language = language.En,
     containerClasses = "govuk-width-container",
     signOutHref = signOutHref


### PR DESCRIPTION
- Add ability to over-ride the "service url" in the page header
- Use that ability to change the url for the "enrolment" pages to `/enrolment-ppt-reference`

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave


![image](https://user-images.githubusercontent.com/46934286/139096675-21337f33-c0cd-453b-af51-a77903fde84f.png)
