### PR TITLE
Promote the ALF localhost override from maybe to required. This makes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ This service integrates with the Generic Registration Service and Tax Enrolments
 sm --start PLASTIC_PACKAGING_TAX_ALL INCORPORATED_ENTITY_IDENTIFICATION_ALL EMAIL_VERIFICATION_ALL TAX_ENROLMENTS_ALL ADDRESS_LOOKUP_SERVICES -r
 
 # For the above organisation types along with partnerships and sole traders use these profiles -
-sm --start PLASTIC_PACKAGING_TAX_ALL INCORPORATED_ENTITY_IDENTIFICATION_ALL SOLE_TRADER_IDENTIFICATION_ALL PARTNERSHIP_IDENTIFICATION_ALL EMAIL_VERIFICATION_ALL TAX_ENROLMENTS_ALL ADDRESS_LOOKUP_SERVICES -r
+sm --start PLASTIC_PACKAGING_TAX_ALL INCORPORATED_ENTITY_IDENTIFICATION_ALL SOLE_TRADER_IDENTIFICATION_ALL PARTNERSHIP_IDENTIFICATION_ALL EMAIL_VERIFICATION_ALL TAX_ENROLMENTS_ALL ADDRESS_LOOKUP_SERVICES -r --appendArgs '{"ADDRESS_LOOKUP_FRONTEND":["-J-Dapplication.router=testOnlyDoNotUseInAppConf.Routes","-J-Dmicroservice.hosts.allowList.1=localhost"]}'
 
 # confirm all services are running
 sm -s 
 ```
 
-It may be necessary (at least for a time after writing this [23/12/2021]) to specifically permit `localhost` as a permitted host for URLs passed to the Address Lookup Frontend. It can be done
-as follows:
+It is necessary (at least for a time after writing this [23/12/2021]) to specifically permit `localhost` as a permitted host for URLs passed to the Address Lookup Frontend.
+This is because the default application.conf for ALK does not allow list localhost.
+It can be done as follows:
 
 ```
 --appendArgs '{"ADDRESS_LOOKUP_FRONTEND":["-J-Dapplication.router=testOnlyDoNotUseInAppConf.Routes","-J-Dmicroservice.hosts.allowList.1=localhost"]}'


### PR DESCRIPTION
… this README consistent with what is in our acceptance test's README.

Avoids confusion with failing acceptances tests if a local machine was sm started from plastics frontend rather than acceptance tests.

### Description of Work carried through

Brief description of what/why/how.

#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
