### PR TITLE
PPTP-1432 - Groups - 7B. Errors - Organisation already added to group

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorController.scala
@@ -16,26 +16,38 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 
+import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.nominated_organisation_already_registered_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.{
+  nominated_organisation_already_registered_page,
+  organisation_already_in_group_page
+}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-
-import javax.inject.{Inject, Singleton}
 
 @Singleton
 class NotableErrorController @Inject() (
   authenticate: AuthAction,
   journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
-  nominatedOrganisationAlreadyRegisteredPage: nominated_organisation_already_registered_page
+  nominatedOrganisationAlreadyRegisteredPage: nominated_organisation_already_registered_page,
+  organisationAlreadyInGroupPage: organisation_already_in_group_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def nominatedOrganisationAlreadyRegistered(): Action[AnyContent] =
     (authenticate andThen journeyAction) { implicit request =>
       Ok(nominatedOrganisationAlreadyRegisteredPage())
+    }
+
+  def organisationAlreadyInGroup(): Action[AnyContent] =
+    (authenticate andThen journeyAction) { implicit request =>
+      request.registration.groupDetail.flatMap(_.groupError) match {
+        case Some(groupError) => Ok(organisationAlreadyInGroupPage(groupError))
+        case _                => Redirect(groupRoutes.OrganisationListController.displayPage())
+      }
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/GroupDetail.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/GroupDetail.scala
@@ -18,13 +18,17 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType.OrgType
-import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupMember
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.{
+  GroupError,
+  GroupMember
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 case class GroupDetail(
   membersUnderGroupControl: Option[Boolean] = None,
   members: Seq[GroupMember] = Seq.empty,
-  currentMemberOrganisationType: Option[OrgType] = None
+  currentMemberOrganisationType: Option[OrgType] = None,
+  groupError: Option[GroupError] = None
 ) {
 
   def status: TaskStatus =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/group/GroupError.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/group/GroupError.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group
+
+import play.api.libs.json.{Format, Json, OFormat, Reads, Writes}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupErrorType.GroupErrorType
+
+object GroupErrorType extends Enumeration {
+  type GroupErrorType = Value
+  val MEMBER_IN_GROUP: Value     = Value("MEMBER_IN_GROUP")
+  val MEMBER_IS_NOMINATED: Value = Value("MEMBER_IS_NOMINATED")
+
+  implicit def value(errorType: GroupErrorType): String = errorType.toString
+
+  implicit val format: Format[GroupErrorType] =
+    Format(Reads.enumNameReads(GroupErrorType), Writes.enumNameWrites)
+
+}
+
+case class GroupError(errorType: GroupErrorType, memberName: String)
+
+object GroupError {
+  implicit val format: OFormat[GroupError] = Json.format[GroupError]
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/group/organisation_already_in_group_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/group/organisation_already_in_group_page.scala.html
@@ -1,0 +1,53 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupError
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupErrorType
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
+
+@this(
+        govukLayout: main_template,
+        pageHeading: pageHeading,
+        paragraphBody: paragraphBody,
+        paragraph: paragraph,
+        link:link
+)
+
+@(groupError: GroupError)(implicit request: JourneyRequest[_], messages: Messages)
+
+
+@errorDetails =@{
+  groupError.errorType match {
+      case GroupErrorType.MEMBER_IN_GROUP =>  messages("organisation.already.in.group.detail.member", groupError.memberName)
+      case GroupErrorType.MEMBER_IS_NOMINATED =>  messages("organisation.already.in.group.detail.nominated", groupError.memberName)
+  }
+}
+
+@govukLayout(title = Title("organisation.already.in.group.title", groupError.memberName)) {
+    @pageHeading(text = messages("organisation.already.in.group.title", groupError.memberName))
+    @paragraphBody(message = errorDetails)
+    @paragraph{
+        @link(
+            text = messages("site.button.saveAndContinue"),
+            call = groupRoutes.OrganisationListController.displayPage(),
+            classes = "govuk-button"
+        )
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -134,4 +134,5 @@ POST       /enrolment-security        uk.gov.hmrc.plasticpackagingtax.registrati
 GET        /enrolment-reference-number-already-used     uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment.NotableErrorController.enrolmentReferenceNumberAlreadyUsedPage()
 
 GET        /group-nominated-organisation-already-registered    uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.NotableErrorController.nominatedOrganisationAlreadyRegistered()
+GET        /organisation-already-in-group    uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.NotableErrorController.organisationAlreadyInGroup()
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -411,6 +411,10 @@ enrolment.referenceNumber.already.used.button = Back to your business tax accoun
 
 nominated.organisation.already.registered.title = You cannot set up a new group
 nominated.organisation.already.registered.detail1 = {0} has already registered for PPT, either as a single organisation or as part of a group.
-nominated.organisation.already.registered.detail2 = To set up a new group, you'll need to de-register for PPT first.
+nominated.organisation.already.registered.detail2 = To set up a new group, you’ll need to de-register for PPT first.
 nominated.organisation.already.registered.detail3 = You could also set up a {0}.
 nominated.organisation.already.registered.detail3.link.text = new group with a different nominated organisation
+
+organisation.already.in.group.title = {0} cannot be added to the group again
+organisation.already.in.group.detail.member = You’ve already added {0} to the group.
+organisation.already.in.group.detail.nominated = The nominated organisation {0} is already in the group.

--- a/tampermonkey/PPT_AutoComplete.js
+++ b/tampermonkey/PPT_AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PPT Registration AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      15.0
+// @version      15.1
 // @description
 // @author       pmonteiro
 // @match        http*://*/register-for-plastic-packaging-tax*
@@ -77,9 +77,10 @@ function createAutoCompleteCheckbox() {
 
     let panel = document.createElement("div");
     panel.appendChild(chkBox);
-    let span = document.createElement("span");
-    span.innerText = "Auto complete";
-    panel.appendChild(span);
+    let label = document.createElement("label");
+    label.innerText = "Auto complete";
+    label.setAttribute("for", "autoComplete");
+    panel.appendChild(label);
 
     panel.style.position = 'absolute'
     panel.style.top = '100px'

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorControllerSpec.scala
@@ -20,10 +20,17 @@ import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import play.api.http.Status.OK
-import play.api.test.Helpers.{contentAsString, status}
+import play.api.http.Status.{OK, SEE_OTHER}
+import play.api.test.Helpers.{contentAsString, redirectLocation, status}
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.nominated_organisation_already_registered_page
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.GroupDetail
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupError
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupErrorType.MEMBER_IN_GROUP
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.{
+  nominated_organisation_already_registered_page,
+  organisation_already_in_group_page
+}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 class NotableErrorControllerSpec extends ControllerSpec {
@@ -33,12 +40,15 @@ class NotableErrorControllerSpec extends ControllerSpec {
   private val nominatedOrganisationAlreadyRegisteredPage =
     mock[nominated_organisation_already_registered_page]
 
+  private val organisationAlreadyInGroupPage = mock[organisation_already_in_group_page]
+
   private val controller =
     new NotableErrorController(authenticate = mockAuthAction,
                                mockJourneyAction,
                                mcc = mcc,
                                nominatedOrganisationAlreadyRegisteredPage =
-                                 nominatedOrganisationAlreadyRegisteredPage
+                                 nominatedOrganisationAlreadyRegisteredPage,
+                               organisationAlreadyInGroupPage = organisationAlreadyInGroupPage
     )
 
   override protected def beforeEach(): Unit = {
@@ -46,9 +56,12 @@ class NotableErrorControllerSpec extends ControllerSpec {
     when(nominatedOrganisationAlreadyRegisteredPage.apply()(any(), any())).thenReturn(
       HtmlFormat.raw("error nominated organisation already been registered")
     )
+    when(organisationAlreadyInGroupPage.apply(any())(any(), any())).thenReturn(
+      HtmlFormat.raw("error organisation already in group")
+    )
   }
 
-  "NotableErrorController" should {
+  "NotableErrorController nominatedOrganisationAlreadyRegistered" should {
 
     "present nominated organisation already been registered page" in {
       authorizedUser()
@@ -56,6 +69,36 @@ class NotableErrorControllerSpec extends ControllerSpec {
 
       status(resp) mustBe OK
       contentAsString(resp) mustBe "error nominated organisation already been registered"
+    }
+  }
+
+  "NotableErrorController organisationAlreadyInGroup" should {
+
+    "present organisation already in group page" when {
+      "registration has group error" in {
+        authorizedUser()
+        val registration = aRegistration(
+          withGroupDetail(
+            Some(GroupDetail(groupError = Some(GroupError(MEMBER_IN_GROUP, "Member Name"))))
+          )
+        )
+        mockRegistrationFind(registration)
+
+        val resp = controller.organisationAlreadyInGroup()(getRequest())
+
+        status(resp) mustBe OK
+        contentAsString(resp) mustBe "error organisation already in group"
+      }
+    }
+
+    "redirect to organisation list" when {
+      "registration does not have group error" in {
+        authorizedUser()
+        val resp = controller.organisationAlreadyInGroup()(getRequest())
+
+        status(resp) mustBe SEE_OTHER
+        redirectLocation(resp) mustBe Some(groupRoutes.OrganisationListController.displayPage().url)
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/group/OrganisationAlreadyInGroupViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/group/OrganisationAlreadyInGroupViewSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.group
+
+import base.unit.UnitViewSpec
+import org.scalatest.matchers.must.Matchers
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupError
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupErrorType.{
+  MEMBER_IN_GROUP,
+  MEMBER_IS_NOMINATED
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.organisation_already_in_group_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class OrganisationAlreadyInGroupViewSpec extends UnitViewSpec with Matchers {
+
+  private val page: organisation_already_in_group_page =
+    instanceOf[organisation_already_in_group_page]
+
+  private val groupError = GroupError(MEMBER_IN_GROUP, "Member Name")
+
+  private def createView(groupError: GroupError = groupError): Html =
+    page(groupError)(journeyRequest, messages)
+
+  "Organisation Already In Group Page" should {
+
+    val view: Html = createView()
+
+    "display title" in {
+      view.select("title").text() must include(
+        messages("organisation.already.in.group.title", "Member Name")
+      )
+    }
+
+    "display heading" in {
+      view.select("h1").text() must include(
+        messages("organisation.already.in.group.title", "Member Name")
+      )
+    }
+
+    "display save and continue link-button" in {
+      view.select("a.govuk-button").text() must include(messages("site.button.saveAndContinue"))
+      view.select("a.govuk-button").first() must haveHref(
+        groupRoutes.OrganisationListController.displayPage()
+      )
+    }
+
+    "display detail" when {
+      "nominated member is already group" in {
+        val view = createView(GroupError(MEMBER_IS_NOMINATED, "Nominated Member"))
+        view.select("p.govuk-body").text() must include(
+          messages("organisation.already.in.group.detail.nominated", "Nominated Member")
+        )
+      }
+
+      "member is already group" in {
+        val view = createView(GroupError(MEMBER_IN_GROUP, "Member"))
+        view.select("p.govuk-body").text() must include(
+          messages("organisation.already.in.group.detail.member", "Member")
+        )
+      }
+    }
+
+  }
+
+  override def exerciseGeneratedRenderingMethods() = {
+    page.f(groupError)(journeyRequest, messages)
+    page.render(groupError, journeyRequest, messages)
+  }
+
+}


### PR DESCRIPTION
Two error pages added
- member is already in group (as a member)
- member is already in group (as nominated org)

Refactored GroupMemberGrsController so that
- problems adding a new member are returned as a Left(GroupError) 
- registration with added member is not saved until it has been verified as valid (will apply to next ticket - member is already subscribed (DUPLICATE_SUBSCRIPTION))

Requires BE change - https://github.com/hmrc/plastic-packaging-tax-registration/pull/101

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave


![image](https://user-images.githubusercontent.com/46934286/143764680-3c37058c-40f9-48b9-bef9-3ccef44471c6.png)


![image](https://user-images.githubusercontent.com/46934286/143764709-c09ce454-a8d3-4dfa-b6e0-c9535c44799e.png)
