### PR TITLE
PPTP 1286 - Sole Trader custom registration failed error page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnector.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/connectors/addresslookup/AddressLookupFrontendConnector.scala
@@ -17,12 +17,8 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup
 
 import com.kenshoo.play.metrics.Metrics
-import play.api.Logger
-
-import javax.inject.{Inject, Singleton}
 import play.api.http.HeaderNames.LOCATION
 import play.api.http.Status.ACCEPTED
-import play.api.libs.json.Json
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
@@ -32,6 +28,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup.{
   AddressLookupOnRamp
 }
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorController.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.enrolment_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.grs_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.business_verification_failure_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.sole_trader_verification_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
   duplicate_subscription_page,
   error_page
@@ -40,6 +41,7 @@ class NotableErrorController @Inject() (
   errorNoSavePage: enrolment_failure_page,
   grsFailurePage: grs_failure_page,
   businessVerificationFailurePage: business_verification_failure_page,
+  soleTraderVerificationFailurePage: sole_trader_verification_failure_page,
   duplicateSubscriptionPage: duplicate_subscription_page
 ) extends FrontendController(mcc) with I18nSupport {
 
@@ -56,6 +58,11 @@ class NotableErrorController @Inject() (
   def businessVerificationFailure(): Action[AnyContent] =
     authenticate { implicit request =>
       Ok(businessVerificationFailurePage())
+    }
+
+  def soleTraderVerificationFailure(): Action[AnyContent] =
+    authenticate { implicit request =>
+      Ok(soleTraderVerificationFailurePage())
     }
 
   def grsFailure(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsAddressController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup.AddressLookupFrontendConnector
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
@@ -72,7 +72,7 @@ trait OrganisationDetailsTypeHelper extends Cacheable with I18nSupport {
       case (Some(OrgType.OVERSEAS_COMPANY_UK_BRANCH), false) =>
         getUkCompanyRedirectUrl(businessVerificationCheck)
           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
-      case (Some(OrgType.SOLE_TRADER), _) =>
+      case (Some(OrgType.SOLE_TRADER), false) =>
         getSoleTraderRedirectUrl()
           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
       case (Some(OrgType.REGISTERED_SOCIETY), false) =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
@@ -72,7 +72,7 @@ trait OrganisationDetailsTypeHelper extends Cacheable with I18nSupport {
       case (Some(OrgType.OVERSEAS_COMPANY_UK_BRANCH), false) =>
         getUkCompanyRedirectUrl(businessVerificationCheck)
           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
-      case (Some(OrgType.SOLE_TRADER), false) =>
+      case (Some(OrgType.SOLE_TRADER), _) =>
         getSoleTraderRedirectUrl()
           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
       case (Some(OrgType.REGISTERED_SOCIETY), false) =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsController.scala
@@ -25,16 +25,26 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs._
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.RegistrationStatus.{BUSINESS_IDENTIFICATION_FAILED, BUSINESS_VERIFICATION_FAILED, DUPLICATE_SUBSCRIPTION, GRS_FAILED, RegistrationStatus, STATUS_OK, UNSUPPORTED_ORGANISATION}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.RegistrationStatus.{
+  BUSINESS_VERIFICATION_FAILED,
+  DUPLICATE_SUBSCRIPTION,
   GRS_FAILED,
+  RegistrationStatus,
   SOLE_TRADER_VERIFICATION_FAILED,
+  STATUS_OK,
+  UNSUPPORTED_ORGANISATION
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.{routes => orgRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType.SOLE_TRADER
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnershipTypeEnum.PartnershipTypeEnum
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration._
-import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, OrganisationDetails, Registration}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
+  Cacheable,
+  OrganisationDetails,
+  Registration
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.SubscriptionStatus
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.SubscriptionStatus.SUBSCRIBED

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/sole_trader_verification_failure_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/sole_trader_verification_failure_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/sole_trader_verification_failure_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/sole_trader_verification_failure_page.scala.html
@@ -1,0 +1,39 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.selfAssessmentHelplineDetails
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.Title
+
+@this(
+        govukLayout: main_template,
+        pageHeading: pageHeading,
+        sectionHeader: sectionHeader,
+        paragraph: paragraph,
+        link: link,
+        selfAssessmentHelplineDetails: selfAssessmentHelplineDetails
+)
+@()(implicit request: Request[_], messages: Messages)
+
+@govukLayout(title = Title("soleTraderEntityVerification.failure.title")) {
+
+    @sectionHeader(messages("organisationDetails.sectionHeader"))
+    @pageHeading(messages("soleTraderEntityVerification.failure.heading"))
+
+    @paragraph(Html(messages("soleTraderEntityVerification.failure.detail")))
+
+    @selfAssessmentHelplineDetails()
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/selfAssessmentHelplineDetails.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/selfAssessmentHelplineDetails.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/selfAssessmentHelplineDetails.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/selfAssessmentHelplineDetails.scala.html
@@ -1,0 +1,44 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.paragraphBody
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.stackedContentWithLabel
+
+@this(
+paragraphBody: paragraphBody,
+stackedContentWithLabel: stackedContentWithLabel
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@paragraphBody(message = messages("selfAssessmentHelpline.intro"))
+
+@stackedContentWithLabel(
+label = messages("selfAssessmentHelpline.telephone.title"),
+content = messages("selfAssessmentHelpline.telephone.detail")
+)
+
+@stackedContentWithLabel(
+label = messages("selfAssessmentHelpline.telephone.outsideUK.title"),
+content = messages("selfAssessmentHelpline.telephone.outsideUK.detail")
+)
+
+@stackedContentWithLabel(
+label = messages("selfAssessmentHelpline.openingTimes.title"),
+content = messages("selfAssessmentHelpline.openingTimes.detail.1")
+)
+
+@paragraphBody(message = messages("selfAssessmentHelpline.openingTimes.detail.2"))

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -95,6 +95,7 @@ GET        /enrolment-failed                    uk.gov.hmrc.plasticpackagingtax.
 GET        /grs-failed                          uk.gov.hmrc.plasticpackagingtax.registration.controllers.NotableErrorController.grsFailure()
 GET        /business-not-verified               uk.gov.hmrc.plasticpackagingtax.registration.controllers.NotableErrorController.businessVerificationFailure()
 GET        /organisation-already-registered     uk.gov.hmrc.plasticpackagingtax.registration.controllers.NotableErrorController.duplicateRegistration()
+GET        /sole-trader-not-verified            uk.gov.hmrc.plasticpackagingtax.registration.controllers.NotableErrorController.soleTraderVerificationFailure()
 
 GET        /sign-out                uk.gov.hmrc.plasticpackagingtax.registration.controllers.SignOutController.signOut(signOutReason: uk.gov.hmrc.plasticpackagingtax.registration.views.model.SignOutReason)
 GET        /security-signed-out     uk.gov.hmrc.plasticpackagingtax.registration.controllers.SignOutController.sessionTimeoutSignedOut()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -352,6 +352,10 @@ businessEntityVerification.failure.title = Sorry, your business could not be ver
 businessEntityVerification.failure.heading = Sorry, your business could not be verified
 businessEntityVerification.failure.detail = You can try again after 24 hours.
 
+soleTraderEntityVerification.failure.title = Sorry, your business could not be verified
+soleTraderEntityVerification.failure.heading = Sorry, your business could not be verified
+soleTraderEntityVerification.failure.detail = You can try again after 24 hours.
+
 duplicateSubscription.title = Your organisation is already registered
 duplicateSubscription.detail = Someone in {0} has already registered for Plastic Packaging Tax (PPT).
 
@@ -374,6 +378,15 @@ corpTaxHelpline.telephone.outsideUK.detail = +44 151 268 0571
 corpTaxHelpline.openingTimes.title = Opening times:
 corpTaxHelpline.openingTimes.detail.1 = Monday to Friday: 8am to 6pm
 corpTaxHelpline.openingTimes.detail.2 = Closed on weekends and bank holidays.
+
+selfAssessmentHelpline.intro = Contact the Self Assessment helpline if you have any questions.
+selfAssessmentHelpline.telephone.title = Telephone:
+selfAssessmentHelpline.telephone.detail = 0300 200 3410
+selfAssessmentHelpline.telephone.outsideUK.title = Outside UK:
+selfAssessmentHelpline.telephone.outsideUK.detail = +44 161 931 9070
+selfAssessmentHelpline.openingTimes.title = Opening times:
+selfAssessmentHelpline.openingTimes.detail.1 = Monday to Friday: 8am to 6pm
+selfAssessmentHelpline.openingTimes.detail.2 = Closed on weekends and bank holidays.
 
 enrolment.failure.title = Sorry, there is a problem with the service
 enrolment.failure.heading = Sorry, there is a problem with the service.

--- a/test/builders/RegistrationBuilder.scala
+++ b/test/builders/RegistrationBuilder.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.{
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType.{
   PARTNERSHIP,
+  SOLE_TRADER,
   UK_COMPANY
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.EmailStatus
@@ -32,7 +33,8 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   IncorporationAddressDetails,
   IncorporationDetails,
   PartnershipDetails,
-  RegistrationDetails
+  RegistrationDetails,
+  SoleTraderDetails
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration._
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.SubscriptionStatus.NOT_SUBSCRIBED
@@ -161,6 +163,15 @@ trait RegistrationBuilder {
       reg.copy(organisationDetails =
         reg.organisationDetails.copy(businessRegisteredAddress = Some(businessAddress))
       )
+
+  def withSoleTraderDetails(soleTraderDetails: Option[SoleTraderDetails]): RegistrationModifier = {
+    registration =>
+      registration.copy(organisationDetails =
+        registration.organisationDetails.copy(organisationType = Some(SOLE_TRADER),
+                                              soleTraderDetails = soleTraderDetails
+        )
+      )
+  }
 
   def withPartnershipDetails(partnershipDetails: Option[PartnershipDetails]): RegistrationModifier =
     reg =>

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -178,6 +178,15 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                          Some(verificationFailedRegistrationDetails)
     )
 
+  protected val verificationFailedSoleTraderDetails: SoleTraderDetails =
+    SoleTraderDetails(firstName = "Sole",
+                      lastName = "Trader",
+                      dateOfBirth = Some("12/12/1960"),
+                      nino = "1234",
+                      sautr = Some("ABC"),
+                      registration = Some(verificationFailedRegistrationDetails)
+    )
+
   protected val unregisteredSoleTraderDetails: SoleTraderDetails =
     SoleTraderDetails(firstName = "Sole",
                       lastName = "Trader",

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -182,7 +182,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     SoleTraderDetails(firstName = "Sole",
                       lastName = "Trader",
                       dateOfBirth = Some("12/12/1960"),
-                      nino = "1234",
+                      ninoOrTrn = "1234",
                       sautr = Some("ABC"),
                       registration = Some(verificationFailedRegistrationDetails)
     )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorControllerSpec.scala
@@ -26,6 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.enrolment_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.grs_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.business_verification_failure_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.sole_trader_verification_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
   duplicate_subscription_page,
   error_page
@@ -36,11 +37,12 @@ class NotableErrorControllerSpec extends ControllerSpec {
 
   private val mcc = stubMessagesControllerComponents()
 
-  private val errorPage                      = mock[error_page]
-  private val enrolmentFailurePage           = mock[enrolment_failure_page]
-  private val grsFailurePage                 = mock[grs_failure_page]
-  private val businessVerificationFailedPage = mock[business_verification_failure_page]
-  private val duplicateSubscriptionPage      = mock[duplicate_subscription_page]
+  private val errorPage                        = mock[error_page]
+  private val enrolmentFailurePage             = mock[enrolment_failure_page]
+  private val grsFailurePage                   = mock[grs_failure_page]
+  private val businessVerificationFailedPage   = mock[business_verification_failure_page]
+  private val soleTraderVerificationFailedPage = mock[sole_trader_verification_failure_page]
+  private val duplicateSubscriptionPage        = mock[duplicate_subscription_page]
 
   private val controller =
     new NotableErrorController(authenticate = mockAuthAction,
@@ -50,6 +52,7 @@ class NotableErrorControllerSpec extends ControllerSpec {
                                errorNoSavePage = enrolmentFailurePage,
                                grsFailurePage = grsFailurePage,
                                businessVerificationFailurePage = businessVerificationFailedPage,
+                               soleTraderVerificationFailurePage = soleTraderVerificationFailedPage,
                                duplicateSubscriptionPage = duplicateSubscriptionPage
     )
 
@@ -62,6 +65,9 @@ class NotableErrorControllerSpec extends ControllerSpec {
     when(grsFailurePage.apply()(any(), any())).thenReturn(HtmlFormat.raw("grs failure content"))
     when(businessVerificationFailedPage.apply()(any(), any())).thenReturn(
       HtmlFormat.raw("error business verification failed content")
+    )
+    when(soleTraderVerificationFailedPage.apply()(any(), any())).thenReturn(
+      HtmlFormat.raw("error sole trader verification failed content")
     )
     when(duplicateSubscriptionPage.apply()(any(), any())).thenReturn(
       HtmlFormat.raw("duplicate subscription content")
@@ -91,6 +97,14 @@ class NotableErrorControllerSpec extends ControllerSpec {
 
       status(resp) mustBe OK
       contentAsString(resp) mustBe "error business verification failed content"
+    }
+
+    "present the sole trader verification failed page" in {
+      authorizedUser()
+      val resp = controller.soleTraderVerificationFailure()(getRequest())
+
+      status(resp) mustBe OK
+      contentAsString(resp) mustBe "error sole trader verification failed content"
     }
 
     "present the grs failure page" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/CheckAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/CheckAnswersControllerSpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.OK
 import play.api.test.Helpers.{contentAsString, status}
 import play.twirl.api.HtmlFormat
-import spec.PptTestData
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.check_answers_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsControllerSpec.scala
@@ -70,9 +70,12 @@ class GrsControllerSpec extends ControllerSpec {
     withOrganisationDetails(unregisteredUkCompanyOrgDetails())
   )
 
-  private val verificationFailedLimitedCompany = aRegistration(
+  private val verificationFailedLimitedCompany: Registration = aRegistration(
     withOrganisationDetails(verificationFailedUkCompanyOrgDetails())
   )
+
+  private val verificationFailedSoleTrader: Registration =
+    aRegistration(withSoleTraderDetails(Some(verificationFailedSoleTraderDetails)))
 
   private val registeredLimitedCompany = aRegistration(
     withOrganisationDetails(registeredUkCompanyOrgDetails())
@@ -279,13 +282,23 @@ class GrsControllerSpec extends ControllerSpec {
     }
 
     "show verification error page" when {
-      "business verification status is FAIL and registrationStatus is REGISTRATION_NOT_CALLED " in {
+      "business verification status is FAIL and registrationStatus is REGISTRATION_NOT_CALLED" in {
         authorizedUser()
         val result = simulateBusinessVerificationFailureLimitedCompanyCallback()
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(
           pptRoutes.NotableErrorController.businessVerificationFailure().url
+        )
+      }
+
+      "sole trader business verification status is FAIL and registrationStatus is REGISTRATION_NOT_CALLED" in {
+        authorizedUser()
+        val result = simulateBusinessVerificationFailureSoleTraderCallback()
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result) mustBe Some(
+          pptRoutes.NotableErrorController.soleTraderVerificationFailure().url
         )
       }
     }
@@ -369,6 +382,15 @@ class GrsControllerSpec extends ControllerSpec {
     authorizedUser()
     mockGetUkCompanyDetails(verificationFailedIncorporationDetails)
     mockRegistrationFind(verificationFailedLimitedCompany)
+    mockRegistrationUpdate()
+
+    controller.grsCallback(registration.incorpJourneyId.get)(getRequest())
+  }
+
+  private def simulateBusinessVerificationFailureSoleTraderCallback() = {
+    authorizedUser()
+    mockGetSoleTraderDetails(verificationFailedSoleTraderDetails)
+    mockRegistrationFind(verificationFailedSoleTrader)
     mockRegistrationUpdate()
 
     controller.grsCallback(registration.incorpJourneyId.get)(getRequest())

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/UserDataRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/UserDataRepositorySpec.scala
@@ -83,8 +83,7 @@ class UserDataRepositorySpec
 
     "add data to cache and delete it" when {
       "explicit id used" in {
-        val id                                          = "123"
-        implicit val request: AuthenticatedRequest[Any] = authRequest("12345")
+        val id = "123"
         await(repository.putData(id, "testKey", "testData"))
 
         await(repository.deleteData[String](id, "testKey")).mustBe(())

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/SoleTraderVerificationFailureViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/SoleTraderVerificationFailureViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/SoleTraderVerificationFailureViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/SoleTraderVerificationFailureViewSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.organisation
+
+import base.unit.UnitViewSpec
+import org.scalatest.matchers.must.Matchers
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.sole_trader_verification_failure_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class SoleTraderVerificationFailureViewSpec extends UnitViewSpec with Matchers {
+
+  private val page: sole_trader_verification_failure_page =
+    instanceOf[sole_trader_verification_failure_page]
+
+  private def createView(): Html = page()(journeyRequest, messages)
+
+  "Sole Trader Verification Failure Page" should {
+
+    val view: Html = createView()
+
+    // Minimal asserts to verify the page is specific to sole traders and refers to self assessment
+    "display sole trader heading" in {
+      view.select("h1").text() must include(messages("soleTraderEntityVerification.failure.title"))
+    }
+
+    "display self assessment tax helpline details" in {
+      val parasText = view.select("p").text
+      parasText must include(messages("selfAssessmentHelpline.intro"))
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods() = {
+    page.f()(request, messages)
+    page.render(request, messages)
+  }
+
+}


### PR DESCRIPTION
### Description of Work carried through

Add a specific failure page for Sole traders returning from a failed GRS journey.
Sole Traders are challenged with questions about their Self Assessment history so this screen should prompt them to contact Self Assessment.



Log output for a Sole Trader returning from GRS after entering incorrect Business Verification Self Assessment answers 5 times:
```
logger=[uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.GrsController]
message=[PPT GRS callback for journeyId [33e7eae0-2fbb-4c43-9659-3f26013299b2]
and organisation type [SoleTrader] had registration status [SOLE_TRADER_VERIFICATION_FAILED]
and details [RegistrationDetails(true,Some(FAIL),REGISTRATION_NOT_CALLED,None)]]

```
#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave


![Screenshot from 2022-01-06 11-38-04](https://user-images.githubusercontent.com/95688374/148377416-a11b8c11-33ca-4384-a242-a23ece19a437.png)
