### PR TITLE
PPTP-1417 - fix urls for GRS general and scottish partnership journeys

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -79,8 +79,8 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   lazy val partnershipBaseUrl            = s"$partnershipHost/partnership-identification/api"
   lazy val partnershipJourneyUrl         = s"$partnershipBaseUrl/journey"
-  lazy val generalPartnershipJourneyUrl  = s"$partnershipBaseUrl/general-partnership/journey"
-  lazy val scottishPartnershipJourneyUrl = s"$partnershipBaseUrl/scottish-partnership/journey"
+  lazy val generalPartnershipJourneyUrl  = s"$partnershipBaseUrl/general-partnership-journey"
+  lazy val scottishPartnershipJourneyUrl = s"$partnershipBaseUrl/scottish-partnership-journey"
   // Define other partnership URLs here?
 
   lazy val grsCallbackUrl: String = config.get[String]("urls.grsCallback")

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfigSpec.scala
@@ -73,7 +73,7 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
     "have 'generalPartnershipJourneyUrl' defined" in {
       validAppConfig.generalPartnershipJourneyUrl must be(
-        "http://localhost:9722/partnership-identification/api/general-partnership/journey"
+        "http://localhost:9722/partnership-identification/api/general-partnership-journey"
       )
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/grs/GeneralPartnershipGrsConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/grs/GeneralPartnershipGrsConnectorISpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs
 
+import java.util.UUID
+
 import base.Injector
 import base.it.ConnectorISpec
 import com.github.tomakehurst.wiremock.client.WireMock
@@ -30,8 +32,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   IncorporationRegistrationDetails,
   PartnershipGrsCreateRequest
 }
-
-import java.util.UUID
 
 class GeneralPartnershipGrsConnectorISpec extends ConnectorISpec with Injector with ScalaFutures {
 
@@ -108,7 +108,7 @@ class GeneralPartnershipGrsConnectorISpec extends ConnectorISpec with Injector w
 
   private def expectPartnershipIdentificationServiceToSuccessfullyCreateNewJourney() =
     stubFor(
-      post("/partnership-identification/api/general-partnership/journey")
+      post("/partnership-identification/api/general-partnership-journey")
         .willReturn(
           aResponse()
             .withStatus(Status.CREATED)
@@ -118,7 +118,7 @@ class GeneralPartnershipGrsConnectorISpec extends ConnectorISpec with Injector w
 
   private def expectPartnershipIdentificationServiceToFailToCreateNewJourney(statusCode: Int) =
     stubFor(
-      post("/partnership-identification/api/general-partnership/journey")
+      post("/partnership-identification/api/general-partnership-journey")
         .willReturn(
           aResponse()
             .withStatus(statusCode)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/grs/ScottishPartnershipGrsConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/grs/ScottishPartnershipGrsConnectorISpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs
 
+import java.util.UUID
+
 import base.Injector
 import base.it.ConnectorISpec
 import com.github.tomakehurst.wiremock.client.WireMock
@@ -30,8 +32,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   PartnershipGrsCreateRequest,
   ScottishPartnershipDetails
 }
-
-import java.util.UUID
 
 class ScottishPartnershipGrsConnectorISpec extends ConnectorISpec with Injector with ScalaFutures {
 
@@ -108,7 +108,7 @@ class ScottishPartnershipGrsConnectorISpec extends ConnectorISpec with Injector 
 
   private def expectPartnershipIdentificationServiceToSuccessfullyCreateNewJourney() =
     stubFor(
-      post("/partnership-identification/api/scottish-partnership/journey")
+      post("/partnership-identification/api/scottish-partnership-journey")
         .willReturn(
           aResponse()
             .withStatus(Status.CREATED)
@@ -118,7 +118,7 @@ class ScottishPartnershipGrsConnectorISpec extends ConnectorISpec with Injector 
 
   private def expectPartnershipIdentificationServiceToFailToCreateNewJourney(statusCode: Int) =
     stubFor(
-      post("/partnership-identification/api/scottish-partnership/journey")
+      post("/partnership-identification/api/scottish-partnership-journey")
         .willReturn(
           aResponse()
             .withStatus(statusCode)


### PR DESCRIPTION
Update urls as per latest build in https://github.com/hmrc/partnership-identification-frontend

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
