### PR TITLE
PPTP-1489 - case-insentive allow list checking

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AllowedUsers.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AllowedUsers.scala
@@ -24,7 +24,9 @@ import javax.inject.Provider
 
 @ProvidedBy(classOf[AllowedUsersProvider])
 class AllowedUsers(users: Seq[AllowedUser]) {
-  def isAllowed(email: String): Boolean = users.isEmpty || users.exists(user => user.email == email)
+
+  def isAllowed(email: String): Boolean =
+    users.isEmpty || users.exists(user => user.email.equalsIgnoreCase(email))
 
   def getUserFeatures(email: String): Option[Map[String, Boolean]] =
     users.find(_.email == email).map(_.features)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AllowedUsers.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AllowedUsers.scala
@@ -17,19 +17,18 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions
 
 import com.google.inject.{Inject, ProvidedBy}
+import javax.inject.Provider
 import play.api.Configuration
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AllowedUser
-
-import javax.inject.Provider
 
 @ProvidedBy(classOf[AllowedUsersProvider])
 class AllowedUsers(users: Seq[AllowedUser]) {
 
   def isAllowed(email: String): Boolean =
-    users.isEmpty || users.exists(user => user.email.equalsIgnoreCase(email))
+    users.isEmpty || users.exists(_.email.equalsIgnoreCase(email))
 
   def getUserFeatures(email: String): Option[Map[String, Boolean]] =
-    users.find(_.email == email).map(_.features)
+    users.find(_.email.equalsIgnoreCase(email)).map(_.features)
 
 }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AllowedUsersSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AllowedUsersSpec.scala
@@ -34,12 +34,25 @@ class AllowedUsersSpec extends AnyWordSpec with Matchers with MockitoSugar {
       }
     }
     "has elements" should {
-      val emailAllowedList = new AllowedUsers(Seq(AllowedUser(email = testEmail1)))
+      val emailAllowedList = new AllowedUsers(
+        Seq(AllowedUser(email = testEmail1, features = Map("someFeature" -> true)))
+      )
       "allow listed email" in {
         emailAllowedList.isAllowed(testEmail1) mustBe true
+        val features = emailAllowedList.getUserFeatures(testEmail1).get
+        features.get("someFeature") mustBe Some(true)
+        features.get("someOtherFeature") mustBe None
+      }
+      "allow listed email with different case" in {
+        val email = testEmail1.toUpperCase
+        emailAllowedList.isAllowed(email) mustBe true
+        val features = emailAllowedList.getUserFeatures(email).get
+        features.get("someFeature") mustBe Some(true)
+        features.get("someOtherFeature") mustBe None
       }
       "disallow not listed email" in {
         emailAllowedList.isAllowed(testEmail2) mustBe false
+        emailAllowedList.getUserFeatures(testEmail2) mustBe None
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -77,6 +77,19 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       ) mustBe Results.Ok
     }
 
+    "process request when use email number is allowed with different case" in {
+      val allowedEmail = "Amina@HMRC.co.uk"
+      val user         = PptTestData.newUser("123")
+      authorizedUser(user)
+
+      await(
+        createAuthAction(new AllowedUsers(Seq(AllowedUser(email = allowedEmail)))).invokeBlock(
+          authRequest(Headers(), user),
+          okResponseGenerator
+        )
+      ) mustBe Results.Ok
+    }
+
     "redirect to unauthorised page when user email is not allowed" in {
       val user = PptTestData.newUser("123")
       authorizedUser(user)


### PR DESCRIPTION
Change to case-insensitive check for email address on allow list

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
