### PR TITLE
PPTP-1540 : Amend Registration - Part I

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/AppConfig.scala
@@ -32,11 +32,12 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.config
 
-import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import play.api.mvc.Call
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesConfig) {
@@ -141,6 +142,9 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   def pptSubscriptionStatusUrl(safeNumber: String): String =
     s"$pptSubscriptionsUrl/status/$safeNumber"
+
+  def pptSubscriptionGetUrl(pptReference: String): String =
+    s"$pptSubscriptionsUrl/$pptReference"
 
   def pptSubscriptionCreateUrl(safeNumber: String): String =
     s"$pptSubscriptionsUrl/$safeNumber"

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/SubscriptionsConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/SubscriptionsConnector.scala
@@ -64,6 +64,22 @@ class SubscriptionsConnector @Inject() (
       }
   }
 
+  def getSubscription(pptReference: String)(implicit hc: HeaderCarrier): Future[Registration] = {
+    val timer = metrics.defaultRegistry.timer("ppt.subscription.get.timer").time()
+    httpClient.GET[Registration](config.pptSubscriptionGetUrl(pptReference))
+      .andThen { case _ => timer.stop() }
+      .andThen {
+        case Success(registration) =>
+          logger.info(s"Successfully obtained PPT subscription for pptReference [$pptReference]")
+          registration
+        case Failure(exception) =>
+          throw new Exception(
+            s"Failed to obtain PPT subscription for pptReference [$pptReference] due to [${exception.getMessage}]",
+            exception
+          )
+      }
+  }
+
   def submitSubscription(safeId: String, payload: Registration)(implicit
     hc: HeaderCarrier
   ): Future[SubscriptionCreateResponse] = {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -22,12 +22,13 @@ import play.api.Logger
 import play.api.mvc.Results.Redirect
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{agentCode, _}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
+import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{
   AuthenticatedRequest,
   IdentityData
@@ -139,7 +140,7 @@ abstract class AuthActionBase @Inject() (
     email: String,
     allEnrolments: Enrolments
   ) =
-    if (checkAlreadyEnrolled && allEnrolments.getEnrolment("HMRC-PPT-ORG").isDefined)
+    if (checkAlreadyEnrolled && allEnrolments.getEnrolment(PptEnrolment.Identifier).isDefined)
       Future.successful(Results.Redirect(appConfig.pptAccountUrl))
     else if (allowedUsers.isAllowed(email))
       block(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment
+
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.amend_registration_page
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class AmendRegistrationController @Inject() (
+  authenticate: AuthNoEnrolmentCheckAction,
+  mcc: MessagesControllerComponents,
+  amendmentJourneyAction: AmendmentJourneyAction,
+  amendRegistrationPage: amend_registration_page
+) extends FrontendController(mcc) with I18nSupport {
+
+  def displayPage(): Action[AnyContent] =
+    (authenticate andThen amendmentJourneyAction) { implicit request =>
+      Ok(amendRegistrationPage(request.registration))
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/enrolment/PptEnrolment.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/enrolment/PptEnrolment.scala
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.models.request
+package uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment
 
-import play.api.mvc.{Request, WrappedRequest}
-import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
-import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
-
-class AuthenticatedRequest[+A](request: Request[A], val user: SignedInUser)
-    extends WrappedRequest[A](request) {
-
-  def pptReference: Option[String] =
-    user.enrolments.getEnrolment(PptEnrolment.Identifier).flatMap(
-      enrolment => enrolment.getIdentifier(PptEnrolment.Key)
-    ).map(id => id.value)
-
+object PptEnrolment {
+  val Identifier = "HMRC-PPT-ORG"
+  val Key        = "EtmpRegistrationNumber"
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
@@ -19,11 +19,6 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType.{GROUP, RegType}
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.{
-  OrgType,
-  PartnershipTypeEnum
-}
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnershipTypeEnum.PartnershipTypeEnum
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 
 case class Registration(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyAction.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.request
+
+import play.api.Logger
+import play.api.mvc.{ActionRefiner, Result}
+import uk.gov.hmrc.auth.core.InsufficientEnrolments
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.SubscriptionsConnector
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AmendmentJourneyAction @Inject() (
+  appConfig: AppConfig,
+  subscriptionsConnector: SubscriptionsConnector
+)(implicit val exec: ExecutionContext)
+    extends ActionRefiner[AuthenticatedRequest, JourneyRequest] {
+
+  private val logger = Logger(this.getClass)
+
+  override protected def refine[A](
+    request: AuthenticatedRequest[A]
+  ): Future[Either[Result, JourneyRequest[A]]] = {
+    implicit val hc: HeaderCarrier =
+      HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+    request.user.identityData.internalId.filter(_.trim.nonEmpty) match {
+      case Some(_) =>
+        request.pptReference match {
+          case Some(pptReference) =>
+            subscriptionsConnector.getSubscription(pptReference).map { registration =>
+              Right(new JourneyRequest[A](request, registration, appConfig))
+            }
+          case _ => throw InsufficientEnrolments()
+        }
+      case None =>
+        logger.warn(s"Enrolment not present, throwing")
+        throw InsufficientEnrolments()
+    }
+  }
+
+  override protected def executionContext: ExecutionContext = exec
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyAction.scala
@@ -47,10 +47,14 @@ class AmendmentJourneyAction @Inject() (
             subscriptionsConnector.getSubscription(pptReference).map { registration =>
               Right(new JourneyRequest[A](request, registration, appConfig))
             }
-          case _ => throw InsufficientEnrolments()
+          case _ =>
+            logger.warn(
+              s"Denied attempt to access ${request.uri} since user ppt enrolment not present"
+            )
+            throw InsufficientEnrolments()
         }
       case None =>
-        logger.warn(s"Enrolment not present, throwing")
+        logger.warn(s"Denied attempt to access ${request.uri} since user internal id not present")
         throw InsufficientEnrolments()
     }
   }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyAction.scala
@@ -50,7 +50,7 @@ class JourneyAction @Inject() (
           case Left(error) => throw error
         }
       case None =>
-        logger.warn(s"Enrolment not present, throwing")
+        logger.warn(s"Denied attempt to access ${request.uri} since user internal id not present")
         throw InsufficientEnrolments()
     }
   }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/amend_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/amend_registration_page.scala.html
@@ -20,7 +20,8 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
-@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.review._
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.amendment.primaryContactDetails
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.review.{groupMemberListDetails, liabilityDetails, organisationDetails}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
 
 @this(
@@ -32,36 +33,28 @@
         paragraphBody: paragraphBody,
         subHeading: subHeading,
         appConfig: AppConfig,
-        liabilityDetails: liabilityDetails,
         organisationDetails: organisationDetails,
         groupMemberListDetails: groupMemberListDetails,
         primaryContactDetails: primaryContactDetails
 )
 
 @(
-        registration: Registration,
-        liabilityStartLink: Call,
+        registration: Registration
 )(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
 @govukLayout(
-    title = Title("reviewRegistration.organisationDetails.title"),
-    backButton = Some(BackButton(messages("site.back"), pptRoutes.TaskListController.displayPage(), messages("site.back.hiddenText")))) {
+    title = Title("amendRegistration.organisationDetails.title"),
+    backButton = Some(BackButton(messages("site.back"), Call("GET", appConfig.pptAccountUrl), messages("site.back.hiddenText")))) {
 
-    @pageHeading(messages("reviewRegistration.organisationDetails.title"))
+    @pageHeading(messages("amendRegistration.organisationDetails.title"))
 
     @formHelper(action = pptRoutes.ReviewRegistrationController.submit(), 'autoComplete -> "off") {
 
-        @liabilityDetails(registration.liabilityDetails, Some(liabilityStartLink), registration.registrationType, registration.groupDetail)
         @organisationDetails(registration.organisationDetails, registration.registrationType)
         @primaryContactDetails(registration.primaryContactDetails)
 
         @if(registration.registrationType.contains(GROUP)) {
             @groupMemberListDetails(registration.groupDetail.get)
         }
-
-        @subHeading(messages("reviewRegistration.sendYourApplication.title"))
-        @paragraphBody(messages("reviewRegistration.sendYourApplication.body"))
-
-        @saveAndContinue("site.button.acceptAndSend")
     }
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/amendment/primaryContactDetails.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/amendment/primaryContactDetails.scala.html
@@ -1,0 +1,40 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.PrimaryContactDetails
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.subHeading
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.utils.ViewUtils
+
+@this(
+        subHeading: subHeading,
+        govukSummaryList: GovukSummaryList,
+        viewUtils: ViewUtils
+)
+
+@(primaryContactDetails: PrimaryContactDetails)(implicit request: Request[_], messages: Messages)
+
+@subHeading(messages("primaryContactDetails.check.label"))
+@govukSummaryList(
+    SummaryList(
+        rows = Seq(
+            viewUtils.summaryListRow("primaryContactDetails.check.fullName", primaryContactDetails.name, None),
+            viewUtils.summaryListRow("primaryContactDetails.check.jobTitle", primaryContactDetails.jobTitle, None),
+            viewUtils.summaryListRow("primaryContactDetails.check.email", primaryContactDetails.email, None),
+            viewUtils.summaryListRow("primaryContactDetails.check.phoneNumber", primaryContactDetails.phoneNumber, None),
+            viewUtils.summaryListRow("primaryContactDetails.check.address", primaryContactDetails.address.map(viewUtils.extractAddress), None)
+        ).filterNot(_.value.content == Empty)
+    )
+)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/review/liabilityDetails.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/review/liabilityDetails.scala.html
@@ -32,7 +32,7 @@
 
 @(
         liabilityDetails: LiabilityDetails,
-        liabilityStartLink: Call,
+        liabilityStartLink: Option[Call] = None,
         registrationType: Option[RegType] = None,
         groupDetails: Option[GroupDetail] = None
 )(implicit request: JourneyRequest[_], messages: Messages)
@@ -47,7 +47,7 @@
                 Text(liabilityDetails.weight.map(_.totalKg.getOrElse(0) + " kg").getOrElse(""))
             }
         ),
-        call = Some(liabilityStartLink)
+        call = liabilityStartLink
     )
 }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -137,3 +137,6 @@ GET        /group-nominated-organisation-already-registered    uk.gov.hmrc.plast
 GET        /organisation-already-in-group    uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.NotableErrorController.organisationAlreadyInGroup()
 GET        /group-organisation-already-registered    uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.NotableErrorController.groupMemberAlreadyRegistered()
 
+# Registration Amendment
+
+GET        /amend-registration      uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.AmendRegistrationController.displayPage()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -422,3 +422,5 @@ organisation.already.in.group.detail.nominated = The nominated organisation {0} 
 group.member.already.registered.title = You cannot add {0} to the group
 group.member.already.registered.detail1 = {0} has already registered for PPT, so cannot be added to the group.
 group.member.already.registered.detail2 = {0} will need to de-register for PPT before you can add them to the group.
+
+amendRegistration.organisationDetails.title = Your business details

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -70,6 +70,9 @@ trait ControllerSpec
   ): AuthenticatedRequest[AnyContentAsEmpty.type] =
     new AuthenticatedRequest(FakeRequest().withHeaders(headers), user)
 
+  def authRequest[A](fakeRequest: FakeRequest[A], user: SignedInUser) =
+    new AuthenticatedRequest(fakeRequest, user)
+
   protected def viewOf(result: Future[Result]): Html = Html(contentAsString(result))
 
   protected def postRequest(body: JsValue): Request[AnyContentAsJson] =

--- a/test/base/unit/MockAmendmentJourneyAction.scala
+++ b/test/base/unit/MockAmendmentJourneyAction.scala
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.models.request
+package base.unit
 
-import play.api.mvc.{Request, WrappedRequest}
-import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
-import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
+import base.MockAuthAction
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 
-class AuthenticatedRequest[+A](request: Request[A], val user: SignedInUser)
-    extends WrappedRequest[A](request) {
+import scala.concurrent.ExecutionContext
 
-  def pptReference: Option[String] =
-    user.enrolments.getEnrolment(PptEnrolment.Identifier).flatMap(
-      enrolment => enrolment.getIdentifier(PptEnrolment.Key)
-    ).map(id => id.value)
+trait MockAmendmentJourneyAction
+    extends MockSubscriptionConnector with MockAuthAction with AnyWordSpecLike {
+
+  protected implicit val ec: ExecutionContext = ExecutionContext.global
+
+  protected val mockAmendmentJourneyAction: AmendmentJourneyAction =
+    new AmendmentJourneyAction(appConfig, mockSubscriptionConnector)(ExecutionContext.global)
 
 }

--- a/test/base/unit/MockSubscriptionConnector.scala
+++ b/test/base/unit/MockSubscriptionConnector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base.unit
+
+import builders.RegistrationBuilder
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.mockito.stubbing.OngoingStubbing
+import org.mockito.{ArgumentCaptor, Mockito}
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
+  DownstreamServiceError,
+  RegistrationConnector,
+  ServiceError,
+  SubscriptionsConnector
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
+
+import scala.concurrent.Future
+
+trait MockSubscriptionConnector extends RegistrationBuilder with MockitoSugar {
+
+  protected val mockSubscriptionConnector: SubscriptionsConnector = mock[SubscriptionsConnector]
+  protected val mockSubscription                                  = aRegistration()
+
+  when(mockSubscriptionConnector.getSubscription(any())(any())).thenReturn(
+    Future.successful(mockSubscription)
+  )
+
+  protected def simulateGetSubscriptionFailure() =
+    when(mockSubscriptionConnector.getSubscription(any())(any())).thenThrow(
+      new IllegalStateException("BANG!")
+    )
+
+}

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -52,6 +52,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.{
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   GroupDetail,
   OrganisationDetails,
+  Registration,
   UserEnrolmentDetails
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -25,6 +25,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AllowedUser
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes
+import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
 
 import scala.concurrent.Future
@@ -105,7 +106,9 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
     "redirect to PPT account url when user already enrolled" in {
       when(appConfig.pptAccountUrl).thenReturn("/ppt-accounts-url")
       val user =
-        PptTestData.newUser("123").copy(enrolments = Enrolments(Set(Enrolment("HMRC-PPT-ORG"))))
+        PptTestData.newUser("123").copy(enrolments =
+          Enrolments(Set(Enrolment(PptEnrolment.Identifier)))
+        )
       authorizedUser(user)
 
       val result =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationControllerTest.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment
+
+import base.PptTestData.newUser
+import base.unit.MockAmendmentJourneyAction
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers
+import play.api.http.Status.OK
+import play.api.mvc.{AnyContentAsEmpty, Request}
+import play.api.test.Helpers.{contentAsString, status}
+import play.api.test.{DefaultAwaitTimeout, FakeRequest}
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.amend_registration_page
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import utils.FakeRequestCSRFSupport.CSRFFakeRequest
+
+class AmendRegistrationControllerTest
+    extends MockAmendmentJourneyAction with Matchers with DefaultAwaitTimeout {
+
+  private val mcc  = stubMessagesControllerComponents()
+  private val page = mock[amend_registration_page]
+
+  when(page.apply(any())(any(), any())).thenReturn(HtmlFormat.raw("registration amendment"))
+
+  private val controller =
+    new AmendRegistrationController(mockAuthAllowEnrolmentAction,
+                                    mcc,
+                                    mockAmendmentJourneyAction,
+                                    page
+    )
+
+  private def authorisedUserWithPptSubscription() =
+    authorizedUser(user =
+      newUser().copy(enrolments =
+        Enrolments(
+          Set(
+            new Enrolment(PptEnrolment.Identifier,
+                          Seq(EnrolmentIdentifier(PptEnrolment.Key, "XMPPT0000000123")),
+                          "activated"
+            )
+          )
+        )
+      )
+    )
+
+  "Amend Registration Controller" should {
+
+    "display the amend registration page" when {
+
+      "user is authenticated" in {
+        authorisedUserWithPptSubscription()
+
+        val resp = controller.displayPage()(getRequest())
+
+        status(resp) mustBe OK
+        contentAsString(resp) mustBe "registration amendment"
+      }
+    }
+
+    "throw exception" when {
+      "unauthenticated user attempts to access the amendment page" in {
+        unAuthorizedUser()
+
+        val resp = controller.displayPage()(getRequest())
+
+        intercept[RuntimeException] {
+          status(resp)
+        }
+      }
+
+      "user is authenticated but attempt to retrieve registration fails" in {
+        authorisedUserWithPptSubscription()
+        simulateGetSubscriptionFailure()
+
+        val resp = controller.displayPage()(getRequest())
+
+        intercept[RuntimeException] {
+          status(resp)
+        }
+      }
+    }
+  }
+
+  private def getRequest(session: (String, String) = "" -> ""): Request[AnyContentAsEmpty.type] =
+    FakeRequest("GET", "").withSession(session).withCSRFToken
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyActionSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.models.request
+
+import base.PptTestData.newUser
+import base.unit.MockAmendmentJourneyAction
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status.OK
+import play.api.mvc.{AnyContent, Result, Results}
+import play.api.test.Helpers.status
+import play.api.test.{DefaultAwaitTimeout, FakeRequest}
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments, InsufficientEnrolments}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
+
+import scala.concurrent.Future
+
+class AmendmentJourneyActionSpec extends MockAmendmentJourneyAction with DefaultAwaitTimeout {
+
+  private val responseGenerator = mock[JourneyRequest[_] => Future[Result]]
+
+  private val requestCaptor: ArgumentCaptor[JourneyRequest[AnyContent]] =
+    ArgumentCaptor.forClass(classOf[JourneyRequest[AnyContent]])
+
+  when(responseGenerator.apply(requestCaptor.capture())).thenReturn(Future.successful(Results.Ok))
+
+  private val user = newUser()
+
+  "Amendment Journey Action" should {
+
+    "returns a JourneyRequest with a registration" in {
+      val request = new AuthenticatedRequest(
+        FakeRequest(),
+        user.copy(enrolments =
+          Enrolments(
+            Set(
+              new Enrolment(PptEnrolment.Identifier,
+                            Seq(EnrolmentIdentifier(PptEnrolment.Key, "XMPPT0000000123")),
+                            "activated"
+              )
+            )
+          )
+        )
+      )
+      status(mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)) mustBe OK
+      requestCaptor.getValue.registration mustBe mockSubscription
+    }
+
+    "throw InsufficientEnrolments exception" when {
+
+      "user does not have an internal id" in {
+        val request = new AuthenticatedRequest(
+          FakeRequest(),
+          user.copy(identityData = user.identityData.copy(internalId = None))
+        )
+        intercept[InsufficientEnrolments] {
+          mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)
+        }
+      }
+
+      "user does not have a ppt enrolment" in {
+        val request = new AuthenticatedRequest(FakeRequest(), user)
+        intercept[InsufficientEnrolments] {
+          mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)
+        }
+      }
+
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/AmendRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/AmendRegistrationViewSpec.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.amendment
+
+import base.unit.UnitViewSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.mvc.Flash
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType
+import uk.gov.hmrc.plasticpackagingtax.registration.services.CountryService
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.amend_registration_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class AmendRegistrationViewSpec extends UnitViewSpec with Matchers {
+
+  private val page: amend_registration_page = instanceOf[amend_registration_page]
+  private val registration                  = aRegistration()
+  private val realAppConfig                 = instanceOf[AppConfig]
+  private val countryService                = instanceOf[CountryService]
+
+  private def createView(flash: Flash = new Flash(Map.empty)): Html =
+    page(registration)(journeyRequest, messages)
+
+  "Amend Registration Page view" should {
+
+    val view: Html = createView()
+
+    "contain timeout dialog function" in {
+      containTimeoutDialogFunction(view) mustBe true
+    }
+
+    "display sign out link" in {
+      displaySignOutLink(view)
+    }
+
+    "display title" in {
+      view.select("title").text() must include(
+        messages("amendRegistration.organisationDetails.title")
+      )
+    }
+
+    "display back link to ppt home" in {
+      view.getElementById("back-link") must haveHref(realAppConfig.pptAccountUrl)
+    }
+
+    "display page heading" in {
+      view.select("h1").text() must include(messages("amendRegistration.organisationDetails.title"))
+    }
+
+    "display organisation details" in {
+      view.select("h2").get(0).text() must include(
+        messages("reviewRegistration.organisationDetails.check.label.singleEntity")
+      )
+      val descriptionList = view.select("dl").get(0).text()
+      val expectedOrganisationDetails =
+        Seq(registration.organisationDetails.organisationType.map(OrgType.displayName).get,
+            registration.organisationDetails.businessName.get,
+            registration.organisationDetails.incorporationDetails.map(id => id.companyNumber).get,
+            registration.organisationDetails.businessRegisteredAddress.map(
+              bra => bra.addressLine1
+            ).get,
+            registration.organisationDetails.businessRegisteredAddress.map(
+              bra => bra.addressLine2.getOrElse("")
+            ).get,
+            registration.organisationDetails.businessRegisteredAddress.map(
+              bra => bra.addressLine3.getOrElse("")
+            ).get,
+            registration.organisationDetails.businessRegisteredAddress.map(
+              bra => bra.townOrCity
+            ).get,
+            registration.organisationDetails.businessRegisteredAddress.map(
+              bra => bra.postCode.getOrElse("")
+            ).get,
+            countryService.getName(
+              registration.organisationDetails.businessRegisteredAddress.map(
+                bra => bra.countryCode
+              ).get
+            ),
+            registration.organisationDetails.incorporationDetails.map(id => id.ctutr).get
+        ).filter(_.nonEmpty)
+      expectedOrganisationDetails.foreach(orgDetail => descriptionList must include(orgDetail))
+    }
+
+    "display main contact details" in {
+      view.select("h2").get(1).text() must include(messages("primaryContactDetails.check.label"))
+      val descriptionList = view.select("dl").get(1).text()
+      val expectedContactDetails = Seq(registration.primaryContactDetails.name.get,
+                                       registration.primaryContactDetails.jobTitle.get,
+                                       registration.primaryContactDetails.email.get,
+                                       registration.primaryContactDetails.phoneNumber.get,
+                                       registration.primaryContactDetails.address.map(
+                                         a => a.addressLine1
+                                       ).get,
+                                       registration.primaryContactDetails.address.map(
+                                         a => a.addressLine2.getOrElse("")
+                                       ).get,
+                                       registration.primaryContactDetails.address.map(
+                                         a => a.addressLine3.getOrElse("")
+                                       ).get,
+                                       registration.primaryContactDetails.address.map(
+                                         a => a.townOrCity
+                                       ).get,
+                                       registration.primaryContactDetails.address.map(
+                                         a => a.postCode.getOrElse("")
+                                       ).get,
+                                       countryService.getName(
+                                         registration.primaryContactDetails.address.map(
+                                           a => a.countryCode
+                                         ).get
+                                       )
+      ).filter(_.nonEmpty)
+      expectedContactDetails.foreach(orgDetail => descriptionList must include(orgDetail))
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods() = {
+    page.f(registration)(journeyRequest, messages)
+    page.render(registration, journeyRequest, messages)
+  }
+
+}


### PR DESCRIPTION
We only display selected data from a previously created registration in part i.

Returns FE: https://github.com/hmrc/plastic-packaging-tax-returns-frontend/pull/97

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave

![image](https://user-images.githubusercontent.com/87077443/145458678-994b7cde-56bc-4d1b-865d-5ae3ef24fefd.png)
