### PR TITLE
PPTP-1358 - ensure email is verified before submitting registration

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressController.scala
@@ -76,22 +76,16 @@ class ContactDetailsEmailAddressController @Inject() (
           (formWithErrors: Form[EmailAddress]) =>
             Future.successful(BadRequest(page(formWithErrors))),
           emailAddress =>
-            request.user.identityData.credentials.map { creds =>
-              updateRegistration(formData = emailAddress, credId = creds.providerId).flatMap {
-                case Right(registration) =>
-                  FormAction.bindFromRequest match {
-                    case SaveAndContinue =>
-                      saveAndContinue(registration, creds.providerId)
-                    case _ =>
-                      Future(Redirect(routes.RegistrationController.displayPage()))
-                  }
-                case Left(error) => throw error
-              }
-            }.getOrElse(
-              throw DownstreamServiceError("Cannot find user credentials id",
-                                           RegistrationException("Cannot find user credentials id")
-              )
-            )
+            updateRegistration(formData = emailAddress, credId = request.user.credId).flatMap {
+              case Right(registration) =>
+                FormAction.bindFromRequest match {
+                  case SaveAndContinue =>
+                    saveAndContinue(registration, request.user.credId)
+                  case _ =>
+                    Future(Redirect(routes.RegistrationController.displayPage()))
+                }
+              case Left(error) => throw error
+            }
         )
     }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/SignedInUser.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/SignedInUser.scala
