### PR TITLE
PPTP-1243 - initial integration with address lookup frontend

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -34,6 +34,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.config
 
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration
+import play.api.mvc.Call
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -50,6 +51,8 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
     .getOptional[String]("platform.frontend.host")
     .getOrElse("http://localhost:8503")
 
+  def selfUrl(call: Call): String = s"$selfBaseUrl${call.url}"
+
   lazy val contactBaseUrl = servicesConfig.baseUrl("contact-frontend")
 
   lazy val reportTechincalProblemUrl: String =
@@ -58,8 +61,11 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val loginUrl         = config.get[String]("urls.login")
   lazy val loginContinueUrl = config.get[String]("urls.loginContinue")
 
-  lazy val externalSignOutLink =
-    s"$selfBaseUrl${routes.SignOutController.signOut(uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason.UserAction).url}"
+  lazy val externalSignOutLink = selfUrl(
+    routes.SignOutController.signOut(
+      uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason.UserAction
+    )
+  )
 
   lazy val incorpIdHost: String =
     servicesConfig.baseUrl("incorporated-entity-identification-frontend")
@@ -116,6 +122,15 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
     config.get[Boolean]("microservice.services.email-verification.enabled")
 
   lazy val pptRegistrationInfoUrl: String = config.get[String]("urls.pptRegistrationsInfoLink")
