### PR TITLE
PPTP-1642 Prompt for user supplied names for Partner types which GRS does not supply names for

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameController.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
   SaveAndContinue
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.MemberName
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   Partner,
@@ -95,7 +96,7 @@ class PartnerContactNameController @Inject() (
                          partnerRoutes.PartnerTypeController.displayNewPartner(),
                          partnerRoutes.PartnerContactNameController.submitNewPartner(),
                          partnerRoutes.PartnerEmailAddressController.displayNewPartner(),
-                         partnerRoutes.PartnerContactNameController.displayNewPartner(),
+                         commonRoutes.TaskListController.displayPage(),
                          updateInflightPartner
         )
       }.getOrElse(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGRSRedirections.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGRSRedirections.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.AnyContent
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
+  PartnershipGrsConnector,
+  SoleTraderGrsConnector,
+  UkCompanyGrsConnector
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
+  IncorpEntityGrsCreateRequest,
+  PartnershipGrsCreateRequest,
+  SoleTraderGrsCreateRequest
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
+
+import scala.concurrent.Future
+
+trait PartnerGRSRedirections extends I18nSupport {
+
+  def appConfig: AppConfig
+  def soleTraderGrsConnector: SoleTraderGrsConnector
+  def ukCompanyGrsConnector: UkCompanyGrsConnector
+  def partnershipGrsConnector: PartnershipGrsConnector
+
+  def getUkCompanyRedirectUrl(url: String, partnerId: Option[String])(implicit
+    request: JourneyRequest[AnyContent],
+    hc: HeaderCarrier
+  ): Future[String] =
+    ukCompanyGrsConnector.createJourney(
+      IncorpEntityGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
+                                   Some(request2Messages(request)("service.name")),
+                                   appConfig.serviceIdentifier,
+                                   appConfig.signOutLink,
+                                   appConfig.grsAccessibilityStatementPath,
+                                   businessVerificationCheck = false
+      ),
+      url
+    )
+
+  def getPartnershipRedirectUrl(url: String, partnerId: Option[String])(implicit
+    request: JourneyRequest[AnyContent],
+    hc: HeaderCarrier
+  ): Future[String] =
+    partnershipGrsConnector.createJourney(
+      PartnershipGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
+                                  Some(request2Messages(request)("service.name")),
+                                  appConfig.serviceIdentifier,
+                                  appConfig.signOutLink,
+                                  appConfig.grsAccessibilityStatementPath
+      ),
+      url
+    )
+
+  def getSoleTraderRedirectUrl(url: String, partnerId: Option[String])(implicit
+    request: JourneyRequest[AnyContent],
+    hc: HeaderCarrier
+  ): Future[String] =
+    soleTraderGrsConnector.createJourney(
+      SoleTraderGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
+                                 Some(request2Messages(request)("service.name")),
+                                 appConfig.serviceIdentifier,
+                                 appConfig.signOutLink,
+                                 appConfig.grsAccessibilityStatementPath
+      ),
+      url
+    )
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -241,10 +241,23 @@ class PartnerGrsController @Inject() (
     soleTraderDetails: Option[SoleTraderDetails],
     incorporationDetails: Option[IncorporationDetails],
     partnershipDetails: Option[PartnerPartnershipDetails]
-  ): Partner =
+  ): Partner = {
+    // If we previously prompted the user to supply the name of this partnership,
+    // then we persisted it in a location which is about to be overwritten by this fresh GRS callback.
+    val partnershipDetailsWithPreservedPartnershipName =
+      partnershipDetails.map(
+        _.copy(partnershipName =
+          if (partner.canEditName)
+            partner.partnerPartnershipDetails.flatMap(_.partnershipName)
+          else
+            None
+        )
+      )
+
     partner.copy(soleTraderDetails = soleTraderDetails,
                  incorporationDetails = incorporationDetails,
-                 partnerPartnershipDetails = partnershipDetails
+                 partnerPartnershipDetails = partnershipDetailsWithPreservedPartnershipName
     )
+  }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -205,11 +205,15 @@ class PartnerGrsController @Inject() (
   )(implicit req: JourneyRequest[AnyContent]): Future[Either[ServiceError, Registration]] =
     update { registration =>
       registration.inflightPartner.map { partner =>
-        val withPartnerType = partner.copy(soleTraderDetails = soleTraderDetails,
-                                           incorporationDetails = incorporationDetails,
-                                           partnerPartnershipDetails = partnershipDetails
+        registration.withInflightPartner(
+          Some(
+            partnerWithUpdatedGRSDetails(partner,
+                                         soleTraderDetails,
+                                         incorporationDetails,
+                                         partnershipDetails
+            )
+          )
         )
-        registration.withInflightPartner(Some(withPartnerType))
       }.getOrElse {
         registration
       }
@@ -224,11 +228,23 @@ class PartnerGrsController @Inject() (
     update { registration =>
       registration.withUpdatedPartner(partnerId,
                                       partner =>
-                                        partner.copy(soleTraderDetails = soleTraderDetails,
-                                                     incorporationDetails = incorporationDetails,
-                                                     partnerPartnershipDetails = partnershipDetails
+                                        partnerWithUpdatedGRSDetails(partner,
+                                                                     soleTraderDetails,
+                                                                     incorporationDetails,
+                                                                     partnershipDetails
                                         )
       )
     }
+
+  private def partnerWithUpdatedGRSDetails(
+    partner: Partner,
+    soleTraderDetails: Option[SoleTraderDetails],
+    incorporationDetails: Option[IncorporationDetails],
+    partnershipDetails: Option[PartnerPartnershipDetails]
+  ) =
+    partner.copy(soleTraderDetails = soleTraderDetails,
+                 incorporationDetails = incorporationDetails,
+                 partnerPartnershipDetails = partnershipDetails
+    )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -244,15 +244,7 @@ class PartnerGrsController @Inject() (
   ): Partner =
     partner.copy(soleTraderDetails = soleTraderDetails,
                  incorporationDetails = incorporationDetails,
-                 partnerPartnershipDetails = partnershipDetails,
-                 userSuppliedName =
-                   // If this GRS return has supplied a GRS provided name then we should clear
-                   // any existing user supplied name; switching the partner type could cause
-                   // a sticky name
-                   if (partner.grsProvidedName.isEmpty)
-                     partner.userSuppliedName
-                   else
-                     None
+                 partnerPartnershipDetails = partnershipDetails
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -241,10 +241,18 @@ class PartnerGrsController @Inject() (
     soleTraderDetails: Option[SoleTraderDetails],
     incorporationDetails: Option[IncorporationDetails],
     partnershipDetails: Option[PartnerPartnershipDetails]
-  ) =
+  ): Partner =
     partner.copy(soleTraderDetails = soleTraderDetails,
                  incorporationDetails = incorporationDetails,
-                 partnerPartnershipDetails = partnershipDetails
+                 partnerPartnershipDetails = partnershipDetails,
+                 userSuppliedName =
+                   // If this GRS return has supplied a GRS provided name then we should clear
+                   // any existing user supplied name; switching the partner type could cause
+                   // a sticky name
+                   if (partner.grsProvidedName.isEmpty)
+                     partner.userSuppliedName
+                   else
+                     None
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.partnership_name
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class PartnerNameController @Inject() (
+  authenticate: AuthAction,
+  journeyAction: JourneyAction,
+  override val registrationConnector: RegistrationConnector,
+  mcc: MessagesControllerComponents,
+  page: partnership_name
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with Cacheable with I18nSupport {
+
+  def displayNewPartner(): Action[AnyContent] =
+    (authenticate andThen journeyAction) { implicit request =>
+      Ok("TODO")
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -41,10 +41,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTy
   SCOTTISH_PARTNERSHIP
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.PartnerName
-import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
-  Partner,
-  PartnerPartnershipDetails
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.Partner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
 import uk.gov.hmrc.plasticpackagingtax.registration.services.GRSRedirections
@@ -91,7 +88,7 @@ class PartnerNameController @Inject() (
   def submitNewPartner(): Action[AnyContent] =
     (authenticate andThen journeyAction).async { implicit request =>
       request.registration.inflightPartner.map { partner =>
-        partner.partnerType.map { partnerType =>
+        partner.partnerType.map { _ =>
           handleSubmission(partner,
                            None,
                            partnerRoutes.PartnerTypeController.displayNewPartner(),
@@ -206,11 +203,10 @@ class PartnerNameController @Inject() (
       )
     }
 
-  private def setPartnershipNameFor(partner: Partner, formData: PartnerName) = {
-    val partnershipDetailsWithPartnershipName: Option[PartnerPartnershipDetails] =
+  private def setPartnershipNameFor(partner: Partner, formData: PartnerName): Partner = {
+    val partnershipDetailsWithPartnershipName =
       partner.partnerPartnershipDetails.map(_.copy(partnershipName = Some(formData.value)))
-    val withName = partner.copy(partnerPartnershipDetails = partnershipDetailsWithPartnershipName)
-    withName
+    partner.copy(partnerPartnershipDetails = partnershipDetailsWithPartnershipName)
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -43,12 +43,10 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTy
   SCOTTISH_PARTNERSHIP
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.PartnerName
-import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
-  Partner,
-  PartnershipGrsCreateRequest
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.Partner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
+import uk.gov.hmrc.plasticpackagingtax.registration.services.GRSRedirections
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_name_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -67,7 +65,7 @@ class PartnerNameController @Inject() (
   mcc: MessagesControllerComponents,
   page: partner_name_page
 )(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with Cacheable with I18nSupport with PartnerGRSRedirections {
+    extends FrontendController(mcc) with Cacheable with I18nSupport with GRSRedirections {
 
   private val partnerTypesWhichPermitUserSuppliedNames =
     Set(PartnerTypeEnum.SCOTTISH_PARTNERSHIP, PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP)
@@ -167,11 +165,11 @@ class PartnerNameController @Inject() (
                     partnerType match {
                       case SCOTTISH_PARTNERSHIP =>
                         getPartnershipRedirectUrl(appConfig.scottishPartnershipJourneyUrl,
-                                                  existingPartnerId
+                                                  appConfig.partnerGrsCallbackUrl(existingPartnerId)
                         ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case SCOTTISH_LIMITED_PARTNERSHIP =>
                         getPartnershipRedirectUrl(appConfig.scottishLimitedPartnershipJourneyUrl,
-                                                  existingPartnerId
+                                                  appConfig.partnerGrsCallbackUrl(existingPartnerId)
                         ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case _ =>
                         //TODO later CHARITABLE_INCORPORATED_ORGANISATION & OVERSEAS_COMPANY_NO_UK_BRANCH will have their own not supported page

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -34,7 +34,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes 
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
-  LIMITED_LIABILITY_PARTNERSHIP,
   PartnerTypeEnum,
   SCOTTISH_LIMITED_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP
@@ -64,11 +63,8 @@ class PartnerNameController @Inject() (
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 
-  private val partnerTypesWhichPermitUserSuppliedNames = Set(
-    PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
-    PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP,
-    PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
-  )
+  private val partnerTypesWhichPermitUserSuppliedNames =
+    Set(PartnerTypeEnum.SCOTTISH_PARTNERSHIP, PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP)
 
   def displayNewPartner(): Action[AnyContent] =
     (authenticate andThen journeyAction) { implicit request =>
@@ -163,11 +159,6 @@ class PartnerNameController @Inject() (
                   case SaveAndContinue =>
                     // Select GRS journey type based on selected partner type
                     partnerType match {
-                      // TODO deduplicate this with PartnerTypeController
-                      case LIMITED_LIABILITY_PARTNERSHIP =>
-                        getPartnershipRedirectUrl(existingPartnerId,
-                                                  appConfig.limitedLiabilityPartnershipJourneyUrl
-                        ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case SCOTTISH_PARTNERSHIP =>
                         getPartnershipRedirectUrl(existingPartnerId,
                                                   appConfig.scottishPartnershipJourneyUrl
@@ -215,6 +206,7 @@ class PartnerNameController @Inject() (
       )
     }
 
+  // TODO deduplicate GRS redirects with PartnerTypeController
   private def getPartnershipRedirectUrl(
     existingPartnerId: Option[String],
     createJourneyUrlForPartnershipType: String

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -43,4 +43,9 @@ class PartnerNameController @Inject() (
       Ok("TODO")
     }
 
+  def displayExistingPartner(partnerId: String): Action[AnyContent] =
+    (authenticate andThen journeyAction) { implicit request =>
+      Ok("TODO")
+    }
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -68,7 +68,7 @@ class PartnerNameController @Inject() (
     extends FrontendController(mcc) with Cacheable with I18nSupport with GRSRedirections {
 
   private val partnerTypesWhichPermitUserSuppliedNames =
-    Set(PartnerTypeEnum.SCOTTISH_PARTNERSHIP, PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP)
+    Set(PartnerTypeEnum.SCOTTISH_PARTNERSHIP, PartnerTypeEnum.GENERAL_PARTNERSHIP)
 
   def displayNewPartner(): Action[AnyContent] =
     (authenticate andThen journeyAction) { implicit request =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -48,6 +48,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTy
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.Partner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
+import uk.gov.hmrc.plasticpackagingtax.registration.services.GRSRedirections
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.partner_type
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -66,7 +67,7 @@ class PartnerTypeController @Inject() (
   mcc: MessagesControllerComponents,
   page: partner_type
 )(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with Cacheable with I18nSupport with PartnerGRSRedirections {
+    extends FrontendController(mcc) with Cacheable with I18nSupport with GRSRedirections {
 
   def displayNewPartner(): Action[AnyContent] = displayPage()
 
@@ -104,14 +105,18 @@ class PartnerTypeController @Inject() (
                   case SaveAndContinue =>
                     partnershipPartnerType.answer match {
                       case Some(SOLE_TRADER) =>
-                        getSoleTraderRedirectUrl(appConfig.soleTraderJourneyUrl, partnerId)
+                        getSoleTraderRedirectUrl(appConfig.soleTraderJourneyUrl,
+                                                 appConfig.partnerGrsCallbackUrl(partnerId)
+                        )
                           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case Some(UK_COMPANY) | Some(OVERSEAS_COMPANY_UK_BRANCH) =>
-                        getUkCompanyRedirectUrl(appConfig.incorpLimitedCompanyJourneyUrl, partnerId)
+                        getUkCompanyRedirectUrl(appConfig.incorpLimitedCompanyJourneyUrl,
+                                                appConfig.partnerGrsCallbackUrl(partnerId)
+                        )
                           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case Some(LIMITED_LIABILITY_PARTNERSHIP) =>
                         getPartnershipRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl,
-                                                  partnerId
+                                                  appConfig.partnerGrsCallbackUrl(partnerId)
                         ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case Some(SCOTTISH_PARTNERSHIP) | Some(SCOTTISH_LIMITED_PARTNERSHIP) =>
                         redirectToPartnerNamePrompt(partnerId)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -41,6 +41,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTy
   GENERAL_PARTNERSHIP,
   LIMITED_LIABILITY_PARTNERSHIP,
   OVERSEAS_COMPANY_UK_BRANCH,
+  SCOTTISH_LIMITED_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP,
   SOLE_TRADER,
   UK_COMPANY
@@ -116,6 +117,10 @@ class PartnerTypeController @Inject() (
                           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case Some(LIMITED_LIABILITY_PARTNERSHIP) =>
                         getPartnershipRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl,
+                                                  appConfig.partnerGrsCallbackUrl(partnerId)
+                        ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
+                      case Some(SCOTTISH_LIMITED_PARTNERSHIP) =>
+                        getPartnershipRedirectUrl(appConfig.scottishLimitedPartnershipJourneyUrl,
                                                   appConfig.partnerGrsCallbackUrl(partnerId)
                         ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                       case Some(SCOTTISH_PARTNERSHIP) | Some(GENERAL_PARTNERSHIP) =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -38,9 +38,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes 
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
+  GENERAL_PARTNERSHIP,
   LIMITED_LIABILITY_PARTNERSHIP,
   OVERSEAS_COMPANY_UK_BRANCH,
-  SCOTTISH_LIMITED_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP,
   SOLE_TRADER,
   UK_COMPANY
@@ -118,7 +118,7 @@ class PartnerTypeController @Inject() (
                         getPartnershipRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl,
                                                   appConfig.partnerGrsCallbackUrl(partnerId)
                         ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
-                      case Some(SCOTTISH_PARTNERSHIP) | Some(SCOTTISH_LIMITED_PARTNERSHIP) =>
+                      case Some(SCOTTISH_PARTNERSHIP) | Some(GENERAL_PARTNERSHIP) =>
                         redirectToPartnerNamePrompt(partnerId)
                       case _ =>
                         //TODO later CHARITABLE_INCORPORATED_ORGANISATION & OVERSEAS_COMPANY_NO_UK_BRANCH will have their own not supported page

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -116,11 +116,11 @@ class PartnerTypeController @Inject() (
                           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
 
                       case Some(LIMITED_LIABILITY_PARTNERSHIP) =>
-                        redirectToPartnerNamePrompt
+                        redirectToPartnerNamePrompt(partnerId)
                       case Some(SCOTTISH_PARTNERSHIP) =>
-                        redirectToPartnerNamePrompt
+                        redirectToPartnerNamePrompt(partnerId)
                       case Some(SCOTTISH_LIMITED_PARTNERSHIP) =>
-                        redirectToPartnerNamePrompt
+                        redirectToPartnerNamePrompt(partnerId)
 
                       case _ =>
                         //TODO later CHARITABLE_INCORPORATED_ORGANISATION & OVERSEAS_COMPANY_NO_UK_BRANCH will have their own not supported page
@@ -204,11 +204,11 @@ class PartnerTypeController @Inject() (
       )
     }
 
-  private def redirectToPartnerNamePrompt: Future[Result] =
-    Future(
-      Redirect(
-        partnerRoutes.PartnerNameController.displayNewPartner() // TODO support exisitng partners
-      )
-    )
+  private def redirectToPartnerNamePrompt(existingParterId: Option[String]): Future[Result] =
+    Future {
+      Redirect(existingParterId.map { partnerId =>
+        partnerRoutes.PartnerNameController.displayExistingPartner(partnerId)
+      }.getOrElse(partnerRoutes.PartnerNameController.displayNewPartner()))
+    }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -22,7 +22,6 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
-  PartnershipGrsConnector,
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
@@ -48,7 +47,6 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTy
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
   IncorpEntityGrsCreateRequest,
   Partner,
-  PartnershipGrsCreateRequest,
   SoleTraderGrsCreateRequest
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
@@ -66,7 +64,6 @@ class PartnerTypeController @Inject() (
   appConfig: AppConfig,
   soleTraderGrsConnector: SoleTraderGrsConnector,
   ukCompanyGrsConnector: UkCompanyGrsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
   override val registrationConnector: RegistrationConnector,
   mcc: MessagesControllerComponents,
   page: partner_type
@@ -146,19 +143,6 @@ class PartnerTypeController @Inject() (
                                    appConfig.signOutLink,
                                    appConfig.grsAccessibilityStatementPath,
                                    businessVerificationCheck = false
-      ),
-      url
-    )
-
-  private def getPartnershipRedirectUrl(url: String, partnerId: Option[String])(implicit
-    request: JourneyRequest[AnyContent]
-  ): Future[String] =
-    partnershipGrsConnector.createJourney(
-      PartnershipGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
-                                  Some(request2Messages(request)("service.name")),
-                                  appConfig.serviceIdentifier,
-                                  appConfig.signOutLink,
-                                  appConfig.grsAccessibilityStatementPath
       ),
       url
     )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/partner/PartnerName.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/partner/PartnerName.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.forms.partner
+
+import play.api.data.{Form, Forms}
+import play.api.data.Forms.text
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address.{
+  isMatchingPattern,
+  isNonEmpty
+}
+
+import java.util.regex.Pattern
+
+case class PartnerName(value: String)
+
+object PartnerName {
+
+  implicit val format: OFormat[PartnerName] = Json.format[PartnerName]
+  val partnerNameEmptyError                 = "partner.name.empty.error"
+  val partnerNameFormatError                = "partner.name.format.error"
+
+  private val PARTNER_NAME_REGEX =
+    Pattern.compile("""^[a-zA-Z0-9À-ÿ !#$%&'‘’"“”«»()*+,./:;=?@\[\]£€¥\\—–‐-]{1,160}$""")
+
+  val maxLength   = 160
+  val partnerName = "value"
+
+  private val mapping = Forms.mapping(
+    partnerName ->
+      text()
+        .verifying(partnerNameEmptyError, isNonEmpty)
+        .verifying(partnerNameFormatError,
+                   partnerName =>
+                     !isNonEmpty(partnerName) || isMatchingPattern(partnerName, PARTNER_NAME_REGEX)
+        )
+  )(PartnerName.apply)(PartnerName.unapply)
+
+  def form(): Form[PartnerName] = Form(mapping)
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/partner/PartnerName.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/partner/PartnerName.scala
@@ -31,8 +31,8 @@ case class PartnerName(value: String)
 object PartnerName {
 
   implicit val format: OFormat[PartnerName] = Json.format[PartnerName]
-  val partnerNameEmptyError                 = "partner.name.empty.error"
-  val partnerNameFormatError                = "partner.name.format.error"
+  val partnerNameEmptyError                 = "partnership.name.empty.error"
+  val partnerNameFormatError                = "partnership.name.format.error"
 
   private val PARTNER_NAME_REGEX =
     Pattern.compile("""^[a-zA-Z0-9À-ÿ !#$%&'‘’"“”«»()*+,./:;=?@\[\]£€¥\\—–‐-]{1,160}$""")

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -30,8 +30,7 @@ case class Partner(
   incorporationDetails: Option[IncorporationDetails] = None,
   partnerPartnershipDetails: Option[PartnerPartnershipDetails] = None,
   contactDetails: Option[PartnerContactDetails] = None,
-  organisationName: Option[String] =
-    None // TODO remove in favour of partner.name
+  userSuppliedName: Option[String] = None
 ) {
 
   lazy val name: String = {
@@ -45,7 +44,8 @@ case class Partner(
       case _ =>
         incorporationDetails.map(_.companyName)
     }
-    grsProvidedName.getOrElse(throw new IllegalStateException("Partner name absent"))
+    val availableNames = Seq(userSuppliedName, grsProvidedName).flatten
+    availableNames.headOption.getOrElse(throw new IllegalStateException("Partner name absent"))
   }
 
   def withContactAddress(contactAddress: Address): Partner =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -34,21 +34,18 @@ case class Partner(
     None // TODO remove in favour of partner.name
 ) {
 
-  lazy val name: String = partnerType match {
-    case Some(PartnerTypeEnum.SOLE_TRADER) =>
-      soleTraderDetails.map(_.name).getOrElse(
-        throw new IllegalStateException("Sole Trader details absent")
-      )
-    case Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP) | Some(
-          PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
-        ) | Some(PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP) =>
-      partnerPartnershipDetails.flatMap(_.name).getOrElse(
-        throw new IllegalStateException("Partnership details absent")
-      )
-    case _ =>
-      incorporationDetails.map(_.companyName).getOrElse(
-        throw new IllegalStateException("Incorporation details absent")
-      )
+  lazy val name: String = {
+    val grsProvidedName = partnerType match {
+      case Some(PartnerTypeEnum.SOLE_TRADER) =>
+        soleTraderDetails.map(_.name)
+      case Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) | Some(
+            PartnerTypeEnum.SCOTTISH_PARTNERSHIP
+          ) | Some(PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP) =>
+        partnerPartnershipDetails.flatMap(_.partnershipName)
+      case _ =>
+        incorporationDetails.map(_.companyName)
+    }
+    grsProvidedName.getOrElse(throw new IllegalStateException("Partner name absent"))
   }
 
   def withContactAddress(contactAddress: Address): Partner =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -42,10 +42,8 @@ case class Partner(
     val grsProvidedName = partnerType match {
       case Some(PartnerTypeEnum.SOLE_TRADER) =>
         soleTraderDetails.map(_.name)
-      case Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) | Some(
-            PartnerTypeEnum.SCOTTISH_PARTNERSHIP
-          ) | Some(PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP) =>
-        partnerPartnershipDetails.flatMap(_.partnershipName)
+      case Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) =>
+        partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.flatMap(_.companyName))
       case _ =>
         incorporationDetails.map(_.companyName)
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -34,6 +34,11 @@ case class Partner(
 ) {
 
   lazy val name: String = {
+    val availableNames = Seq(userSuppliedName, grsProvidedName).flatten
+    availableNames.headOption.getOrElse(throw new IllegalStateException("Partner name absent"))
+  }
+
+  def grsProvidedName: Option[String] = {
     val grsProvidedName = partnerType match {
       case Some(PartnerTypeEnum.SOLE_TRADER) =>
         soleTraderDetails.map(_.name)
@@ -44,8 +49,7 @@ case class Partner(
       case _ =>
         incorporationDetails.map(_.companyName)
     }
-    val availableNames = Seq(userSuppliedName, grsProvidedName).flatten
-    availableNames.headOption.getOrElse(throw new IllegalStateException("Partner name absent"))
+    grsProvidedName
   }
 
   def withContactAddress(contactAddress: Address): Partner =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -35,18 +35,18 @@ case class Partner(
   lazy val name: String = partnerType match {
     case Some(PartnerTypeEnum.SOLE_TRADER) =>
       soleTraderDetails.map(_.name).getOrElse(
-        throw new IllegalStateException("Sole Trader details absent")
+        throw new IllegalStateException("Sole Trader details name absent")
       )
     case Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP) | Some(PartnerTypeEnum.GENERAL_PARTNERSHIP) |
         Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) | Some(
           PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP
         ) =>
       partnerPartnershipDetails.flatMap(_.name).getOrElse(
-        throw new IllegalStateException("Partnership details absent")
+        throw new IllegalStateException("Partnership details name absent")
       )
     case _ =>
       incorporationDetails.map(_.companyName).getOrElse(
-        throw new IllegalStateException("Incorporation details absent")
+        throw new IllegalStateException("Incorporation details name absent")
       )
   }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -53,6 +53,14 @@ case class Partner(
   def withContactAddress(contactAddress: Address): Partner =
     this.copy(contactDetails = this.contactDetails.map(_.withUpdatedAddress(contactAddress)))
 
+  def canEditName: Boolean = {
+    val partnerTypesWhichPermitUserSuppliedNames =
+      Set(PartnerTypeEnum.SCOTTISH_PARTNERSHIP, PartnerTypeEnum.GENERAL_PARTNERSHIP)
+    partnerType.exists { partnerType =>
+      partnerTypesWhichPermitUserSuppliedNames.contains(partnerType)
+    }
+  }
+
 }
 
 object Partner {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -29,25 +29,25 @@ case class Partner(
   soleTraderDetails: Option[SoleTraderDetails] = None,
   incorporationDetails: Option[IncorporationDetails] = None,
   partnerPartnershipDetails: Option[PartnerPartnershipDetails] = None,
-  contactDetails: Option[PartnerContactDetails] = None,
-  userSuppliedName: Option[String] = None
+  contactDetails: Option[PartnerContactDetails] = None
 ) {
 
-  lazy val name: String = {
-    val availableNames = Seq(userSuppliedName, grsProvidedName).flatten
-    availableNames.headOption.getOrElse(throw new IllegalStateException("Partner name absent"))
-  }
-
-  def grsProvidedName: Option[String] = {
-    val grsProvidedName = partnerType match {
-      case Some(PartnerTypeEnum.SOLE_TRADER) =>
-        soleTraderDetails.map(_.name)
-      case Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) =>
-        partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.flatMap(_.companyName))
-      case _ =>
-        incorporationDetails.map(_.companyName)
-    }
-    grsProvidedName
+  lazy val name: String = partnerType match {
+    case Some(PartnerTypeEnum.SOLE_TRADER) =>
+      soleTraderDetails.map(_.name).getOrElse(
+        throw new IllegalStateException("Sole Trader details absent")
+      )
+    case Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP) | Some(PartnerTypeEnum.GENERAL_PARTNERSHIP) |
+        Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) | Some(
+          PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP
+        ) =>
+      partnerPartnershipDetails.flatMap(_.name).getOrElse(
+        throw new IllegalStateException("Partnership details absent")
+      )
+    case _ =>
+      incorporationDetails.map(_.companyName).getOrElse(
+        throw new IllegalStateException("Incorporation details absent")
+      )
   }
 
   def withContactAddress(contactAddress: Address): Partner =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -19,10 +19,12 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
+  GENERAL_PARTNERSHIP,
   LIMITED_LIABILITY_PARTNERSHIP,
   LIMITED_PARTNERSHIP,
   PartnerTypeEnum,
-  SCOTTISH_LIMITED_PARTNERSHIP
+  SCOTTISH_LIMITED_PARTNERSHIP,
+  SCOTTISH_PARTNERSHIP
 }
 
 case class PartnershipDetails(
@@ -78,8 +80,17 @@ object PartnershipDetails {
 
 case class PartnerPartnershipDetails(
   partnershipType: PartnerTypeEnum,
+  partnershipName: Option[String] = None,
   partnershipBusinessDetails: Option[PartnershipBusinessDetails] = None
-)
+) {
+
+  lazy val name: Option[String] = partnershipType match {
+    case GENERAL_PARTNERSHIP | SCOTTISH_PARTNERSHIP =>
+      partnershipName
+    case _ => partnershipBusinessDetails.flatMap(_.companyProfile.map(_.companyName))
+  }
+
+}
 
 object PartnerPartnershipDetails {
   implicit val format: OFormat[PartnerPartnershipDetails] = Json.format[PartnerPartnershipDetails]

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -78,7 +78,6 @@ object PartnershipDetails {
 
 case class PartnerPartnershipDetails(
   partnershipType: PartnerTypeEnum,
-  partnershipName: Option[String] = None,
   partnershipBusinessDetails: Option[PartnershipBusinessDetails] = None
 )
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -89,7 +89,7 @@ case class PartnerPartnershipDetails(
       if (partnershipName.isDefined)
         partnershipName
       else
-        Some("TODO: Capture Non-Incorp Partnership Name")
+        Some("TODO: Capture Non-Incorp Partnership Name") // TODO Confirm is this is still active
     case _ => partnershipBusinessDetails.flatMap(_.companyProfile.map(_.companyName))
   }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -19,12 +19,10 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
-  GENERAL_PARTNERSHIP,
   LIMITED_LIABILITY_PARTNERSHIP,
   LIMITED_PARTNERSHIP,
   PartnerTypeEnum,
-  SCOTTISH_LIMITED_PARTNERSHIP,
-  SCOTTISH_PARTNERSHIP
+  SCOTTISH_LIMITED_PARTNERSHIP
 }
 
 case class PartnershipDetails(
@@ -84,11 +82,10 @@ case class PartnerPartnershipDetails(
   partnershipBusinessDetails: Option[PartnershipBusinessDetails] = None
 ) {
 
-  lazy val name: Option[String] = partnershipType match {
-    case GENERAL_PARTNERSHIP | SCOTTISH_PARTNERSHIP =>
-      partnershipName
-    case _ => partnershipBusinessDetails.flatMap(_.companyProfile.map(_.companyName))
-  }
+  lazy val name: Option[String] =
+    Seq(partnershipName,
+        partnershipBusinessDetails.flatMap(_.companyProfile.map(_.companyName))
+    ).flatten.headOption
 
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -82,18 +82,7 @@ case class PartnerPartnershipDetails(
   partnershipType: PartnerTypeEnum,
   partnershipName: Option[String] = None,
   partnershipBusinessDetails: Option[PartnershipBusinessDetails] = None
-) {
-
-  lazy val name: Option[String] = partnershipType match {
-    case GENERAL_PARTNERSHIP | SCOTTISH_PARTNERSHIP =>
-      if (partnershipName.isDefined)
-        partnershipName
-      else
-        Some("TODO: Capture Non-Incorp Partnership Name") // TODO Confirm is this is still active
-    case _ => partnershipBusinessDetails.flatMap(_.companyProfile.map(_.companyName))
-  }
-
-}
+)
 
 object PartnerPartnershipDetails {
   implicit val format: OFormat[PartnerPartnershipDetails] = Json.format[PartnerPartnershipDetails]

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -19,12 +19,10 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
-  GENERAL_PARTNERSHIP,
   LIMITED_LIABILITY_PARTNERSHIP,
   LIMITED_PARTNERSHIP,
   PartnerTypeEnum,
-  SCOTTISH_LIMITED_PARTNERSHIP,
-  SCOTTISH_PARTNERSHIP
+  SCOTTISH_LIMITED_PARTNERSHIP
 }
 
 case class PartnershipDetails(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/services/GRSRedirections.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/services/GRSRedirections.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
+package uk.gov.hmrc.plasticpackagingtax.registration.services
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.AnyContent
@@ -34,54 +34,55 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyReques
 
 import scala.concurrent.Future
 
-trait PartnerGRSRedirections extends I18nSupport {
+// Can be migrated from trait to a service to reduce dependency injections in callers
+trait GRSRedirections extends I18nSupport {
 
   def appConfig: AppConfig
   def soleTraderGrsConnector: SoleTraderGrsConnector
   def ukCompanyGrsConnector: UkCompanyGrsConnector
   def partnershipGrsConnector: PartnershipGrsConnector
 
-  def getUkCompanyRedirectUrl(url: String, partnerId: Option[String])(implicit
+  def getUkCompanyRedirectUrl(grsUrl: String, callbackUrl: String)(implicit
     request: JourneyRequest[AnyContent],
     hc: HeaderCarrier
   ): Future[String] =
     ukCompanyGrsConnector.createJourney(
-      IncorpEntityGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
+      IncorpEntityGrsCreateRequest(callbackUrl,
                                    Some(request2Messages(request)("service.name")),
                                    appConfig.serviceIdentifier,
                                    appConfig.signOutLink,
                                    appConfig.grsAccessibilityStatementPath,
                                    businessVerificationCheck = false
       ),
-      url
+      grsUrl
     )
 
-  def getPartnershipRedirectUrl(url: String, partnerId: Option[String])(implicit
+  def getPartnershipRedirectUrl(grsUrl: String, callbackUrl: String)(implicit
     request: JourneyRequest[AnyContent],
     hc: HeaderCarrier
   ): Future[String] =
     partnershipGrsConnector.createJourney(
-      PartnershipGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
+      PartnershipGrsCreateRequest(callbackUrl,
                                   Some(request2Messages(request)("service.name")),
                                   appConfig.serviceIdentifier,
                                   appConfig.signOutLink,
                                   appConfig.grsAccessibilityStatementPath
       ),
-      url
+      grsUrl
     )
 
-  def getSoleTraderRedirectUrl(url: String, partnerId: Option[String])(implicit
+  def getSoleTraderRedirectUrl(grsUrl: String, callbackUrl: String)(implicit
     request: JourneyRequest[AnyContent],
     hc: HeaderCarrier
   ): Future[String] =
     soleTraderGrsConnector.createJourney(
-      SoleTraderGrsCreateRequest(appConfig.partnerGrsCallbackUrl(partnerId),
+      SoleTraderGrsCreateRequest(callbackUrl,
                                  Some(request2Messages(request)("service.name")),
                                  appConfig.serviceIdentifier,
                                  appConfig.signOutLink,
                                  appConfig.grsAccessibilityStatementPath
       ),
-      url
+      grsUrl
     )
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -34,6 +34,15 @@
 
 @(partner: Partner)(implicit request: JourneyRequest[_], messages: Messages)
 
+@changePartnerNameLink = @{
+    if(partner.canEditName) {
+        Some(partnerRoutes.PartnerNameController.displayExistingPartner(partner.id))
+    } else {
+        None
+    }
+}
+
+
 @partnerContactRows() = @{
     Seq(
         viewUtils.summaryListRow("partner.check.contact.name", partner.contactDetails.flatMap(_.name), Some(partnerRoutes.PartnerContactNameController.displayExistingPartner(partner.id))),
@@ -71,7 +80,7 @@
     SummaryList(
         rows = Seq(
             viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
-            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), None),
+            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), changePartnerNameLink),
             viewUtils.summaryListRow("partner.check.sautr", partner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.map(_.sautr)), None),
         ) ++ partnerContactRows().filterNot(_.value.content == Empty)
     )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -71,7 +71,7 @@
     SummaryList(
         rows = Seq(
             viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
-            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), Some(partnerRoutes.PartnerNameController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), partner.userSuppliedName.map(_ => partnerRoutes.PartnerNameController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("partner.check.sautr", partner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.map(_.sautr)), None),
         ) ++ partnerContactRows().filterNot(_.value.content == Empty)
     )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -71,7 +71,7 @@
     SummaryList(
         rows = Seq(
             viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
-            viewUtils.summaryListRow("partner.check.orgName", partner.partnerPartnershipDetails.flatMap(_.name), None),
+            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), Some(partnerRoutes.PartnerNameController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("partner.check.sautr", partner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.map(_.sautr)), None),
         ) ++ partnerContactRows().filterNot(_.value.content == Empty)
     )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -71,7 +71,7 @@
     SummaryList(
         rows = Seq(
             viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
-            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), partner.userSuppliedName.map(_ => partnerRoutes.PartnerNameController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), None),
             viewUtils.summaryListRow("partner.check.sautr", partner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.map(_.sautr)), None),
         ) ++ partnerContactRows().filterNot(_.value.content == Empty)
     )

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
@@ -35,7 +35,7 @@
 @partnerNameField = @{form("value")}
 
 @govukLayout(
-    title = Title("partner.name.title"),
+    title = Title("partnership.name.title"),
     backButton = Some(BackButton(messages("site.back"), backLink, messages("site.back.hiddenText")))) {
 
     @errorSummary(form.errors)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
-@import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnershipName
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.PartnerName
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
 
@@ -30,7 +30,7 @@
     errorSummary: errorSummary
 )
 
-@(form: Form[PartnershipName], backLink: Call, updateCall: Call)(implicit request: Request[_], messages: Messages)
+@(form: Form[PartnerName], backLink: Call, updateCall: Call)(implicit request: Request[_], messages: Messages)
 
 @partnerNameField = @{form("value")}
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
@@ -1,0 +1,60 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.{routes => pptRoutes}
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnershipName
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.model.{BackButton, Title}
+
+@this(
+    formHelper: FormWithCSRF,
+    pageHeading: pageHeading,
+    govukLayout: main_template,
+    govukInput: GovukInput,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    errorSummary: errorSummary
+)
+
+@(form: Form[PartnershipName], backLink: Call, updateCall: Call)(implicit request: Request[_], messages: Messages)
+
+@partnerNameField = @{form("value")}
+
+@govukLayout(
+    title = Title("partner.name.title"),
+    backButton = Some(BackButton(messages("site.back"), backLink, messages("site.back.hiddenText")))) {
+
+    @errorSummary(form.errors)
+
+    @formHelper(action = updateCall, 'autoComplete -> "off") {
+
+        @govukInput(
+            Input(
+                id = partnerNameField.name,
+                name = partnerNameField.name,
+                value = partnerNameField.value,
+                label = Label(
+                    isPageHeading = true,
+                    classes = gdsLabelPageHeading,
+                    content = Text(messages("partner.name.title"))),
+                errorMessage = partnerNameField.error.map(err => ErrorMessage(content = Text(messages(err.message))))
+            )
+        )
+
+        @saveButtons()
+    }
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_name_page.scala.html
@@ -50,7 +50,7 @@
                 label = Label(
                     isPageHeading = true,
                     classes = gdsLabelPageHeading,
-                    content = Text(messages("partner.name.title"))),
+                    content = Text(messages("partnership.name.title"))),
                 errorMessage = partnerNameField.error.map(err => ErrorMessage(content = Text(messages(err.message))))
             )
         )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -93,7 +93,9 @@ POST       /partnership-partner-type    uk.gov.hmrc.plasticpackagingtax.registra
 POST       /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitExistingPartner(partnerId: String)
 
 GET        /partner-name                        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayNewPartner()
+POST       /partner-name                        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.submitNewPartner()
 GET        /partner-name/:partnerId             uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayExistingPartner(partnerId: String)
+POST       /partner-name/:partnerId             uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.submitExistingPartner(partnerId: String)
 
 GET        /partner-grs-callback   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsController.grsCallbackNewPartner(journeyId)
 GET        /partner-grs-callback/:partnerId   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsController.grsCallbackExistingPartner(journeyId, partnerId)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -92,6 +92,8 @@ GET        /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingt
 POST       /partnership-partner-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitNewPartner()
 POST       /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitExistingPartner(partnerId: String)
 
+GET        /partner-name                            uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayNewPartner()
+
 GET        /partner-grs-callback   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsController.grsCallbackNewPartner(journeyId)
 GET        /partner-grs-callback/:partnerId   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsController.grsCallbackExistingPartner(journeyId, partnerId)
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -92,7 +92,8 @@ GET        /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingt
 POST       /partnership-partner-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitNewPartner()
 POST       /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitExistingPartner(partnerId: String)
 
-GET        /partner-name                            uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayNewPartner()
+GET        /partner-name                        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayNewPartner()
+GET        /partner-name/:partnerId             uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayExistingPartner(partnerId: String)
 
 GET        /partner-grs-callback   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsController.grsCallbackNewPartner(journeyId)
 GET        /partner-grs-callback/:partnerId   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsController.grsCallbackExistingPartner(journeyId, partnerId)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -340,7 +340,7 @@ organisationDetails.type.GroupNominatedPartnership = Limited liability partnersh
 partnership.type.title = What type of partnership are you registering?
 partnership.type.empty.error = Value must be selected
 
-partnership.name.title = What's the name of the partnership?
+partnership.name.title = What’s the name of the partnership?
 partnership.name.empty.error = Please enter your partnership name
 partnership.name.format.error = Please enter your partnership name in correct format
 
@@ -614,6 +614,10 @@ partner.check.contact.name = Contact name
 partner.check.contact.email = Contact email
 partner.check.contact.phone = Phone number
 partner.check.contact.address = Contact address
+
+partner.name.title = What’s the name of the partner?
+partner.name.empty.error = Please enter your partner name
+partner.name.format.error = Please enter your partner name in correct format
 
 partnership.partnerList.title = You have added {0} partners
 partnership.partnerList.nominatedPartner = Nominated partner

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -615,13 +615,6 @@ partner.check.contact.email = Contact email
 partner.check.contact.phone = Phone number
 partner.check.contact.address = Contact address
 
-partner.name.title = What’s the name of the partner?
-partner.name.empty.error = Please enter your partner name
-partner.name.format.error = Please enter your partner name in correct format
-partner.name.title = What’s the name of the partner?
-partner.name.empty.error = Please enter your partner name
-partner.name.format.error = Please enter your partner name in correct format
-
 partnership.partnerList.title = You have added {0} partners
 partnership.partnerList.nominatedPartner = Nominated partner
 partnership.partnerList.subHeading = Do you need to add another partner?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -618,6 +618,9 @@ partner.check.contact.address = Contact address
 partner.name.title = What’s the name of the partner?
 partner.name.empty.error = Please enter your partner name
 partner.name.format.error = Please enter your partner name in correct format
+partner.name.title = What’s the name of the partner?
+partner.name.empty.error = Please enter your partner name
+partner.name.format.error = Please enter your partner name in correct format
 
 partnership.partnerList.title = You have added {0} partners
 partnership.partnerList.nominatedPartner = Nominated partner

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -590,6 +590,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     Partner(partnerType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP),
             partnerPartnershipDetails = Some(
               PartnerPartnershipDetails(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
+                                        partnershipName = Some("The Plastic Partnership"),
                                         partnershipBusinessDetails = Some(
                                           PartnershipBusinessDetails(sautr = "234923487362",
                                                                      postcode = "LS1 1HS",
@@ -621,8 +622,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                                       )
                                     )
               )
-            ),
-            userSuppliedName = Some("The Plastic Partnership")
+            )
     )
 
 }

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -590,7 +590,6 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     Partner(partnerType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP),
             partnerPartnershipDetails = Some(
               PartnerPartnershipDetails(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
-                                        partnershipName = Some("The Plastic Partnership"),
                                         partnershipBusinessDetails = Some(
                                           PartnershipBusinessDetails(sautr = "234923487362",
                                                                      postcode = "LS1 1HS",
@@ -622,7 +621,8 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
                                       )
                                     )
               )
-            )
+            ),
+            userSuppliedName = Some("The Plastic Partnership")
     )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerSpec.scala
@@ -27,7 +27,6 @@ import play.api.test.Helpers.status
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.MemberName
-import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.PartnerContactDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_member_name_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -121,7 +120,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
 
         status(result) mustBe SEE_OTHER
 
-        val modifiedContactDetails: Option[PartnerContactDetails] =
+        val modifiedContactDetails =
           modifiedRegistration.findPartner(existingPartner.id).flatMap(_.contactDetails)
         modifiedContactDetails.flatMap(_.firstName) mustBe Some("Jane")
         modifiedContactDetails.flatMap(_.lastName) mustBe Some("Smith")

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerSpec.scala
@@ -68,7 +68,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
       withPartnershipDetails(Some(generalPartnershipDetails.copy(partners = Seq(existingPartner))))
     )
 
-  "PartnerEmailAddressController" should {
+  "PartnerContactNameController" should {
 
     "return 200" when {
       "user is authorised, a registration already exists with already collected nominated partner" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerEmailAddressControllerSpec.scala
@@ -75,7 +75,7 @@ class PartnerEmailAddressControllerSpec extends ControllerSpec with DefaultAwait
       withPartnershipDetails(Some(generalPartnershipDetails.copy(partners = Seq(existingPartner))))
     )
 
-  "PartnershipOtherPartnerEmailAddressController" should {
+  "PartnerEmailAddressController" should {
 
     "return 200" when {
       "user is authorised, a registration already exists with already collected contact name and display page method is invoked" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerEmailAddressControllerSpec.scala
@@ -120,9 +120,23 @@ class PartnerEmailAddressControllerSpec extends ControllerSpec with DefaultAwait
 
         status(result) mustBe SEE_OTHER
 
-        modifiedRegistration.inflightPartner.flatMap(
-          _.contactDetails.flatMap(_.emailAddress)
-        ) mustBe Some("test@localhost")
+        modifiedRegistration.inflightPartner.flatMap(_.contactDetails.flatMap(_.emailAddress))
+      }
+
+      "user submits an amendment to an existing partners email address" in {
+        authorizedUser()
+        mockRegistrationFind(registrationWithExistingPartner)
+        mockRegistrationUpdate()
+
+        val result = controller.submitExistingPartner(existingPartner.id)(
+          postRequestEncoded(EmailAddress("amended@localhost"))
+        )
+
+        status(result) mustBe SEE_OTHER
+
+        modifiedRegistration.findPartner(existingPartner.id).flatMap(_.contactDetails).flatMap(
+          _.emailAddress
+        ) mustBe Some("amended@localhost")
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
@@ -36,10 +36,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTy
   SOLE_TRADER,
   UK_COMPANY
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{
-  Partner,
-  PartnerPartnershipDetails
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.PartnerPartnershipDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.SubscriptionStatus.{
   NOT_SUBSCRIBED,
   SUBSCRIBED

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
@@ -101,15 +101,9 @@ class PartnerGrsControllerSpec extends ControllerSpec {
           mockRegistrationFind(registration)
           mockRegistrationUpdate()
 
-          partnershipDetails._1 match {
-            case SOLE_TRADER => mockGetSoleTraderDetails(soleTraderDetails)
-            case UK_COMPANY | OVERSEAS_COMPANY_UK_BRANCH =>
-              mockGetUkCompanyDetails(incorporationDetails)
-            case LIMITED_LIABILITY_PARTNERSHIP | LIMITED_PARTNERSHIP | SCOTTISH_PARTNERSHIP |
-                SCOTTISH_LIMITED_PARTNERSHIP =>
-              mockGetPartnershipBusinessDetails(partnershipBusinessDetails)
-            case _ =>
-          }
+          mockGetSoleTraderDetails(soleTraderDetails)
+          mockGetUkCompanyDetails(incorporationDetails)
+          mockGetPartnershipBusinessDetails(partnershipBusinessDetails)
 
           val result =
             controller.grsCallbackNewPartner(registration.incorpJourneyId.get)(getRequest())

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
@@ -191,6 +191,36 @@ class PartnerGrsControllerSpec extends ControllerSpec {
         )
       }
     }
+
+    "update registration" when {
+      "called back to with a supported partner type" in {
+        val registration = aRegistration(
+          withPartnershipDetails(
+            Some(
+              scottishPartnershipDetails.copy(inflightPartner =
+                Some(nominatedPartner(PartnerTypeEnum.SCOTTISH_PARTNERSHIP))
+              )
+            )
+          )
+        )
+        authorizedUser()
+        mockGetUkCompanyDetails(incorporationDetails)
+        mockRegistrationFind(registration)
+        mockRegistrationUpdate()
+        mockGetSubscriptionStatus(SubscriptionStatusResponse(SUBSCRIBED, Some("XDPPT1234567890")))
+        mockGetPartnershipBusinessDetails(partnershipBusinessDetails)
+
+        val result =
+          controller.grsCallbackNewPartner(registration.incorpJourneyId.get)(getRequest())
+
+        status(result) mustBe SEE_OTHER
+
+        // businessPartnerId is an example of a field we would expect to have captured from GRS
+        modifiedRegistration.organisationDetails.partnerBusinessPartnerId(None) mustBe Some(
+          "XXPPTP123456789"
+        )
+      }
+    }
   }
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
@@ -22,13 +22,12 @@ import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status.SEE_OTHER
 import play.api.test.Helpers.{await, redirectLocation, status}
 import uk.gov.hmrc.http.InternalServerException
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => pptRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
   CHARITABLE_INCORPORATED_ORGANISATION,
   LIMITED_LIABILITY_PARTNERSHIP,
-  LIMITED_PARTNERSHIP,
   OVERSEAS_COMPANY_NO_UK_BRANCH,
   OVERSEAS_COMPANY_UK_BRANCH,
   SCOTTISH_LIMITED_PARTNERSHIP,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerSpec.scala
@@ -41,6 +41,8 @@ class PartnerNameControllerSpec extends ControllerSpec with DefaultAwaitTimeout 
                               registrationConnector =
                                 mockRegistrationConnector,
                               config,
+                              soleTraderGrsConnector = mockSoleTraderGrsConnector,
+                              ukCompanyGrsConnector = mockUkCompanyGrsConnector,
                               mockPartnershipGrsConnector,
                               mcc = mcc,
                               page = page

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerSpec.scala
@@ -111,7 +111,9 @@ class PartnerNameControllerSpec extends ControllerSpec with DefaultAwaitTimeout 
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("https://test/redirect/grs/identify-partnership")
-        modifiedRegistration.inflightPartner.flatMap(_.userSuppliedName) mustBe Some("Test Partner")
+        modifiedRegistration.inflightPartner.flatMap(
+          _.partnerPartnershipDetails.flatMap(_.partnershipName)
+        ) mustBe Some("Test Partner")
       }
 
       "user submits an amendment to an existing partners name" in {
@@ -127,7 +129,7 @@ class PartnerNameControllerSpec extends ControllerSpec with DefaultAwaitTimeout 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some("https://test/redirect/grs/identify-partnership")
         modifiedRegistration.findPartner(existingPartner.id).flatMap(
-          _.userSuppliedName
+          _.partnerPartnershipDetails.flatMap(_.partnershipName)
         ) mustBe Some("Test Partner")
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerSpec.scala
@@ -76,7 +76,7 @@ class PartnerNameControllerSpec extends ControllerSpec with DefaultAwaitTimeout 
       withPartnershipDetails(Some(generalPartnershipDetails.copy(partners = Seq(existingPartner))))
     )
 
-  "PartnerEmailAddressController" should {
+  "PartnerNameController" should {
 
     "return 200" when {
       "user is authorised, a registration already exists with inflight partner" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerPhoneNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerPhoneNumberControllerSpec.scala
@@ -86,7 +86,7 @@ class PartnerPhoneNumberControllerSpec extends ControllerSpec with DefaultAwaitT
       withPartnershipDetails(Some(generalPartnershipDetails.copy(partners = Seq(existingPartner))))
     )
 
-  "PartnershipOtherPartnerPhoneNumberController" should {
+  "PartnerPhoneNumberController" should {
 
     "return 200" when {
       "user is authorised, a registration already exists with already collected contact name and display page method is invoked" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
@@ -43,6 +43,7 @@ class PartnerTypeControllerSpec extends ControllerSpec {
     appConfig = appConfig,
     soleTraderGrsConnector = mockSoleTraderGrsConnector,
     ukCompanyGrsConnector = mockUkCompanyGrsConnector,
+    partnershipGrsConnector = mockPartnershipGrsConnector,
     registrationConnector = mockRegistrationConnector,
     mcc = mcc,
     page = page
@@ -110,6 +111,11 @@ class PartnerTypeControllerSpec extends ControllerSpec {
       "user selected a type which has a GRS provided name" when {
         forAll(
           Seq(
+            (LIMITED_LIABILITY_PARTNERSHIP,
+             llpPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(LIMITED_LIABILITY_PARTNERSHIP))
+             )
+            ),
             (SOLE_TRADER,
              scottishPartnershipDetails.copy(partners =
                Seq(nominatedPartner(PartnerTypeEnum.SOLE_TRADER))
@@ -147,8 +153,7 @@ class PartnerTypeControllerSpec extends ControllerSpec {
                 redirectLocation(result) mustBe Some("http://test/redirect/soletrader")
               case UK_COMPANY | OVERSEAS_COMPANY_UK_BRANCH =>
                 redirectLocation(result) mustBe Some("http://test/redirect/ukCompany")
-              case LIMITED_LIABILITY_PARTNERSHIP | SCOTTISH_PARTNERSHIP |
-                  SCOTTISH_LIMITED_PARTNERSHIP =>
+              case LIMITED_LIABILITY_PARTNERSHIP =>
                 redirectLocation(result) mustBe Some("http://test/redirect/partnership")
               case _ =>
                 redirectLocation(result) mustBe Some(
@@ -167,11 +172,6 @@ class PartnerTypeControllerSpec extends ControllerSpec {
             (SCOTTISH_LIMITED_PARTNERSHIP,
              scottishPartnershipDetails.copy(partners =
                Seq(nominatedPartner(SCOTTISH_LIMITED_PARTNERSHIP))
-             )
-            ),
-            (LIMITED_LIABILITY_PARTNERSHIP,
-             llpPartnershipDetails.copy(partners =
-               Seq(nominatedPartner(LIMITED_LIABILITY_PARTNERSHIP))
              )
             ),
             (SCOTTISH_PARTNERSHIP, scottishPartnershipDetails)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
@@ -107,99 +107,103 @@ class PartnerTypeControllerSpec extends ControllerSpec {
       }
     }
 
-    "redirect to partnership GRS for new partner with GRS provided names" when {
-      forAll(
-        Seq(
-          (SOLE_TRADER,
-           scottishPartnershipDetails.copy(partners =
-             Seq(nominatedPartner(PartnerTypeEnum.SOLE_TRADER))
-           )
-          ),
-          (UK_COMPANY,
-           scottishPartnershipDetails.copy(partners =
-             Seq(nominatedPartner(PartnerTypeEnum.UK_COMPANY))
-           )
-          ),
-          (OVERSEAS_COMPANY_UK_BRANCH,
-           scottishPartnershipDetails.copy(partners =
-             Seq(nominatedPartner(PartnerTypeEnum.OVERSEAS_COMPANY_UK_BRANCH))
-           )
-          ),
-          (CHARITABLE_INCORPORATED_ORGANISATION, scottishPartnershipDetails)
-        )
-      ) { partnershipDetails =>
-        s"a ${partnershipDetails._1} type was selected" in {
-          val registration = aRegistration(withPartnershipDetails(Some(partnershipDetails._2)))
+    "redirect to partnership GRS for new partner" when {
+      "user selected a type which has a GRS provided name" when {
+        forAll(
+          Seq(
+            (SOLE_TRADER,
+             scottishPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(PartnerTypeEnum.SOLE_TRADER))
+             )
+            ),
+            (UK_COMPANY,
+             scottishPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(PartnerTypeEnum.UK_COMPANY))
+             )
+            ),
+            (OVERSEAS_COMPANY_UK_BRANCH,
+             scottishPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(PartnerTypeEnum.OVERSEAS_COMPANY_UK_BRANCH))
+             )
+            ),
+            (CHARITABLE_INCORPORATED_ORGANISATION, scottishPartnershipDetails)
+          )
+        ) { partnershipDetails =>
+          s"a ${partnershipDetails._1} type was selected" in {
+            val registration = aRegistration(withPartnershipDetails(Some(partnershipDetails._2)))
 
-          authorizedUser()
-          mockRegistrationFind(registration)
-          mockRegistrationUpdate()
+            authorizedUser()
+            mockRegistrationFind(registration)
+            mockRegistrationUpdate()
 
-          mockCreateSoleTraderPartnershipGrsJourneyCreation("http://test/redirect/soletrader")
-          mockCreateUkCompanyPartnershipGrsJourneyCreation("http://test/redirect/ukCompany")
-          mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
+            mockCreateSoleTraderPartnershipGrsJourneyCreation("http://test/redirect/soletrader")
+            mockCreateUkCompanyPartnershipGrsJourneyCreation("http://test/redirect/ukCompany")
+            mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
 
-          val correctForm =
-            Seq("answer" -> partnershipDetails._1.toString, saveAndContinueFormAction)
-          val result = controller.submitNewPartner()(postJsonRequestEncoded(correctForm: _*))
-          partnershipDetails._1 match {
-            case SOLE_TRADER =>
-              redirectLocation(result) mustBe Some("http://test/redirect/soletrader")
-            case UK_COMPANY | OVERSEAS_COMPANY_UK_BRANCH =>
-              redirectLocation(result) mustBe Some("http://test/redirect/ukCompany")
-            case LIMITED_LIABILITY_PARTNERSHIP | SCOTTISH_PARTNERSHIP |
-                SCOTTISH_LIMITED_PARTNERSHIP =>
-              redirectLocation(result) mustBe Some("http://test/redirect/partnership")
-            case _ =>
-              redirectLocation(result) mustBe Some(
-                orgRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
-              )
+            val correctForm =
+              Seq("answer" -> partnershipDetails._1.toString, saveAndContinueFormAction)
+            val result = controller.submitNewPartner()(postJsonRequestEncoded(correctForm: _*))
+            partnershipDetails._1 match {
+              case SOLE_TRADER =>
+                redirectLocation(result) mustBe Some("http://test/redirect/soletrader")
+              case UK_COMPANY | OVERSEAS_COMPANY_UK_BRANCH =>
+                redirectLocation(result) mustBe Some("http://test/redirect/ukCompany")
+              case LIMITED_LIABILITY_PARTNERSHIP | SCOTTISH_PARTNERSHIP |
+                  SCOTTISH_LIMITED_PARTNERSHIP =>
+                redirectLocation(result) mustBe Some("http://test/redirect/partnership")
+              case _ =>
+                redirectLocation(result) mustBe Some(
+                  orgRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+                )
+            }
           }
         }
       }
     }
 
-    "redirect to capture partner name for new partner types with no GRS provided name" when {
-      forAll(
-        Seq(
-          (SCOTTISH_LIMITED_PARTNERSHIP,
-           scottishPartnershipDetails.copy(partners =
-             Seq(nominatedPartner(SCOTTISH_LIMITED_PARTNERSHIP))
-           )
-          ),
-          (LIMITED_LIABILITY_PARTNERSHIP,
-           llpPartnershipDetails.copy(partners =
-             Seq(nominatedPartner(LIMITED_LIABILITY_PARTNERSHIP))
-           )
-          ),
-          (SCOTTISH_PARTNERSHIP, scottishPartnershipDetails)
-        )
-      ) { partnershipDetails =>
-        s"a ${partnershipDetails._1} type was selected" in {
-          val registration = aRegistration(withPartnershipDetails(Some(partnershipDetails._2)))
-
-          authorizedUser()
-          mockRegistrationFind(registration)
-          mockRegistrationUpdate()
-
-          mockCreateSoleTraderPartnershipGrsJourneyCreation("http://test/redirect/soletrader")
-          mockCreateUkCompanyPartnershipGrsJourneyCreation("http://test/redirect/ukCompany")
-          mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
-
-          val correctForm =
-            Seq("answer" -> partnershipDetails._1.toString, saveAndContinueFormAction)
-
-          val result = controller.submitNewPartner()(postJsonRequestEncoded(correctForm: _*))
-
-          redirectLocation(result) mustBe Some(
-            partnerRoutes.PartnerNameController.displayNewPartner().url
+    "redirect to capture partner name for new partner" when {
+      "user selected a type which has no GRS provided name" when {
+        forAll(
+          Seq(
+            (SCOTTISH_LIMITED_PARTNERSHIP,
+             scottishPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(SCOTTISH_LIMITED_PARTNERSHIP))
+             )
+            ),
+            (LIMITED_LIABILITY_PARTNERSHIP,
+             llpPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(LIMITED_LIABILITY_PARTNERSHIP))
+             )
+            ),
+            (SCOTTISH_PARTNERSHIP, scottishPartnershipDetails)
           )
+        ) { partnershipDetails =>
+          s"a ${partnershipDetails._1} type was selected" in {
+            val registration = aRegistration(withPartnershipDetails(Some(partnershipDetails._2)))
+
+            authorizedUser()
+            mockRegistrationFind(registration)
+            mockRegistrationUpdate()
+
+            mockCreateSoleTraderPartnershipGrsJourneyCreation("http://test/redirect/soletrader")
+            mockCreateUkCompanyPartnershipGrsJourneyCreation("http://test/redirect/ukCompany")
+            mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
+
+            val correctForm =
+              Seq("answer" -> partnershipDetails._1.toString, saveAndContinueFormAction)
+
+            val result = controller.submitNewPartner()(postJsonRequestEncoded(correctForm: _*))
+
+            redirectLocation(result) mustBe Some(
+              partnerRoutes.PartnerNameController.displayNewPartner().url
+            )
+          }
         }
       }
     }
 
-    "redirect to partnership GRS " when {
-      "for existing partner" in {
+    "redirect to partnership GRS for existing partner" when {
+      "existing partner selects a type which has a GRS supplied name" in {
         val registration =
           aRegistration(withPartnershipDetails(Some(generalPartnershipDetailsWithPartners)))
 
@@ -210,9 +214,33 @@ class PartnerTypeControllerSpec extends ControllerSpec {
 
         val correctForm =
           Seq("answer" -> SOLE_TRADER.toString, saveAndContinueFormAction)
+
         val result =
           controller.submitExistingPartner("123")(postJsonRequestEncoded(correctForm: _*))
+
         redirectLocation(result) mustBe Some("http://test/redirect/soletrader")
+      }
+    }
+
+    "redirect to capture partner name for existing partner" when {
+      "existing partner selects a type which does not have a have GRS provided name" in {
+        val registration =
+          aRegistration(withPartnershipDetails(Some(generalPartnershipDetailsWithPartners)))
+
+        authorizedUser()
+        mockRegistrationFind(registration)
+        mockRegistrationUpdate()
+        mockCreateSoleTraderPartnershipGrsJourneyCreation("http://test/redirect/soletrader")
+
+        val correctForm =
+          Seq("answer" -> SCOTTISH_PARTNERSHIP.toString, saveAndContinueFormAction)
+
+        val result =
+          controller.submitExistingPartner("123")(postJsonRequestEncoded(correctForm: _*))
+
+        redirectLocation(result) mustBe Some(
+          partnerRoutes.PartnerNameController.displayExistingPartner("123").url
+        )
       }
     }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
@@ -158,7 +158,7 @@ class PartnerTypeControllerSpec extends ControllerSpec {
                 redirectLocation(result) mustBe Some("http://test/redirect/soletrader")
               case UK_COMPANY | OVERSEAS_COMPANY_UK_BRANCH =>
                 redirectLocation(result) mustBe Some("http://test/redirect/ukCompany")
-              case LIMITED_LIABILITY_PARTNERSHIP =>
+              case LIMITED_LIABILITY_PARTNERSHIP | SCOTTISH_LIMITED_PARTNERSHIP =>
                 redirectLocation(result) mustBe Some("http://test/redirect/partnership")
               case _ =>
                 redirectLocation(result) mustBe Some(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
@@ -73,7 +73,7 @@ class PartnerTypeControllerSpec extends ControllerSpec {
     )
   }
 
-  "Partnership Partner Type Controller" should {
+  "Partner Type Controller" should {
 
     "successfully return partnership partner type selection page" when {
       "no previous partnership partner type in registration" in {
@@ -114,6 +114,11 @@ class PartnerTypeControllerSpec extends ControllerSpec {
             (LIMITED_LIABILITY_PARTNERSHIP,
              llpPartnershipDetails.copy(partners =
                Seq(nominatedPartner(LIMITED_LIABILITY_PARTNERSHIP))
+             )
+            ),
+            (SCOTTISH_LIMITED_PARTNERSHIP,
+             scottishPartnershipDetails.copy(partners =
+               Seq(nominatedPartner(SCOTTISH_LIMITED_PARTNERSHIP))
              )
             ),
             (SOLE_TRADER,
@@ -168,13 +173,8 @@ class PartnerTypeControllerSpec extends ControllerSpec {
     "redirect to capture partner name for new partner" when {
       "user selected a type which has no GRS provided name" when {
         forAll(
-          Seq(
-            (SCOTTISH_LIMITED_PARTNERSHIP,
-             scottishPartnershipDetails.copy(partners =
-               Seq(nominatedPartner(SCOTTISH_LIMITED_PARTNERSHIP))
-             )
-            ),
-            (SCOTTISH_PARTNERSHIP, scottishPartnershipDetails)
+          Seq((GENERAL_PARTNERSHIP, generalPartnershipDetails),
+              (SCOTTISH_PARTNERSHIP, scottishPartnershipDetails)
           )
         ) { partnershipDetails =>
           s"a ${partnershipDetails._1} type was selected" in {
@@ -229,7 +229,6 @@ class PartnerTypeControllerSpec extends ControllerSpec {
         authorizedUser()
         mockRegistrationFind(registration)
         mockRegistrationUpdate()
-        mockCreateSoleTraderPartnershipGrsJourneyCreation("http://test/redirect/soletrader")
 
         val correctForm =
           Seq("answer" -> SCOTTISH_PARTNERSHIP.toString, saveAndContinueFormAction)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
@@ -43,7 +43,6 @@ class PartnerTypeControllerSpec extends ControllerSpec {
     appConfig = appConfig,
     soleTraderGrsConnector = mockSoleTraderGrsConnector,
     ukCompanyGrsConnector = mockUkCompanyGrsConnector,
-    partnershipGrsConnector = mockPartnershipGrsConnector,
     registrationConnector = mockRegistrationConnector,
     mcc = mcc,
     page = page

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipTypeControllerSpec.scala
@@ -46,6 +46,9 @@ class PartnershipTypeControllerSpec extends ControllerSpec {
   val controller = new PartnershipTypeController(authenticate = mockAuthAction,
                                                  journeyAction = mockJourneyAction,
                                                  appConfig = config,
+                                                 soleTraderGrsConnector =
+                                                   mockSoleTraderGrsConnector,
+                                                 ukCompanyGrsConnector = mockUkCompanyGrsConnector,
                                                  partnershipGrsConnector =
                                                    mockPartnershipGrsConnector,
                                                  registrationConnector = mockRegistrationConnector,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetailsSpec.scala
@@ -30,7 +30,6 @@ class PartnershipDetailsSpec extends AnyWordSpec with Matchers {
                   partnerPartnershipDetails = Some(
                     PartnerPartnershipDetails(partnershipType =
                                                 PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
-                                              partnershipName = Some("Company 2"),
                                               partnershipBusinessDetails =
                                                 Some(
                                                   PartnershipBusinessDetails("123456789",

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
@@ -158,10 +158,7 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
           PartnerTypeEnum.displayName(partnershipPartner.partnerType.get),
           None: Option[Call]
          ),
-         (messages("partner.check.orgName"),
-          partnershipPartner.partnerPartnershipDetails.get.partnershipName.get,
-          None: Option[Call]
-         ),
+         (messages("partner.check.orgName"), partnershipPartner.name, None: Option[Call]),
          (messages("partner.check.sautr"),
           partnershipPartner.partnerPartnershipDetails.get.partnershipBusinessDetails.get.sautr,
           None: Option[Call]

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerNamePageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerNamePageViewSpec.scala
@@ -59,7 +59,7 @@ class PartnerNamePageViewSpec extends UnitViewSpec with Matchers {
 
     "display title" in {
 
-      view.select("title").text() must include(messages("partner.name.title"))
+      view.select("title").text() must include(messages("partnership.name.title"))
     }
 
     "display name input box" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerNamePageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerNamePageViewSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.partner
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.data.Form
+import play.api.mvc.Call
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.EmailAddress
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnershipName
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.{
+  partner_email_address_page,
+  partner_name_page
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class PartnerNamePageViewSpec extends UnitViewSpec with Matchers {
+
+  private val page = instanceOf[partner_name_page]
+
+  private val backLink   = Call("GET", "/back-link")
+  private val updateLink = Call("PUT", "/update")
+
+  private def createView(form: Form[PartnershipName] = PartnershipName.form()): Document =
+    page(form, backLink, updateLink)(journeyRequest, messages)
+
+  "Email address View" should {
+
+    val view = createView()
+
+    "contain timeout dialog function" in {
+
+      containTimeoutDialogFunction(view) mustBe true
+
+    }
+
+    "display sign out link" in {
+
+      displaySignOutLink(view)
+
+    }
+
+    "display 'Back' button" in {
+
+      view.getElementById("back-link") must haveHref(backLink.url)
+    }
+
+    "display title" in {
+
+      view.select("title").text() must include(messages("partner.name.title"))
+    }
+
+    "display name input box" in {
+      view must containElementWithID("value")
+    }
+
+    "display 'Save and continue' button" in {
+      view must containElementWithID("submit")
+      view.getElementById("submit").text() mustBe "Save and continue"
+    }
+
+  }
+
+  "display error" when {
+    "name is not entered" in {
+
+      val form = PartnershipName
+        .form()
+        .fillAndValidate(PartnershipName(""))
+      val view = createView(form)
+
+      view must haveGovukGlobalErrorSummary
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(PartnershipName.form(), backLink, updateLink)(journeyRequest, messages)
+    page.render(PartnershipName.form(), backLink, updateLink, journeyRequest, messages)
+  }
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerNamePageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerNamePageViewSpec.scala
@@ -21,12 +21,8 @@ import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
 import play.api.data.Form
 import play.api.mvc.Call
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.EmailAddress
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnershipName
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.{
-  partner_email_address_page,
-  partner_name_page
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.PartnerName
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_name_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 
 @ViewTest
@@ -37,7 +33,7 @@ class PartnerNamePageViewSpec extends UnitViewSpec with Matchers {
   private val backLink   = Call("GET", "/back-link")
   private val updateLink = Call("PUT", "/update")
 
-  private def createView(form: Form[PartnershipName] = PartnershipName.form()): Document =
+  private def createView(form: Form[PartnerName] = PartnerName.form()): Document =
     page(form, backLink, updateLink)(journeyRequest, messages)
 
   "Email address View" should {
@@ -80,9 +76,9 @@ class PartnerNamePageViewSpec extends UnitViewSpec with Matchers {
   "display error" when {
     "name is not entered" in {
 
-      val form = PartnershipName
+      val form = PartnerName
         .form()
-        .fillAndValidate(PartnershipName(""))
+        .fillAndValidate(PartnerName(""))
       val view = createView(form)
 
       view must haveGovukGlobalErrorSummary
@@ -90,8 +86,8 @@ class PartnerNamePageViewSpec extends UnitViewSpec with Matchers {
   }
 
   override def exerciseGeneratedRenderingMethods(): Unit = {
-    page.f(PartnershipName.form(), backLink, updateLink)(journeyRequest, messages)
-    page.render(PartnershipName.form(), backLink, updateLink, journeyRequest, messages)
+    page.f(PartnerName.form(), backLink, updateLink)(journeyRequest, messages)
+    page.render(PartnerName.form(), backLink, updateLink, journeyRequest, messages)
   }
 
 }


### PR DESCRIPTION
### Description of Work carried through

For Partnership Partner types who GRS does not supply a name for, prompt the user for a user supplied name instead.
This happens after the user selects a partner type and before the GRS journey.

Do not do this for partners (like UK companies) who we know GRS will supply a name for.
Users should not be able to use this functionality to override a GRS supplied name.

GRS redirects deduplicated into a trait in services, on their way to been a full service one day.
trait defers the need to update all the tests in this PR.


![Screenshot from 2022-01-27 14-25-42](https://user-images.githubusercontent.com/95688374/151379849-ed8bf2e6-6d77-4a2a-a3b6-45fa023ca381.png)
![Screenshot from 2022-01-27 14-23-40](https://user-images.githubusercontent.com/95688374/151379851-d55ffd1b-1a4d-4344-bcc4-456dfddeafbb.png)
![Screenshot from 2022-01-27 14-22-06](https://user-images.githubusercontent.com/95688374/151379854-2809ce67-de46-4430-a7d7-13a5b4d1ab23.png)





#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
