### PR TITLE
PPTP-1353 - allow enrolled user to access enrolment/Confirmation page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationController.scala
@@ -16,17 +16,16 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment
 
+import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.confirmation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-import javax.inject.{Inject, Singleton}
-
 @Singleton
 class ConfirmationController @Inject() (
-  authenticate: AuthAction,
+  authenticate: AuthNoEnrolmentCheckAction,
   mcc: MessagesControllerComponents,
   page: confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment
 
+import base.PptTestData
 import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito.`given`
@@ -24,6 +25,7 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.OK
 import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.confirmation_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -32,7 +34,7 @@ class ConfirmationControllerSpec extends ControllerSpec {
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new ConfirmationController(authenticate = mockAuthAction, mcc = mcc, page = page)
+    new ConfirmationController(authenticate = mockAuthAllowEnrolmentAction, mcc = mcc, page = page)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -50,6 +52,16 @@ class ConfirmationControllerSpec extends ControllerSpec {
 
       "user is authorised and display page method is invoked" in {
         authorizedUser()
+
+        val result = controller.displayPage()(getRequest())
+
+        status(result) mustBe OK
+      }
+
+      "user is already enrolled and display page method is invoked" in {
+        val user =
+          PptTestData.newUser().copy(enrolments = Enrolments(Set(Enrolment("HMRC-PPT-ORG"))))
+        authorizedUser(user)
 
         val result = controller.displayPage()(getRequest())
 


### PR DESCRIPTION
Users that have successfully gone through the manual registration (public body) journey will be enrolled to PPT immediately.   Therefore need to reduce the level of auth checking.  (Same implementation/fix as Confirmation page on main registration journey

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