+
+  lazy val addressLookupHost: String =
+    servicesConfig.baseUrl("address-lookup-frontend")
+
+  lazy val addressLookupInitUrl: String =
+    s"$addressLookupHost/api/init"
+
+  lazy val addressLookupConfirmedUrl: String =
+    s"$addressLookupHost/api/confirmed"
 
   def pptRegistrationUrl(id: String): String = s"$pptRegistrationUrl/$id"
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnector.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup
+
+import com.kenshoo.play.metrics.Metrics
+import javax.inject.{Inject, Singleton}
+import play.api.http.HeaderNames.LOCATION
+import play.api.http.Status
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup.InitialiseAddressLookupHttpParser.InitialiseAddressLookupReads
+import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup.{
+  AddressLookupConfigV2,
+  AddressLookupConfirmation,
+  AddressLookupOnRamp
+}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AddressLookupFrontendConnector @Inject() (
+  http: HttpClient,
+  appConfig: AppConfig,
+  metrics: Metrics
+) {
+
+  def initialiseJourney(
+    addressLookupRequest: AddressLookupConfigV2
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AddressLookupOnRamp] = {
+    val timer = metrics.defaultRegistry.timer("ppt.addresslookup.initialise.timer").time()
+    http.POST[AddressLookupConfigV2, AddressLookupOnRamp](appConfig.addressLookupInitUrl,
+                                                          addressLookupRequest
+    )(implicitly, InitialiseAddressLookupReads, hc, ec)
+      .andThen { case _ => timer.stop() }
+  }
+
+  private[connectors] def getAddressUrl(id: String) =
+    s"${appConfig.addressLookupConfirmedUrl}?id=$id"
+
+  def getAddress(
+    id: String
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AddressLookupConfirmation] = {
+    val timer = metrics.defaultRegistry.timer("ppt.addresslookup.getaddress.timer").time()
+    http.GET[AddressLookupConfirmation](getAddressUrl(id))(implicitly, hc, ec)
+      .andThen { case _ => timer.stop() }
+  }
+
+}
+
+object InitialiseAddressLookupHttpParser {
+
+  implicit object InitialiseAddressLookupReads extends HttpReads[AddressLookupOnRamp] {
+
+    override def read(method: String, url: String, response: HttpResponse): AddressLookupOnRamp =
+      response.status match {
+        case Status.ACCEPTED =>
+          response.header(LOCATION) match {
+            case Some(redirectUrl) => AddressLookupOnRamp(redirectUrl)
+            case None              => throw new IllegalStateException("Missing re-direct url")
+          }
+      }
+
+  }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnector.scala
@@ -19,11 +19,10 @@ package uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup
 import com.kenshoo.play.metrics.Metrics
 import javax.inject.{Inject, Singleton}
 import play.api.http.HeaderNames.LOCATION
-import play.api.http.Status
+import play.api.http.Status.ACCEPTED
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup.InitialiseAddressLookupHttpParser.InitialiseAddressLookupReads
 import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup.{
   AddressLookupConfigV2,
   AddressLookupConfirmation,
@@ -43,38 +42,24 @@ class AddressLookupFrontendConnector @Inject() (
     addressLookupRequest: AddressLookupConfigV2
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AddressLookupOnRamp] = {
     val timer = metrics.defaultRegistry.timer("ppt.addresslookup.initialise.timer").time()
-    http.POST[AddressLookupConfigV2, AddressLookupOnRamp](appConfig.addressLookupInitUrl,
-                                                          addressLookupRequest
-    )(implicitly, InitialiseAddressLookupReads, hc, ec)
-      .andThen { case _ => timer.stop() }
-  }
-
-  private[connectors] def getAddressUrl(id: String) =
-    s"${appConfig.addressLookupConfirmedUrl}?id=$id"
-
-  def getAddress(
-    id: String
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AddressLookupConfirmation] = {
-    val timer = metrics.defaultRegistry.timer("ppt.addresslookup.getaddress.timer").time()
-    http.GET[AddressLookupConfirmation](getAddressUrl(id))(implicitly, hc, ec)
-      .andThen { case _ => timer.stop() }
-  }
-
-}
-
-object InitialiseAddressLookupHttpParser {
-
-  implicit object InitialiseAddressLookupReads extends HttpReads[AddressLookupOnRamp] {
-
-    override def read(method: String, url: String, response: HttpResponse): AddressLookupOnRamp =
-      response.status match {
-        case Status.ACCEPTED =>
+    http.POST[AddressLookupConfigV2, HttpResponse](appConfig.addressLookupInitUrl,
+                                                   addressLookupRequest
+    ).andThen { case _ => timer.stop() }
+      .map {
+        case response @ HttpResponse(ACCEPTED, _, _) =>
           response.header(LOCATION) match {
             case Some(redirectUrl) => AddressLookupOnRamp(redirectUrl)
             case None              => throw new IllegalStateException("Missing re-direct url")
           }
       }
+  }
 
+  def getAddress(
+    id: String
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AddressLookupConfirmation] = {
+    val timer = metrics.defaultRegistry.timer("ppt.addresslookup.getaddress.timer").time()
+    http.GET[AddressLookupConfirmation](appConfig.addressLookupConfirmedUrl, Seq("id" -> id))
+      .andThen { case _ => timer.stop() }
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsAddressController.scala
@@ -132,8 +132,7 @@ class ContactDetailsAddressController @Inject() (
 
   private def initialiseAddressLookup(implicit
     hc: HeaderCarrier,
-    ec: ExecutionContext,
-    request: JourneyRequest[_]
+    ec: ExecutionContext
   ): Future[AddressLookupOnRamp] =
     addressLookupFrontendConnector.initialiseJourney(
       AddressLookupConfigV2(routes.ContactDetailsAddressController.update(None), appConfig)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/contact/Address.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/contact/Address.scala
@@ -20,6 +20,7 @@ import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms, Mapping}
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.CommonFormValidators
+import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup.AddressLookupConfirmation
 
 case class Address(
   addressLine1: String,
@@ -31,6 +32,16 @@ case class Address(
 
 object Address extends CommonFormValidators {
   implicit val format: OFormat[Address] = Json.format[Address]
+
+  def apply(addressLookupConfirmation: AddressLookupConfirmation): Address = {
+    val lines = addressLookupConfirmation.extractAddressLines()
+    new Address(addressLine1 = lines._1,
+                addressLine2 = lines._2.getOrElse(""),
+                addressLine3 = lines._3,
+                townOrCity = lines._4,
+                postCode = addressLookupConfirmation.address.postcode.getOrElse("")
+    )
+  }
 
   private val validateAddressField: Int => String => Boolean =
     (length: Int) =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupAddress.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupAddress.scala
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.config
+package uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup
 
-object Features {
-  val isPreLaunch: String                = "isPreLaunch"
-  val isUkCompanyPrivateBeta: String     = "ukCompanyPrivateBeta"
-  val isGroupRegistrationEnabled: String = "isGroupRegistrationEnabled"
-  val isAddressLookupEnabled: String     = "isAddressLookupEnabled"
+import play.api.libs.json.{Json, OFormat}
+
+case class AddressLookupAddress(
+  lines: List[String],
+  postcode: Option[String],
+  country: Option[AddressLookupCountry]
+)
+
+object AddressLookupAddress {
+  implicit val format: OFormat[AddressLookupAddress] = Json.format[AddressLookupAddress]
+}
+
+case class AddressLookupCountry(code: String, name: String)
+
+object AddressLookupCountry {
+  implicit val format: OFormat[AddressLookupCountry] = Json.format[AddressLookupCountry]
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfigV2.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfigV2.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup
+
+import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
+import play.api.libs.json.{Json, OFormat}
+import play.api.mvc.Call
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
+import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles.gdsFieldsetPageHeading
+
+case class AddressLookupConfigV2(version: Int = 2, options: JourneyOptions, labels: JourneyLabels)
+
+object AddressLookupConfigV2 {
+  implicit val format: OFormat[AddressLookupConfigV2] = Json.format[AddressLookupConfigV2]
+
+  def apply(continue: Call, appConfig: AppConfig)(implicit
+    messagesApi: MessagesApi,
+    request: JourneyRequest[_]
+  ): AddressLookupConfigV2 = {
+    val en: Messages = MessagesImpl(Lang("en"), messagesApi)
+
+    new AddressLookupConfigV2(options = JourneyOptions(continueUrl = appConfig.selfUrl(continue),
+                                                       signOutHref = appConfig.externalSignOutLink,
+                                                       serviceHref = appConfig.selfUrl(
+                                                         commonRoutes.StartController.displayStartPage
+                                                       )
+                              ),
+                              labels = JourneyLabels(en =
+                                LanguageLabels(appLevelLabels =
+                                  AppLevelLabels(navTitle = en("service.name"))
+                                )
+                              )
+    )
+  }
+
+}
+
+case class JourneyOptions(
+  continueUrl: String,
+  signOutHref: String,
+  serviceHref: String,
+  showPhaseBanner: Boolean = true,
+  pageHeadingStyle: String = gdsFieldsetPageHeading,
+  ukMode: Boolean = true,
+  disableTranslations: Boolean = true,
+  includeHMRCBranding: Boolean = false
+)
+
+object JourneyOptions {
+  implicit val format: OFormat[JourneyOptions] = Json.format[JourneyOptions]
+}
+
+case class JourneyLabels(en: LanguageLabels)
+
+object JourneyLabels {
+  implicit val format: OFormat[JourneyLabels] = Json.format[JourneyLabels]
+}
+
+case class LanguageLabels(appLevelLabels: AppLevelLabels)
+
+object LanguageLabels {
+  implicit val format: OFormat[LanguageLabels] = Json.format[LanguageLabels]
+}
+
+case class AppLevelLabels(navTitle: String)
+
+object AppLevelLabels {
+  implicit val format: OFormat[AppLevelLabels] = Json.format[AppLevelLabels]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfigV2.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfigV2.scala
@@ -21,7 +21,6 @@ import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Call
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
-import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
 import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles.gdsFieldsetPageHeading
 
 case class AddressLookupConfigV2(version: Int = 2, options: JourneyOptions, labels: JourneyLabels)
@@ -30,8 +29,7 @@ object AddressLookupConfigV2 {
   implicit val format: OFormat[AddressLookupConfigV2] = Json.format[AddressLookupConfigV2]
 
   def apply(continue: Call, appConfig: AppConfig)(implicit
-    messagesApi: MessagesApi,
-    request: JourneyRequest[_]
+    messagesApi: MessagesApi
   ): AddressLookupConfigV2 = {
     val en: Messages = MessagesImpl(Lang("en"), messagesApi)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfirmation.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfirmation.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup
+
+import play.api.libs.json.{Json, OFormat}
+
+case class AddressLookupConfirmation(
+  auditRef: String,
+  id: Option[String],
+  address: AddressLookupAddress
+) {
+
+  // modified from the address-lookup-frontend, when it wants to split the address for manual edit
+  def extractAddressLines(): (String, Option[String], Option[String], String) = {
+    val l1: String         = this.address.lines.headOption.getOrElse("")
+    val l2: Option[String] = if (this.address.lines.length > 2) this.address.lines.lift(1) else None
+    val l3: Option[String] = if (this.address.lines.length > 3) this.address.lines.lift(2) else None
+    val l4: String =
+      if (this.address.lines.length > 1) this.address.lines.lastOption.getOrElse("") else ""
+    (l1, l2, l3, l4)
+  }
+
+}
+
+object AddressLookupConfirmation {
+  implicit val format: OFormat[AddressLookupConfirmation] = Json.format[AddressLookupConfirmation]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupOnRamp.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupOnRamp.scala
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.config
+package uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup
 
-object Features {
-  val isPreLaunch: String                = "isPreLaunch"
-  val isUkCompanyPrivateBeta: String     = "ukCompanyPrivateBeta"
-  val isGroupRegistrationEnabled: String = "isGroupRegistrationEnabled"
-  val isAddressLookupEnabled: String     = "isAddressLookupEnabled"
+import play.api.libs.json.{Json, Reads}
+
+case class AddressLookupOnRamp(redirectUrl: String)
+
+object AddressLookupOnRamp {
+  implicit val rds: Reads[AddressLookupOnRamp] = Json.reads[AddressLookupOnRamp]
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/MissingAddressIdException.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/MissingAddressIdException.scala
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.config
+package uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup
 
-object Features {
-  val isPreLaunch: String                = "isPreLaunch"
-  val isUkCompanyPrivateBeta: String     = "ukCompanyPrivateBeta"
-  val isGroupRegistrationEnabled: String = "isGroupRegistrationEnabled"
-  val isAddressLookupEnabled: String     = "isAddressLookupEnabled"
-}
+case class MissingAddressIdException()
+    extends RuntimeException("Address lookup called back without address id")

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/contact/address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/contact/address_page.scala.html
@@ -30,8 +30,9 @@
   govukInsetText: GovukInsetText,
   sectionHeader: sectionHeader,
   paragraphBody: paragraphBody,
-  saveButtons: saveButtons,
-  errorSummary: errorSummary
+  saveButton: saveAndContinue,
+  errorSummary: errorSummary,
+  link: link
 )
 
 @(form: Form[Address])(implicit request: JourneyRequest[_], messages: Messages)
@@ -93,6 +94,11 @@
             html = fieldSetBody
         ))
 
-        @saveButtons()
+
+        <div class="govuk-button-group">
+            @saveButton()
+            @link(messages("primaryContactDetails.address.lookup"), pptRoutes.ContactDetailsAddressController.initialise())
+        </div>
+
     }
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/main_template.scala.html
@@ -79,19 +79,19 @@
 
 @beforeContentBlock = {
     @phaseBanner("beta")
+    <div class="govuk-back-link-div">
+    @backButton.map(back =>
+        govukBackLink(BackLink(
+            content = HtmlContent(Html(s"""${back.title}<span class="govuk-visually-hidden">${back.hiddenText}</span>""")),
+            attributes = Map("id" -> "back-link"),
+            classes = "govuk-!-display-none-print",
+            href = back.call.url
+        ))
+    )
+    </div>
 }
 
 @content = {
-    <div class="govuk-back-link-div">
-        @backButton.map(back =>
-            govukBackLink(BackLink(
-                content = HtmlContent(Html(s"""${back.title}<span class="govuk-visually-hidden">${back.hiddenText}</span>""")),
-                attributes = Map("id" -> "back-link"),
-                classes = "govuk-!-display-none-print",
-                href = back.call.url
-            ))
-        )
-    </div>
     @contentBlock
     @hmrcReportTechnicalIssueHelper()
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -74,6 +74,8 @@ POST       /main-contact-telephone    uk.gov.hmrc.plasticpackagingtax.registrati
 GET        /confirm-contact-address     uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.ContactDetailsConfirmAddressController.displayPage()
 POST       /confirm-contact-address     uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.ContactDetailsConfirmAddressController.submit()
 
+GET        /enter-contact-address-initialise    uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.ContactDetailsAddressController.initialise()
+GET        /enter-contact-address-update    uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.ContactDetailsAddressController.update(id: Option[String])
 GET        /enter-contact-address    uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.ContactDetailsAddressController.displayPage()
 POST       /enter-contact-address    uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.ContactDetailsAddressController.submit()
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,7 +119,12 @@ microservice {
       port = 9891
       url = "http://localhost:9891"
       enabled = true
-	}
+    }
+
+    address-lookup-frontend {
+      host = localhost
+      port = 9028
+    }
   }
 }
 
@@ -200,6 +205,7 @@ features {
   isPreLaunch = false
   ukCompanyPrivateBeta = true
   isGroupRegistrationEnabled = false
+  isAddressLookupEnabled = false
 }
 
 # User Specific Feature Flags
@@ -210,6 +216,7 @@ allowedUsers = [
         isPreLaunch = true,
         ukCompanyPrivateBeta = false,
         isGroupRegistrationEnabled = false
+        isAddressLookupEnabled = true
       }
     },
     {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -192,6 +192,7 @@ primaryContactDetails.address.townOrCity.format.error = Enter a town or city in 
 primaryContactDetails.address.postCode = Postcode
 primaryContactDetails.address.postCode.empty.error = Enter a postcode
 primaryContactDetails.address.postCode.format.error = Enter a postcode in the correct format. For example, AB1 2CD
+primaryContactDetails.address.lookup = Search for a new address
 
 primaryContactDetails.check.meta.title = Check the main contact’s details
 primaryContactDetails.check.title = Check your answers

--- a/test/base/it/ConnectorISpec.scala
+++ b/test/base/it/ConnectorISpec.scala
@@ -43,7 +43,9 @@ class ConnectorISpec
         "microservice.services.partnership-identification-frontend.host"         -> wireHost,
         "microservice.services.partnership-identification-frontend.port"         -> wirePort,
         "microservice.services.email-verification.host"                          -> wireHost,
-        "microservice.services.email-verification.port"                          -> wirePort
+        "microservice.services.email-verification.port"                          -> wirePort,
+        "microservice.services.address-lookup-frontend.host"                     -> wireHost,
+        "microservice.services.address-lookup-frontend.port"                     -> wirePort
     )
 
   override def fakeApplication(): Application = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnectorISpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnectorISpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup
+
+import base.Injector
+import base.it.ConnectorISpec
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, post}
+import org.scalatest.concurrent.ScalaFutures
+import play.api.http.HeaderNames.LOCATION
+import play.api.http.Status
+import play.api.test.Helpers.await
+import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup._
+
+class AddressLookupFrontendConnectorISpec extends ConnectorISpec with Injector with ScalaFutures {
+
+  lazy val connector: AddressLookupFrontendConnector =
+    app.injector.instanceOf[AddressLookupFrontendConnector]
+
+  val initialiseRequest = AddressLookupConfigV2(
+    options =
+      JourneyOptions(continueUrl = "/continue", signOutHref = "/signout", serviceHref = "/service"),
+    labels = JourneyLabels(en = LanguageLabels(appLevelLabels = AppLevelLabels(navTitle = "Title")))
+  )
+
+  "address lookup" should {
+
+    "call initialise" in {
+
+      givenInitialiseSuccess("/on-ramp")
+
+      val res = await(connector.initialiseJourney(initialiseRequest))
+
+      res.redirectUrl mustBe "/on-ramp"
+      getTimer("ppt.addresslookup.initialise.timer").getCount mustBe 1
+    }
+
+    "get address" in {
+
+      givenGetAddressSuccess("12345")
+
+      val res = await(connector.getAddress("12345"))
+
+      res.address.postcode mustBe Some("ZZ1 1ZZ")
+      getTimer("ppt.addresslookup.getaddress.timer").getCount mustBe 1
+    }
+
+  }
+
+  private def givenInitialiseSuccess(onRamp: String) =
+    stubFor(
+      post("/api/init")
+        .willReturn(
+          aResponse()
+            .withStatus(Status.ACCEPTED)
+            .withHeader(LOCATION, onRamp)
+        )
+    )
+
+  private def givenGetAddressSuccess(id: String) =
+    stubFor(
+      get(s"/api/confirmed?id=$id")
+        .willReturn(
+          aResponse()
+            .withStatus(Status.OK)
+            .withBody("""
+                |{
+                |    "auditRef" : "bed4bd24-72da-42a7-9338-f43431b7ed72",
+                |    "id" : "GB990091234524",
+                |    "address" : {
+                |        "lines" : [ "10 Other Place", "Some District", "Anytown" ],
+                |        "postcode" : "ZZ1 1ZZ",
+                |        "country" : {
+                |            "code" : "GB",
+                |            "name" : "United Kingdom"
+                |        }
+                |    }
+                |}
+                |""".stripMargin)
+        )
+    )
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/contact/AddressSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/contact/AddressSpec.scala
@@ -27,6 +27,10 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address.{
   postCode,
   townOrCity
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup.{
+  AddressLookupAddress,
+  AddressLookupConfirmation
+}
 
 class AddressSpec extends AnyWordSpec with Matchers with CommonTestUtils {
   "Address validation rules" should {
@@ -116,6 +120,44 @@ class AddressSpec extends AnyWordSpec with Matchers with CommonTestUtils {
           Seq(FormError(postCode, "primaryContactDetails.address.postCode.format.error"))
 
         testFailedValidationErrors(input, expectedErrors)
+      }
+    }
+
+    "be created from AddressLookupConfirmation" when {
+
+      def addressLookupConfirmation(lines: List[String], postcode: Option[String] = None) =
+        AddressLookupConfirmation(
+          auditRef = "ref",
+          id = Some("id"),
+          address = AddressLookupAddress(lines = lines, postcode = postcode, country = None)
+        )
+
+      "four address lines and a postcode are returned" in {
+        val address = Address(
+          addressLookupConfirmation(List("line1", "line2", "line3", "town"), Some("postCode"))
+        )
+        address.addressLine1 mustBe "line1"
+        address.addressLine2 mustBe "line2"
+        address.addressLine3 mustBe Some("line3")
+        address.townOrCity mustBe "town"
+        address.postCode mustBe "postCode"
+      }
+
+      "three address lines are returned" in {
+        val address = Address(addressLookupConfirmation(List("line1", "line2", "town")))
+        address.addressLine1 mustBe "line1"
+        address.addressLine2 mustBe "line2"
+        address.addressLine3 mustBe None
+        address.townOrCity mustBe "town"
+      }
+
+      "two address lines (and no postcode) are returned" in {
+        val address = Address(addressLookupConfirmation(List("line1", "town")))
+        address.addressLine1 mustBe "line1"
+        address.addressLine2 mustBe ""
+        address.addressLine3 mustBe None
+        address.townOrCity mustBe "town"
+        address.postCode mustBe ""
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfirmationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfirmationSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AddressLookupConfirmationSpec extends AnyWordSpec with Matchers {
+
+  "AddressLookupConfirmation" should {
+
+    def addressLookupConfirmation(lines: List[String]) =
+      AddressLookupConfirmation(
+        auditRef = "ref",
+        id = Some("id"),
+        address = AddressLookupAddress(lines = lines, postcode = Some("postcode"), country = None)
+      )
+
+    "extract address lines" when {
+
+      "four address lines are returned" in {
+        val confirmation = addressLookupConfirmation(List("line1", "line2", "line3", "line4"))
+        confirmation.extractAddressLines() mustBe (("line1", Some("line2"), Some("line3"), "line4"))
+      }
+
+      "three address lines are returned" in {
+        val confirmation = addressLookupConfirmation(List("line1", "line2", "line3"))
+        confirmation.extractAddressLines() mustBe (("line1", Some("line2"), None, "line3"))
+      }
+
+      "two address lines are returned" in {
+        val confirmation = addressLookupConfirmation(List("line1", "line2"))
+        confirmation.extractAddressLines() mustBe (("line1", None, None, "line2"))
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
@@ -59,15 +59,13 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
 
   private val page = instanceOf[review_registration_page]
 
-  private val registration = aRegistration()
-
   private val liabilitySection      = 0
   private val organisationSection   = 1
   private val contactDetailsSection = 2
 
   private val liabilityStartLink = Call("GET", "/liabilityStartLink")
 
-  private def createView(reg: Registration = registration): Document =
+  private def createView(reg: Registration): Document =
     page(reg, liabilityStartLink)(journeyRequest, messages)
 
   "Review registration View" should {
@@ -476,6 +474,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
   }
 
   override def exerciseGeneratedRenderingMethods() = {
+    val registration = aRegistration()
     page.f(registration, liabilityStartLink)(journeyRequest, messages)
     page.render(registration, liabilityStartLink, journeyRequest, messages)
   }


### PR DESCRIPTION
Integrate with address lookup frontend to collect contact address

Requires 
Service manager - https://github.com/hmrc/service-manager-config/pull/3956

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
