### PR TITLE
Deduplicate direct usages of EmailVerficationConnector to use EmailVerificationService

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressController.scala
@@ -71,8 +71,10 @@ class AmendEmailAddressController @Inject() (
               emailVerificationService.isEmailVerified(email.value, request.user.credId).flatMap {
                 case true => updateRegistration(updateEmail(email.value))
                 case false =>
-                  emailVerificationService.sendVerificationCode(email.value,
-                                                                request.user.credId
+                  emailVerificationService.sendVerificationCode(
+                    email.value,
+                    request.user.credId,
+                    "/register-for-plastic-packaging-tax/amend-registration"
                   ).map { journeyId =>
                     amendmentJourneyAction.updateLocalRegistration(
                       updateProspectiveEmail(journeyId, email.value)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressController.scala
@@ -20,11 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
-  EmailVerificationConnector,
-  RegistrationConnector,
-  ServiceError
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
   AuthAction,
   FormAction,
@@ -51,7 +47,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class ContactDetailsEmailAddressController @Inject() (
   authenticate: AuthAction,
   journeyAction: JourneyAction,
-  emailVerificationConnector: EmailVerificationConnector,
   override val registrationConnector: RegistrationConnector,
   emailVerificationService: EmailVerificationService,
   mcc: MessagesControllerComponents,
@@ -101,7 +96,7 @@ class ContactDetailsEmailAddressController @Inject() (
   private def updateRegistration(formData: EmailAddress, credId: String)(implicit
     request: JourneyRequest[AnyContent]
   ): Future[Either[ServiceError, Registration]] =
-    emailVerificationConnector.getStatus(credId).flatMap {
+    emailVerificationService.getStatus(credId).flatMap {
       case Right(emailStatusResponse) =>
         emailStatusResponse match {
           case Some(response) =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressController.scala
@@ -20,7 +20,6 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
   EmailVerificationConnector,
   RegistrationConnector,
@@ -41,6 +40,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.Ema
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification._
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
+import uk.gov.hmrc.plasticpackagingtax.registration.services.EmailVerificationService
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.contact.email_address_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -53,8 +53,8 @@ class ContactDetailsEmailAddressController @Inject() (
   journeyAction: JourneyAction,
   emailVerificationConnector: EmailVerificationConnector,
   override val registrationConnector: RegistrationConnector,
+  emailVerificationService: EmailVerificationService,
   mcc: MessagesControllerComponents,
-  appConfig: AppConfig,
   page: email_address_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
@@ -148,18 +148,11 @@ class ContactDetailsEmailAddressController @Inject() (
 
   private def createEmailVerification(credId: String, email: String)(implicit
     hc: HeaderCarrier
-  ): Future[Either[ServiceError, String]] =
-    emailVerificationConnector.create(
-      CreateEmailVerificationRequest(credId = credId,
-                                     continueUrl =
-                                       "/register-for-plastic-packaging-tax/primary-contact-details",
-                                     origin = "ppt",
-                                     accessibilityStatementUrl = "/accessibility",
-                                     email = Email(address = email, enterUrl = "/start"),
-                                     backUrl = "/back",
-                                     pageTitle = "PPT Title",
-                                     deskproServiceName = "plastic-packaging-tax"
-      )
+  ): Future[String] =
+    this.emailVerificationService.sendVerificationCode(
+      email,
+      credId,
+      "/register-for-plastic-packaging-tax/primary-contact-details"
     )
 
   private def handleNotVerifiedEmail(registration: Registration, credId: String)(implicit
@@ -168,17 +161,12 @@ class ContactDetailsEmailAddressController @Inject() (
   ): Future[Result] =
     registration.primaryContactDetails.email match {
       case Some(emailAddress) =>
-        createEmailVerification(credId, emailAddress).flatMap {
-          case Right(verificationJourneyStartUrl) =>
-            updatedJourneyId(registration,
-                             verificationJourneyStartUrl.split("/").slice(0, 4).last
-            ).flatMap {
-              case Left(error) => throw error
-              case Right(_) =>
-                Future(Redirect(routes.ContactDetailsEmailAddressPasscodeController.displayPage()))
-            }
-
-          case Left(error) => throw error
+        createEmailVerification(credId, emailAddress).flatMap { journeyId =>
+          updatedJourneyId(registration, journeyId).map {
+            case Left(error) => throw error
+            case Right(_) =>
+              Redirect(routes.ContactDetailsEmailAddressPasscodeController.displayPage())
+          }
         }
       case None => throw RegistrationException("Failed to get email from the cache")
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
@@ -20,10 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType.{GROUP, RegType}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType
-import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
-  Partner,
-  PartnershipDetails
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.Partner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupMember
 import uk.gov.hmrc.plasticpackagingtax.registration.views.model.TaskStatus
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/services/EmailVerificationService.scala
@@ -18,7 +18,10 @@ package uk.gov.hmrc.plasticpackagingtax.registration.services
 
 import com.google.inject.Inject
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtax.registration.connectors.EmailVerificationConnector
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
+  EmailVerificationConnector,
+  ServiceError
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification._
 
 import javax.inject.Singleton
@@ -29,8 +32,13 @@ class EmailVerificationService @Inject() (emailVerificationConnector: EmailVerif
   implicit ec: ExecutionContext
 ) {
 
+  def getStatus(
+    credId: String
+  )(implicit hc: HeaderCarrier): Future[Either[ServiceError, Option[VerificationStatus]]] =
+    emailVerificationConnector.getStatus(credId)
+
   def isEmailVerified(email: String, credId: String)(implicit hc: HeaderCarrier): Future[Boolean] =
-    emailVerificationConnector.getStatus(credId).map {
+    getStatus(credId).map {
       case Right(resp) =>
         resp.exists { emailStatuses =>
           emailStatuses.emails.exists {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/services/EmailVerificationService.scala
@@ -41,13 +41,12 @@ class EmailVerificationService @Inject() (emailVerificationConnector: EmailVerif
       case Left(ex) => throw ex
     }
 
-  def sendVerificationCode(email: String, credId: String)(implicit
+  def sendVerificationCode(email: String, credId: String, continueUrl: String)(implicit
     hc: HeaderCarrier
   ): Future[String] =
     emailVerificationConnector.create(
       CreateEmailVerificationRequest(credId = credId,
-                                     continueUrl =
-                                       "/register-for-plastic-packaging-tax/amend-registration",
+                                     continueUrl = continueUrl,
                                      origin = "ppt",
                                      accessibilityStatementUrl = "/accessibility",
                                      email = Email(address = email, enterUrl = "/start"),

--- a/test/base/unit/MockConnectors.scala
+++ b/test/base/unit/MockConnectors.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.{
   SubscriptionCreateOrUpdateResponseSuccess,
   SubscriptionStatusResponse
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.services.EmailVerificationService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -49,8 +50,7 @@ trait MockConnectors extends MockitoSugar with RegistrationBuilder with BeforeAn
   val mockPartnershipGrsConnector: PartnershipGrsConnector =
     mock[PartnershipGrsConnector]
 
-  val mockSubscriptionsConnector: SubscriptionsConnector         = mock[SubscriptionsConnector]
-  val mockEmailVerificationConnector: EmailVerificationConnector = mock[EmailVerificationConnector]
+  val mockSubscriptionsConnector: SubscriptionsConnector = mock[SubscriptionsConnector]
 
   def mockGetUkCompanyDetails(
     incorporationDetails: IncorporationDetails

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressControllerSpec.scala
@@ -86,7 +86,7 @@ class AmendEmailAddressControllerSpec
   private val pptReference = "XMPPT0000000123"
   private val sessionId    = "ABC"
 
-  private def authorisedUserWithPptSubscription() =
+  private def authorisedUserWithPptSubscription(): Unit =
     authorizedUser(user =
       newUser().copy(enrolments =
         Enrolments(
@@ -124,7 +124,7 @@ class AmendEmailAddressControllerSpec
     )
 
   private def simulateSendingEmailVerificationCodeSuccess() =
-    when(mockEmailVerificationService.sendVerificationCode(any(), any())(any())).thenReturn(
+    when(mockEmailVerificationService.sendVerificationCode(any(), any(), any())(any())).thenReturn(
       Future.successful("email-verification-journey-id")
     )
 
@@ -161,11 +161,7 @@ class AmendEmailAddressControllerSpec
         )
 
       forAll(showPageTestData) {
-        (
-          testName: String,
-          call: (Request[AnyContent]) => Future[Result],
-          expectedContent: String
-        ) =>
+        (testName: String, call: Request[AnyContent] => Future[Result], expectedContent: String) =>
           s"$testName page requested and registration populated" in {
             val resp = call(getRequest())
 
@@ -366,9 +362,10 @@ class AmendEmailAddressControllerSpec
   }
 
   private def verifyEmailVerificationCodeSentAsExpected(email: String) =
-    verify(mockEmailVerificationService).sendVerificationCode(ArgumentMatchers.eq(email), any())(
-      any()
-    )
+    verify(mockEmailVerificationService).sendVerificationCode(ArgumentMatchers.eq(email),
+                                                              any(),
+                                                              any()
+    )(any())
 
   private def simulateEmailVerificationPassword(
     passcode: String,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressControllerSpec.scala
@@ -62,8 +62,6 @@ class ContactDetailsEmailAddressControllerSpec extends ControllerSpec with Defau
   private val controller =
     new ContactDetailsEmailAddressController(authenticate = mockAuthAction,
                                              journeyAction = mockJourneyAction,
-                                             emailVerificationConnector =
-                                               mockEmailVerificationConnector,
                                              emailVerificationService = emailVerificationService,
                                              registrationConnector = mockRegistrationConnector,
                                              mcc = mcc,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressControllerSpec.scala
@@ -44,6 +44,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   MetaData,
   PrimaryContactDetails
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.services.EmailVerificationService
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.contact.email_address_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -54,14 +55,18 @@ class ContactDetailsEmailAddressControllerSpec extends ControllerSpec with Defau
   private val page = mock[email_address_page]
   private val mcc  = stubMessagesControllerComponents()
 
+  private val emailVerificationService: EmailVerificationService = new EmailVerificationService(
+    mockEmailVerificationConnector
+  )
+
   private val controller =
     new ContactDetailsEmailAddressController(authenticate = mockAuthAction,
                                              journeyAction = mockJourneyAction,
                                              emailVerificationConnector =
                                                mockEmailVerificationConnector,
+                                             emailVerificationService = emailVerificationService,
                                              registrationConnector = mockRegistrationConnector,
                                              mcc = mcc,
-                                             config,
                                              page = page
     )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeControllerSpec.scala
@@ -43,7 +43,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.Ema
   JourneyStatus,
   TOO_MANY_ATTEMPTS
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.VerifyPasscodeRequest
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.PrimaryContactDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.services.EmailVerificationService
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.contact.email_address_passcode_page
@@ -57,15 +56,17 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
   private val page = mock[email_address_passcode_page]
   private val mcc  = stubMessagesControllerComponents()
 
+  private val mockEmailVerificationService = mock[EmailVerificationService]
+
   private val controller =
-    new ContactDetailsEmailAddressPasscodeController(
-      authenticate = mockAuthAction,
-      journeyAction = mockJourneyAction,
-      emailVerificationService = new EmailVerificationService(mockEmailVerificationConnector),
-      registrationConnector =
-        mockRegistrationConnector,
-      mcc = mcc,
-      page = page
+    new ContactDetailsEmailAddressPasscodeController(authenticate = mockAuthAction,
+                                                     journeyAction = mockJourneyAction,
+                                                     emailVerificationService =
+                                                       mockEmailVerificationService,
+                                                     registrationConnector =
+                                                       mockRegistrationConnector,
+                                                     mcc = mcc,
+                                                     page = page
     )
 
   override protected def beforeEach(): Unit = {
@@ -80,19 +81,21 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
 
   def mockEmailVerificationVerifyPasscode(
     dataToReturn: JourneyStatus
-  ): OngoingStubbing[Future[Either[ServiceError, JourneyStatus]]] =
+  ): OngoingStubbing[Future[JourneyStatus]] =
     when(
-      mockEmailVerificationConnector.verifyPasscode(any[String], any[VerifyPasscodeRequest])(any())
-    )
-      .thenReturn(Future.successful(Right(dataToReturn)))
+      mockEmailVerificationService.checkVerificationCode(any[String], any[String], any[String])(
+        any()
+      )
+    ).thenReturn(Future.successful(dataToReturn))
 
   def mockEmailVerificationVerifyPasscodeWithException(
     error: ServiceError
-  ): OngoingStubbing[Future[Either[ServiceError, JourneyStatus]]] =
+  ): OngoingStubbing[Future[JourneyStatus]] =
     when(
-      mockEmailVerificationConnector.verifyPasscode(any[String], any[VerifyPasscodeRequest])(any())
-    )
-      .thenReturn(Future(Left(error)))
+      mockEmailVerificationService.checkVerificationCode(any[String], any[String], any[String])(
+        any()
+      )
+    ).thenReturn(Future.failed(error))
 
   "ContactDetailsEmailAddressPasscodeController" should {
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeControllerSpec.scala
@@ -45,6 +45,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.Ema
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.emailverification.VerifyPasscodeRequest
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.PrimaryContactDetails
+import uk.gov.hmrc.plasticpackagingtax.registration.services.EmailVerificationService
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.contact.email_address_passcode_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -57,14 +58,14 @@ class ContactDetailsEmailAddressPasscodeControllerSpec
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new ContactDetailsEmailAddressPasscodeController(authenticate = mockAuthAction,
-                                                     journeyAction = mockJourneyAction,
-                                                     emailVerificationConnector =
-                                                       mockEmailVerificationConnector,
-                                                     registrationConnector =
-                                                       mockRegistrationConnector,
-                                                     mcc = mcc,
-                                                     page = page
+    new ContactDetailsEmailAddressPasscodeController(
+      authenticate = mockAuthAction,
+      journeyAction = mockJourneyAction,
+      emailVerificationService = new EmailVerificationService(mockEmailVerificationConnector),
+      registrationConnector =
+        mockRegistrationConnector,
+      mcc = mcc,
+      page = page
     )
 
   override protected def beforeEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/services/EmailVerificationServiceSpec.scala
@@ -91,7 +91,9 @@ class EmailVerificationServiceSpec()
     }
 
     "send verification passcode and return journeyId" in {
-      emailVerificationService.sendVerificationCode("user@ppt.com", "123").map(_ mustBe journeyId)
+      emailVerificationService.sendVerificationCode("user@ppt.com", "123", "/a-continue-url").map(
+        _ mustBe journeyId
+      )
     }
 
     "verify passcodes" when {
@@ -141,7 +143,7 @@ class EmailVerificationServiceSpec()
           new IllegalStateException("BANG!")
         )
         intercept[Exception] {
-          emailVerificationService.sendVerificationCode("user@ppt.com", "123")
+          emailVerificationService.sendVerificationCode("user@ppt.com", "123", "/a-continue-url")
         }
       }
 


### PR DESCRIPTION
### Description of Work carried through

Rationalise our implementations on email verification by doubling down in the recent `EmailVerficationService`.
Motivation; we're about to add a 3rd usage of email verification.



#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