@@ -17,10 +17,20 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.models
 
 import uk.gov.hmrc.auth.core.Enrolments
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.RegistrationException
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.IdentityData
 
 case class SignedInUser(
   enrolments: Enrolments,
   identityData: IdentityData,
   features: Map[String, Boolean]
-)
+) {
+
+  val credId: String = identityData.credentials.map(_.providerId).getOrElse(
+    throw DownstreamServiceError("Cannot find user credentials id",
+                                 RegistrationException("Cannot find user credentials id")
+    )
+  )
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/MetaData.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/MetaData.scala
@@ -17,12 +17,12 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.EmailVerificationStatus.EmailVerificationStatus
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.{
   EmailStatus,
   EmailVerificationStatus,
   EmailVerificationStatusMapper
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.EmailVerificationStatus.EmailVerificationStatus
 import uk.gov.hmrc.plasticpackagingtax.registration.models.nrs.NrsDetails
 
 case class MetaData(
@@ -31,6 +31,9 @@ case class MetaData(
   verifiedEmails: Seq[EmailStatus] = Seq(),
   nrsDetails: Option[NrsDetails] = None
 ) {
+
+  def emailVerified(email: String): Boolean =
+    getEmailStatus(email) == EmailVerificationStatus.VERIFIED
 
   def getEmailStatus(email: String): EmailVerificationStatus =
     EmailVerificationStatusMapper.toMap(verifiedEmails).getOrElse(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetails.scala
@@ -30,15 +30,17 @@ case class PrimaryContactDetails(
   address: Option[Address] = None
 ) {
 
-  def status: TaskStatus =
-    if (isCompleted) TaskStatus.Completed
+  def status(emailVerified: String => Boolean): TaskStatus =
+    if (isCompleted(emailVerified)) TaskStatus.Completed
     else if (isInProgress) TaskStatus.InProgress
     else TaskStatus.NotStarted
 
-  def isCompleted: Boolean =
-    name.isDefined && jobTitle.isDefined && email.isDefined && phoneNumber.isDefined && address.isDefined
+  private def isCompleted(emailVerified: String => Boolean): Boolean =
+    name.isDefined && jobTitle.isDefined && email.exists(
+      emailVerified
+    ) && phoneNumber.isDefined && address.isDefined
 
-  def isInProgress: Boolean =
+  private def isInProgress: Boolean =
     name.isDefined || jobTitle.isDefined || email.isDefined || phoneNumber.isDefined || address.isDefined
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
@@ -79,7 +79,7 @@ case class Registration(
     if (companyDetailsStatus != TaskStatus.Completed)
       TaskStatus.CannotStartYet
     else
-      this.primaryContactDetails.status
+      this.primaryContactDetails.status(metaData.emailVerified)
 
   def asCompleted(): Registration =
     this.copy(metaData = this.metaData.copy(registrationCompleted = true))

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ContactDetailsEmailAddressPasscodeControllerSpec.scala
@@ -42,7 +42,10 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.Ema
   TOO_MANY_ATTEMPTS
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.VerifyPasscodeRequest
-import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.PrimaryContactDetails
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
+  MetaData,
+  PrimaryContactDetails
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.email_address_passcode_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -59,6 +62,8 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
                                                      journeyAction = mockJourneyAction,
                                                      emailVerificationConnector =
                                                        mockEmailVerificationConnector,
+                                                     registrationConnector =
+                                                       mockRegistrationConnector,
                                                      mcc = mcc,
                                                      page = page
     )
@@ -112,7 +117,11 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
     forAll(Seq(continueFormAction, unKnownFormAction)) { formAction =>
       "return 200 (OK) for " + formAction._1 when {
         "user submits passcode returns complete" in {
-          val reg = aRegistration()
+          val email = "test2352356523332453@test.com"
+          val reg =
+            aRegistration(withPrimaryContactDetails(PrimaryContactDetails(email = Some(email))))
+          reg.metaData.emailVerified(email) mustBe false
+
           authorizedUser()
           mockRegistrationFind(reg)
           mockRegistrationUpdate()
@@ -125,9 +134,11 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
               redirectLocation(result) mustBe Some(
                 routes.ContactDetailsEmailAddressPasscodeConfirmationController.displayPage().url
               )
+              modifiedRegistration.metaData.emailVerified(email) mustBe true
             case "Unknown" =>
               redirectLocation(result) mustBe Some(routes.RegistrationController.displayPage().url)
           }
+
           reset(mockRegistrationConnector)
         }
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/PrimaryContactDetailsSpec.scala
@@ -23,12 +23,15 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
 
+  val emailVerified: String => Boolean    = _ => true
+  val emailNotVerified: String => Boolean = _ => false
+
   "Primary Contact Details TaskStatus" should {
 
     "be NOT_STARTED " when {
       "primary contact details is empty" in {
         val contactDetails = PrimaryContactDetails()
-        contactDetails.status mustBe TaskStatus.NotStarted
+        contactDetails.status(emailVerified) mustBe TaskStatus.NotStarted
       }
     }
 
@@ -36,7 +39,7 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
       "primary contact details when only 'FullName' is complete" in {
         val contactDetails =
           PrimaryContactDetails(name = Some("firstName lastName"))
-        contactDetails.status mustBe TaskStatus.InProgress
+        contactDetails.status(emailVerified) mustBe TaskStatus.InProgress
       }
 
       "primary contact details when only 'FullName' and 'JobTitle' are complete" in {
@@ -44,7 +47,7 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
                                                      Some("firstName lastName"),
                                                    jobTitle = Some("Dev")
         )
-        contactDetails.status mustBe TaskStatus.InProgress
+        contactDetails.status(emailVerified) mustBe TaskStatus.InProgress
       }
 
       "primary contact details when only 'FullName', 'JobTitle' and 'Email' are complete" in {
@@ -53,7 +56,7 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
                                                    jobTitle = Some("Dev"),
                                                    email = Some("test@test.com")
         )
-        contactDetails.status mustBe TaskStatus.InProgress
+        contactDetails.status(emailVerified) mustBe TaskStatus.InProgress
       }
 
       "primary contact details when only 'FullName', 'JobTitle', 'Email' and 'phoneNumber' are complete" in {
@@ -63,12 +66,10 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
                                                    email = Some("test@test.com"),
                                                    phoneNumber = Some("0203 12345 678")
         )
-        contactDetails.status mustBe TaskStatus.InProgress
+        contactDetails.status(emailVerified) mustBe TaskStatus.InProgress
       }
-    }
 
-    "be COMPLETED " when {
-      "primary contact details are all filled in" in {
+      "primary contact details are all filled in but email not verified" in {
         val contactDetails =
           PrimaryContactDetails(name = Some("FirstName LastName"),
                                 jobTitle = Some("Developer"),
@@ -82,7 +83,26 @@ class PrimaryContactDetailsSpec extends AnyWordSpec with Matchers {
                                   )
                                 )
           )
-        contactDetails.status mustBe TaskStatus.Completed
+        contactDetails.status(emailNotVerified) mustBe TaskStatus.InProgress
+      }
+    }
+
+    "be COMPLETED " when {
+      "primary contact details are all filled in and email verified" in {
+        val contactDetails =
+          PrimaryContactDetails(name = Some("FirstName LastName"),
+                                jobTitle = Some("Developer"),
+                                email = Some("test@test.com"),
+                                phoneNumber = Some("07712345678"),
+                                address = Some(
+                                  Address(addressLine1 = "first line",
+                                          addressLine2 = "second line",
+                                          townOrCity = "Leeds",
+                                          postCode = "LS1 8TY"
+                                  )
+                                )
+          )
+        contactDetails.status(emailVerified) mustBe TaskStatus.Completed
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/RegistrationSpec.scala
@@ -71,8 +71,10 @@ class RegistrationSpec
 
     "be 'In Progress' " when {
       "All sections are complete and the user is reviewing the registration" in {
+        val registrationReviewedMetaData =
+          aRegistration().metaData.copy(registrationReviewed = true)
         val reviewedRegistration =
-          aRegistration(withMetaData(MetaData(registrationReviewed = true)))
+          aRegistration(withMetaData(registrationReviewedMetaData))
 
         reviewedRegistration.isRegistrationComplete mustBe false
         reviewedRegistration.numberOfCompletedSections mustBe 3
@@ -94,9 +96,9 @@ class RegistrationSpec
 
     "be 'Completed' " when {
       "All sections are complete" in {
-        val completeRegistration = aRegistration(
-          withMetaData(MetaData(registrationReviewed = true, registrationCompleted = true))
-        )
+        val registrationCompletedMetaData =
+          aRegistration().metaData.copy(registrationReviewed = true, registrationCompleted = true)
+        val completeRegistration = aRegistration(withMetaData(registrationCompletedMetaData))
 
         completeRegistration.isRegistrationComplete mustBe true
         completeRegistration.numberOfCompletedSections mustBe 4

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationViewSpec.scala
@@ -225,12 +225,45 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
 
       }
 
+      "Primary contact email not verified" when {
+
+        val registration =
+          aRegistration(withMetaData(MetaData()))
+
+        val view: Html =
+          createView(registration)
+
+        "Contact details" in {
+          val contactElement = view.getElementsByClass("app-task").get(PRIMARY_CONTACT_DETAILS)
+
+          header(contactElement) must include(
+            messages("registrationPage.task.contactDetails.heading")
+          )
+
+          sectionName(contactElement, 0) mustBe messages("registrationPage.task.contactDetails")
+          sectionStatus(contactElement, 0) mustBe messages("task.status.inProgress")
+          sectionLink(contactElement, 0) must haveHref(
+            routes.ContactDetailsFullNameController.displayPage()
+          )
+        }
+
+        "Review and send" in {
+          val reviewElement = view.getElementsByClass("app-task").get(CHECK_AND_SUBMIT)
+
+          header(reviewElement) must include(messages("registrationPage.task.review.heading"))
+
+          sectionName(reviewElement, 0) mustBe messages("registrationPage.task.review")
+          sectionStatus(reviewElement, 0) mustBe messages("task.status.cannotStartYet")
+        }
+
+      }
+
       "All Sections completed" when {
 
+        val registrationCompletedMetaData =
+          aRegistration().metaData.copy(registrationReviewed = true, registrationCompleted = true)
         val completeRegistration =
-          aRegistration(
-            withMetaData(MetaData(registrationReviewed = true, registrationCompleted = true))
-          )
+          aRegistration(withMetaData(registrationCompletedMetaData))
 
         val view: Html =
           createView(completeRegistration)
@@ -303,10 +336,11 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
       }
 
       "Check and Submit is 'In Progress'" in {
-        val inProgressRegistration = aRegistration(
-          withMetaData(MetaData(registrationReviewed = true, registrationCompleted = false))
-        )
-        val view: Html = createView(inProgressRegistration)
+
+        val inProgressMetaData =
+          aRegistration().metaData.copy(registrationReviewed = true, registrationCompleted = false)
+        val inProgressRegistration = aRegistration(withMetaData(inProgressMetaData))
+        val view: Html             = createView(inProgressRegistration)
 
         val reviewElement = view.getElementsByClass("app-task").get(CHECK_AND_SUBMIT)
 
@@ -320,10 +354,11 @@ class RegistrationViewSpec extends UnitViewSpec with Matchers {
       }
 
       "Check and Submit is 'Completed'" in {
-        val completedRegistration = aRegistration(
-          withMetaData(MetaData(registrationReviewed = true, registrationCompleted = true))
-        )
-        val view: Html = createView(completedRegistration)
+
+        val completedMetaData =
+          aRegistration().metaData.copy(registrationReviewed = true, registrationCompleted = true)
+        val completedRegistration = aRegistration(withMetaData(completedMetaData))
+        val view: Html            = createView(completedRegistration)
 
         val reviewElement = view.getElementsByClass("app-task").get(CHECK_AND_SUBMIT)
 


### PR DESCRIPTION
Fixes bug whereby an unverified email address can be submitted if the user by-passes the verification code screen.

"Email verified" is now part of the "Primary Contact Details complete" test

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
