### PR TITLE
PPTP-1428 - fix liability and group under single control status logic

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/LiabilityController.scala
@@ -18,13 +18,14 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import play.api.mvc.{AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.LiabilityDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 abstract class LiabilityController(mcc: MessagesControllerComponents)
     extends FrontendController(mcc) {
 
-  protected val deMinimisKg = 10000
+  protected val deMinimisKg: Long = LiabilityDetails.minimumLiabilityWeightKg
 
   protected def isPreLaunch(implicit request: JourneyRequest[AnyContent]) =
     request.isFeatureFlagEnabled(Features.isPreLaunch)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotMembersUnderGroupControlController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotMembersUnderGroupControlController.scala
@@ -40,7 +40,7 @@ class NotMembersUnderGroupControlController @Inject() (
 
   def submit(): Action[AnyContent] =
     (authenticate andThen journeyAction) {
-      Redirect(routes.CheckLiabilityDetailsAnswersController.displayPage())
+      Redirect(routes.RegistrationTypeController.displayPage())
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/LiabilityExpectedWeight.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/LiabilityExpectedWeight.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.forms
 import play.api.data.Form
 import play.api.data.Forms.{mapping, optional, text}
 import play.api.libs.json.{Json, OFormat}
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityExpectedWeight.weightThresholdKg
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.LiabilityDetails
 import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfEqual
 
 import scala.util.Try
@@ -29,13 +29,14 @@ case class LiabilityExpectedWeight(
   totalKg: Option[Long]
 ) {
 
-  def overLiabilityThreshold: Boolean = totalKg.exists(_ >= weightThresholdKg)
+  def overLiabilityThreshold: Boolean =
+    totalKg.exists(_ >= LiabilityDetails.minimumLiabilityWeightKg)
+
 }
 
 object LiabilityExpectedWeight extends CommonFormValues {
   implicit val format: OFormat[LiabilityExpectedWeight] = Json.format[LiabilityExpectedWeight]
 
-  val weightThresholdKg         = 10000L
   val maxTotalKg                = 100000000 // one hundred million
   val answer                    = "answer"
   val totalKg                   = "totalKg"
@@ -53,7 +54,9 @@ object LiabilityExpectedWeight extends CommonFormValues {
     weight.isEmpty || !weightIsValidNumber(weight) || Try(BigInt(weight)).isSuccess
 
   private val weightAboveThreshold: String => Boolean = weight =>
-    weight.isEmpty || !weightIsValidNumber(weight) || BigDecimal(weight) >= weightThresholdKg
+    weight.isEmpty || !weightIsValidNumber(weight) || BigDecimal(
+      weight
+    ) >= LiabilityDetails.minimumLiabilityWeightKg
 
   private val weightWithinRange: String => Boolean = weight =>
     weight.isEmpty || !weightIsValidNumber(weight) || BigDecimal(weight) <= maxTotalKg

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.RegType
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.RegType.RegType
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.RegType.{GROUP, RegType}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 case class Registration(
@@ -81,7 +81,12 @@ case class Registration(
   def isLiabilityDetailsComplete: Boolean = liabilityDetailsStatus == TaskStatus.Completed
 
   def liabilityDetailsStatus: TaskStatus =
-    this.liabilityDetails.status
+    if (this.liabilityDetails.isCompleted && registrationType.contains(GROUP))
+      if (groupDetail.flatMap(_.membersUnderGroupControl).contains(true))
+        TaskStatus.Completed
+      else TaskStatus.InProgress
+    else
+      this.liabilityDetails.status
 
   def isPrimaryContactDetailsComplete: Boolean = primaryContactDetailsStatus == TaskStatus.Completed
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotMembersUnderGroupControlControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotMembersUnderGroupControlControllerSpec.scala
@@ -74,9 +74,7 @@ class NotMembersUnderGroupControlControllerSpec extends ControllerSpec {
           controller.submit()(FakeRequest("POST", ""))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(
-          routes.CheckLiabilityDetailsAnswersController.displayPage().url
-        )
+        redirectLocation(result) mustBe Some(routes.RegistrationTypeController.displayPage().url)
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/LiabilityExpectedWeightTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/LiabilityExpectedWeightTest.scala
@@ -28,9 +28,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.LiabilityExpectedWeigh
   weightDecimalError,
   weightEmptyError,
   weightFormatError,
-  weightOutOfRangeError,
-  weightThresholdKg
+  weightOutOfRangeError
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.LiabilityDetails
 
 class LiabilityExpectedWeightTest extends AnyWordSpec with Matchers {
 
@@ -48,7 +48,8 @@ class LiabilityExpectedWeightTest extends AnyWordSpec with Matchers {
 
       "is exactly min allowed amount" in {
 
-        val input = Map(answer -> "yes", totalKg -> weightThresholdKg.toString)
+        val input =
+          Map(answer -> "yes", totalKg -> LiabilityDetails.minimumLiabilityWeightKg.toString)
 
         val form = LiabilityExpectedWeight.form().bind(input)
         form.errors.size mustBe 0
@@ -99,7 +100,8 @@ class LiabilityExpectedWeightTest extends AnyWordSpec with Matchers {
 
       "contains total less than minimum allowed weight" in {
 
-        val input          = Map(answer -> "yes", totalKg -> (weightThresholdKg - 1).toString)
+        val input =
+          Map(answer -> "yes", totalKg -> (LiabilityDetails.minimumLiabilityWeightKg - 1).toString)
         val expectedErrors = Seq(FormError("totalKg", weightBelowThresholdError))
 
         testFailedValidationErrors(input, expectedErrors)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetailsSpec.scala
@@ -27,6 +27,10 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
 
+  private val belowWeightThreshold = 9999
+  private val atWeightThreshold    = 10000
+  private val aboveWeightThreshold = 10001
+
   "Liability Details TaskStatus" should {
 
     "be NOT_STARTED " when {
@@ -47,19 +51,25 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
 
           "and only liability weight has been answered" in {
             val liabilityDetails =
-              LiabilityDetails(startDate = None, weight = Some(LiabilityWeight(Some(4000))))
+              LiabilityDetails(startDate = None,
+                               weight = Some(LiabilityWeight(Some(aboveWeightThreshold)))
+              )
             liabilityDetails.status mustBe TaskStatus.InProgress
           }
 
           "and 'is liable' has been answered with false" in {
             val liabilityDetails =
-              LiabilityDetails(isLiable = Some(false), weight = Some(LiabilityWeight(Some(12000))))
+              LiabilityDetails(isLiable = Some(false),
+                               weight = Some(LiabilityWeight(Some(aboveWeightThreshold)))
+              )
             liabilityDetails.status mustBe TaskStatus.InProgress
           }
 
           "and weight is less than limit" in {
             val liabilityDetails =
-              LiabilityDetails(isLiable = Some(true), weight = Some(LiabilityWeight(Some(1000))))
+              LiabilityDetails(isLiable = Some(true),
+                               weight = Some(LiabilityWeight(Some(belowWeightThreshold)))
+              )
             liabilityDetails.status mustBe TaskStatus.InProgress
           }
         }
@@ -73,7 +83,9 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
 
           "and only liability weight has been answered" in {
             val liabilityDetails =
-              LiabilityDetails(startDate = None, weight = Some(LiabilityWeight(Some(4000))))
+              LiabilityDetails(startDate = None,
+                               weight = Some(LiabilityWeight(Some(aboveWeightThreshold)))
+              )
             liabilityDetails.status mustBe TaskStatus.InProgress
           }
         }
@@ -88,7 +100,7 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
             LiabilityDetails(startDate =
                                Some(Date(Some(1), Some(5), Some(2022))),
                              expectedWeight =
-                               Some(LiabilityExpectedWeight(Some(true), Some(10000))),
+                               Some(LiabilityExpectedWeight(Some(true), Some(atWeightThreshold))),
                              isLiable = Some(true)
             )
           liabilityDetails.status mustBe TaskStatus.Completed
@@ -99,16 +111,18 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
         "and liability details are all correctly filled in for weight existing exceeding" in {
           val liabilityDetails = LiabilityDetails(startDate =
                                                     Some(Date(Some(1), Some(5), Some(2022))),
-                                                  weight = Some(LiabilityWeight(Some(10000)))
+                                                  weight =
+                                                    Some(LiabilityWeight(Some(atWeightThreshold)))
           )
           liabilityDetails.status mustBe TaskStatus.Completed
         }
         "and liability details are all correctly filled in for weight expected to exceed" in {
-          val liabilityDetails = LiabilityDetails(startDate =
-                                                    Some(Date(Some(1), Some(5), Some(2022))),
-                                                  weight = Some(LiabilityWeight(Some(1000))),
-                                                  expectToExceedThresholdWeight = Some(true)
-          )
+          val liabilityDetails =
+            LiabilityDetails(startDate =
+                               Some(Date(Some(1), Some(5), Some(2022))),
+                             weight = Some(LiabilityWeight(Some(belowWeightThreshold))),
+                             expectToExceedThresholdWeight = Some(true)
+            )
           liabilityDetails.status mustBe TaskStatus.Completed
         }
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/LiabilityDetailsSpec.scala
@@ -18,7 +18,11 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Date, LiabilityWeight}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.{
+  Date,
+  LiabilityExpectedWeight,
+  LiabilityWeight
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
@@ -46,6 +50,18 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
               LiabilityDetails(startDate = None, weight = Some(LiabilityWeight(Some(4000))))
             liabilityDetails.status mustBe TaskStatus.InProgress
           }
+
+          "and 'is liable' has been answered with false" in {
+            val liabilityDetails =
+              LiabilityDetails(isLiable = Some(false), weight = Some(LiabilityWeight(Some(12000))))
+            liabilityDetails.status mustBe TaskStatus.InProgress
+          }
+
+          "and weight is less than limit" in {
+            val liabilityDetails =
+              LiabilityDetails(isLiable = Some(true), weight = Some(LiabilityWeight(Some(1000))))
+            liabilityDetails.status mustBe TaskStatus.InProgress
+          }
         }
 
         "and 'isPreLaunch' flag is disabled" when {
@@ -67,18 +83,31 @@ class LiabilityDetailsSpec extends AnyWordSpec with Matchers {
 
     "be COMPLETED " when {
       "and 'isPreLaunch' flag is enabled" when {
-        "and liability details are all filled in" in {
+        "and liability details are all correctly filled in" in {
           val liabilityDetails =
-            LiabilityDetails(isLiable = Some(false), weight = Some(LiabilityWeight(Some(4000))))
+            LiabilityDetails(startDate =
+                               Some(Date(Some(1), Some(5), Some(2022))),
+                             expectedWeight =
+                               Some(LiabilityExpectedWeight(Some(true), Some(10000))),
+                             isLiable = Some(true)
+            )
           liabilityDetails.status mustBe TaskStatus.Completed
         }
       }
 
       "and 'isPreLaunch' flag is disabled" when {
-        "and liability details are all filled in" in {
+        "and liability details are all correctly filled in for weight existing exceeding" in {
           val liabilityDetails = LiabilityDetails(startDate =
                                                     Some(Date(Some(1), Some(5), Some(2022))),
-                                                  weight = Some(LiabilityWeight(Some(4000)))
+                                                  weight = Some(LiabilityWeight(Some(10000)))
+          )
+          liabilityDetails.status mustBe TaskStatus.Completed
+        }
+        "and liability details are all correctly filled in for weight expected to exceed" in {
+          val liabilityDetails = LiabilityDetails(startDate =
+                                                    Some(Date(Some(1), Some(5), Some(2022))),
+                                                  weight = Some(LiabilityWeight(Some(1000))),
+                                                  expectToExceedThresholdWeight = Some(true)
           )
           liabilityDetails.status mustBe TaskStatus.Completed
         }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationGroupViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationGroupViewSpec.scala
@@ -25,12 +25,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.RegType.GROUP
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Date, LiabilityWeight}
-import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
-  LiabilityDetails,
-  MetaData,
-  OrganisationDetails,
-  Registration
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration._
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.registration_group
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 
@@ -94,7 +89,7 @@ class RegistrationGroupViewSpec extends UnitViewSpec with Matchers {
         val registration = aRegistration(withRegistrationType(Some(GROUP)),
                                          withLiabilityDetails(
                                            LiabilityDetails(weight =
-                                                              Some(LiabilityWeight(Some(1000))),
+                                                              Some(LiabilityWeight(Some(10000))),
                                                             startDate = None
                                            )
                                          ),
@@ -179,9 +174,12 @@ class RegistrationGroupViewSpec extends UnitViewSpec with Matchers {
       "Organisation information and Primary Contact details not started" when {
 
         val registration = aRegistration(withRegistrationType(Some(GROUP)),
+                                         withGroupDetail(
+                                           Some(GroupDetail(membersUnderGroupControl = Some(true)))
+                                         ),
                                          withLiabilityDetails(
                                            LiabilityDetails(
-                                             weight = Some(LiabilityWeight(Some(1000))),
+                                             weight = Some(LiabilityWeight(Some(10000))),
                                              startDate = Some(Date(Some(1), Some(4), Some(2022)))
                                            )
                                          ),
@@ -270,7 +268,10 @@ class RegistrationGroupViewSpec extends UnitViewSpec with Matchers {
       "Primary contact email not verified" when {
 
         val registration =
-          aRegistration(withRegistrationType(Some(GROUP)), withMetaData(MetaData()))
+          aRegistration(withRegistrationType(Some(GROUP)),
+                        withMetaData(MetaData()),
+                        withGroupDetail(Some(GroupDetail(membersUnderGroupControl = Some(true))))
+          )
 
         val view: Html =
           createView(registration)
@@ -309,7 +310,8 @@ class RegistrationGroupViewSpec extends UnitViewSpec with Matchers {
           aRegistration().metaData.copy(registrationReviewed = true, registrationCompleted = true)
         val completeRegistration =
           aRegistration(withRegistrationType(Some(GROUP)),
-                        withMetaData(registrationCompletedMetaData)
+                        withMetaData(registrationCompletedMetaData),
+                        withGroupDetail(Some(GroupDetail(membersUnderGroupControl = Some(true))))
           )
 
         val view: Html =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationSingleEntityViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/RegistrationSingleEntityViewSpec.scala
@@ -158,7 +158,7 @@ class RegistrationSingleEntityViewSpec extends UnitViewSpec with Matchers {
 
         val registration = aRegistration(
           withLiabilityDetails(
-            LiabilityDetails(weight = Some(LiabilityWeight(Some(1000))),
+            LiabilityDetails(weight = Some(LiabilityWeight(Some(10000))),
                              startDate = Some(Date(Some(1), Some(4), Some(2022)))
             )
           ),


### PR DESCRIPTION
Prevent access to task list when group not under single control 
- also when not liable according to weight answers

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
