### PR TITLE
BAU - hide address lookup link when feature not enabled

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/contact/address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/contact/address_page.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.countryCodeAutoComplete
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
+@import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
 
 @this(
   formHelper: FormWithCSRF,
@@ -123,7 +124,9 @@
 
         <div class="govuk-button-group">
             @saveButton()
-            @link(messages("primaryContactDetails.address.lookup"), pptRoutes.ContactDetailsAddressController.initialise())
+            @if(request.isFeatureFlagEnabled(Features.isAddressLookupEnabled)) {
+                @link(text = messages("primaryContactDetails.address.lookup"), call = pptRoutes.ContactDetailsAddressController.initialise(), id = Some("address-lookup-start"))
+            }
         </div>
 
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/contact/ContactDetailsAddressViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/contact/ContactDetailsAddressViewSpec.scala
@@ -20,6 +20,7 @@ import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
 import play.api.data.Form
+import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact.{routes => contactRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.services.CountryService
@@ -32,8 +33,11 @@ class ContactDetailsAddressViewSpec extends UnitViewSpec with Matchers {
   private val page           = instanceOf[address_page]
   private val countryService = instanceOf[CountryService]
 
-  private def createView(form: Form[Address] = Address.form()): Document =
-    page(form, countryService.getAll())(journeyRequest, messages)
+  private def createView(
+    form: Form[Address] = Address.form(),
+    userFeatureFlags: Map[String, Boolean] = Map.empty
+  ): Document =
+    page(form, countryService.getAll())(generateRequest(userFeatureFlags), messages)
 
   "Address View" should {
 
@@ -102,6 +106,22 @@ class ContactDetailsAddressViewSpec extends UnitViewSpec with Matchers {
 
       view must containElementWithID("submit")
       view.getElementById("submit").text() mustBe "Save and continue"
+    }
+
+    "'search for new address' link" when {
+
+      "address lookup is disabled" in {
+        view must not(containElementWithID("address-lookup-start"))
+      }
+
+      "address lookup is enabled" in {
+        val view = createView(userFeatureFlags = Map(Features.isAddressLookupEnabled -> true))
+
+        view must containElementWithID("address-lookup-start")
+        view.getElementById("address-lookup-start").text() mustBe messages(
+          "primaryContactDetails.address.lookup"
+        )
+      }
     }
 
   }


### PR DESCRIPTION
"Search for another address" link should only be visible when address lookup feature is enabled

Enabled - 
![image](https://user-images.githubusercontent.com/46934286/143414082-ca41794f-df7b-4854-89b6-4f1dbcbcec68.png)


Not Enabled - 
![image](https://user-images.githubusercontent.com/46934286/143413942-78b448d9-f804-4d48-b270-bf77e1b8934a.png)


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
