### PR TITLE
Clarify partner type fields

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -119,8 +119,8 @@ class PartnerGrsController @Inject() (
     request: JourneyRequest[AnyContent]
   ): Future[Either[ServiceError, Registration]] = {
     val partnerType: Option[PartnerTypeEnum] = partnerId match {
-      case Some(partnerId) => request.registration.findPartner(partnerId).flatMap(_.partnerType)
-      case None            => request.registration.inflightPartner.flatMap(_.partnerType)
+      case Some(partnerId) => request.registration.findPartner(partnerId).map(_.partnerType)
+      case None            => request.registration.inflightPartner.map(_.partnerType)
     }
     partnerType match {
       case Some(UK_COMPANY) | Some(OVERSEAS_COMPANY_UK_BRANCH) =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -169,10 +169,7 @@ class PartnerGrsController @Inject() (
   ): Future[Either[ServiceError, Registration]] =
     partnershipGrsConnector.getDetails(journeyId).map { partnershipBusinessDetails =>
       val partnershipDetails = Some(
-        PartnerPartnershipDetails(
-          partnershipType = request.registration.organisationDetails.partnerType(partnerId).get,
-          partnershipBusinessDetails = Some(partnershipBusinessDetails)
-        )
+        PartnerPartnershipDetails(partnershipBusinessDetails = Some(partnershipBusinessDetails))
       )
       updateRegistration(soleTraderDetails = None,
                          incorporationDetails = None,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -207,23 +207,14 @@ class PartnerNameController @Inject() (
     }
 
   private def setPartnershipNameFor(partner: Partner, formData: PartnerName): Partner = {
-    val partnershipDetailsWithPartnershipName = {
-      partner.partnerPartnershipDetails match {
-        case Some(partnerPartnershipDetails) =>
-          Some(partnerPartnershipDetails.copy(partnershipName = Some(formData.value)))
-        case None =>
-          // Partnership detail has not been created yet; we need to create a minimal one to carry the user supplied name
-          // until the GRS callback can fully populate it
-          partner.partnerType.map { partnerType =>
-            // This does not look like a good fit; the optionally on one of these can probably be relaxed or tightened.
-            PartnerPartnershipDetails(partnershipType = partnerType,
-                                      partnershipName = Some(formData.value)
-            )
-          }
-      }
+    val partnershipDetailsWithPartnershipName = partner.partnerPartnershipDetails.map(
+      _.copy(partnershipName = Some(formData.value))
+    ).getOrElse {
+      // Partnership details have not been created yet; we need to create a minimal one to carry the user supplied name
+      // until the GRS callback can fully populate it
+      PartnerPartnershipDetails(partnershipName = Some(formData.value))
     }
-
-    partner.copy(partnerPartnershipDetails = partnershipDetailsWithPartnershipName)
+    partner.copy(partnerPartnershipDetails = Some(partnershipDetailsWithPartnershipName))
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -95,14 +95,13 @@ class PartnerTypeController @Inject() (
   private def submit(partnerId: Option[String] = None): Action[AnyContent] =
     (authenticate andThen journeyAction).async {
       implicit request =>
-        val x: Future[Result] = PartnerType.form()
+        PartnerType.form()
           .bindFromRequest()
           .fold(
             (formWithErrors: Form[PartnerType]) =>
               Future(BadRequest(page(formWithErrors, partnerId))),
-            (partnershipPartnerType: PartnerType) => {
-
-              val z: Future[Result] = updatePartnerType(partnershipPartnerType, partnerId).flatMap {
+            (partnershipPartnerType: PartnerType) =>
+              updatePartnerType(partnershipPartnerType, partnerId).flatMap {
                 _ =>
                   FormAction.bindFromRequest match {
                     case SaveAndContinue =>
@@ -138,10 +137,7 @@ class PartnerTypeController @Inject() (
                     case _ => Future(Redirect(commonRoutes.TaskListController.displayPage()))
                   }
               }
-              z
-            }
           )
-        x
     }
 
   private def updatePartnerType(partnerType: PartnerType, partnerId: Option[String])(implicit

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/organisation/PartnerType.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/organisation/PartnerType.scala
@@ -50,7 +50,7 @@ object PartnerTypeEnum extends Enumeration {
 
 }
 
-case class PartnerType(answer: Option[PartnerTypeEnum])
+case class PartnerType(answer: PartnerTypeEnum)
 
 object PartnerType extends CommonFormValidators {
   lazy val emptyError = "partnership.partner.name.empty.error"
@@ -64,9 +64,9 @@ object PartnerType extends CommonFormValidators {
     )
 
   def apply(value: String): PartnerType =
-    PartnerType(PartnerTypeEnum.withNameOpt(value))
+    PartnerType(PartnerTypeEnum.withName(value))
 
   def unapply(partnerType: PartnerType): Option[String] =
-    partnerType.answer.map(_.toString)
+    Some(partnerType.answer.toString)
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/Partner.scala
@@ -25,7 +25,7 @@ import java.util.UUID
 
 case class Partner(
   id: String = UUID.randomUUID().toString,
-  partnerType: Option[PartnerTypeEnum],
+  partnerType: PartnerTypeEnum,
   soleTraderDetails: Option[SoleTraderDetails] = None,
   incorporationDetails: Option[IncorporationDetails] = None,
   partnerPartnershipDetails: Option[PartnerPartnershipDetails] = None,
@@ -33,14 +33,13 @@ case class Partner(
 ) {
 
   lazy val name: String = partnerType match {
-    case Some(PartnerTypeEnum.SOLE_TRADER) =>
+    case PartnerTypeEnum.SOLE_TRADER =>
       soleTraderDetails.map(_.name).getOrElse(
         throw new IllegalStateException("Sole Trader details name absent")
       )
-    case Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP) | Some(PartnerTypeEnum.GENERAL_PARTNERSHIP) |
-        Some(PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP) | Some(
-          PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP
-        ) =>
+    case PartnerTypeEnum.SCOTTISH_PARTNERSHIP | PartnerTypeEnum.GENERAL_PARTNERSHIP |
+        PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP |
+        PartnerTypeEnum.SCOTTISH_LIMITED_PARTNERSHIP =>
       partnerPartnershipDetails.flatMap(_.name).getOrElse(
         throw new IllegalStateException("Partnership details name absent")
       )
@@ -56,9 +55,7 @@ case class Partner(
   def canEditName: Boolean = {
     val partnerTypesWhichPermitUserSuppliedNames =
       Set(PartnerTypeEnum.SCOTTISH_PARTNERSHIP, PartnerTypeEnum.GENERAL_PARTNERSHIP)
-    partnerType.exists { partnerType =>
-      partnerTypesWhichPermitUserSuppliedNames.contains(partnerType)
-    }
+    partnerTypesWhichPermitUserSuppliedNames.contains(partnerType)
   }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetails.scala
@@ -77,7 +77,6 @@ object PartnershipDetails {
 }
 
 case class PartnerPartnershipDetails(
-  partnershipType: PartnerTypeEnum,
   partnershipName: Option[String] = None,
   partnershipBusinessDetails: Option[PartnershipBusinessDetails] = None
 ) {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/OrganisationDetails.scala
@@ -124,8 +124,8 @@ case class OrganisationDetails(
   def partnerType(partnerId: Option[String]): Option[PartnerTypeEnum] =
     partnerId match {
       case Some(partnerId) =>
-        partnershipDetails.flatMap(_.findPartner(partnerId)).flatMap(_.partnerType)
-      case None => inflightPartner.flatMap(_.partnerType)
+        partnershipDetails.flatMap(_.findPartner(partnerId)).map(_.partnerType)
+      case None => inflightPartner.map(_.partnerType)
     }
 
   def partnerGrsRegistration(partnerId: Option[String]): Option[RegistrationDetails] =
@@ -144,20 +144,16 @@ case class OrganisationDetails(
 
   def partnerGrsRegistrationDetails(partner: Partner): Option[RegistrationDetails] =
     partner.partnerType match {
-      case Some(partnerType) =>
-        partnerType match {
-          case PartnerTypeEnum.SOLE_TRADER => partner.soleTraderDetails.flatMap(_.registration)
-          case PartnerTypeEnum.UK_COMPANY | PartnerTypeEnum.OVERSEAS_COMPANY_UK_BRANCH =>
-            partner.incorporationDetails.flatMap(_.registration)
-          case LIMITED_LIABILITY_PARTNERSHIP | SCOTTISH_PARTNERSHIP |
-              SCOTTISH_LIMITED_PARTNERSHIP =>
-            partner.partnerPartnershipDetails.flatMap(
-              _.partnershipBusinessDetails.flatMap(_.registration)
-            )
-          case PartnerTypeEnum.CHARITABLE_INCORPORATED_ORGANISATION => None
-          case PartnerTypeEnum.OVERSEAS_COMPANY_NO_UK_BRANCH        => None
-        }
-      case _ => None
+      case PartnerTypeEnum.SOLE_TRADER => partner.soleTraderDetails.flatMap(_.registration)
+      case PartnerTypeEnum.UK_COMPANY | PartnerTypeEnum.OVERSEAS_COMPANY_UK_BRANCH =>
+        partner.incorporationDetails.flatMap(_.registration)
+      case LIMITED_LIABILITY_PARTNERSHIP | SCOTTISH_PARTNERSHIP | SCOTTISH_LIMITED_PARTNERSHIP =>
+        partner.partnerPartnershipDetails.flatMap(
+          _.partnershipBusinessDetails.flatMap(_.registration)
+        )
+      case PartnerTypeEnum.CHARITABLE_INCORPORATED_ORGANISATION => None
+      case PartnerTypeEnum.OVERSEAS_COMPANY_NO_UK_BRANCH        => None
+      case _                                                    => None
     }
 
   def partnerRegistrationStatus(partnerId: Option[String]): Option[String] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/review/partnerDetail.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/review/partnerDetail.scala.html
@@ -43,7 +43,7 @@
 @ukCompanySummary() = @{
     SummaryList(
         rows = Seq(
-            viewUtils.summaryListRow("reviewRegistration.partner.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("reviewRegistration.partner.orgType", Some(displayName(partner.partnerType)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("reviewRegistration.partner.companyNumber", partner.incorporationDetails.map(_.companyNumber), None),
             viewUtils.summaryListRow("reviewRegistration.partner.orgName", partner.incorporationDetails.map(_.companyName), None),
             viewUtils.summaryListRow("reviewRegistration.partner.utr", partner.incorporationDetails.map(_.ctutr), None),
@@ -54,7 +54,7 @@
 @soleTraderSummary() = @{
     SummaryList(
         rows = Seq(
-            viewUtils.summaryListRow("reviewRegistration.partner.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("reviewRegistration.partner.orgType", Some(displayName(partner.partnerType)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("reviewRegistration.partner.name", partner.soleTraderDetails.map(_.name), None),
             viewUtils.summaryListRow("reviewRegistration.partner.dob", partner.soleTraderDetails.flatMap(_.dateOfBirth), None),
             viewUtils.summaryListRow("reviewRegistration.partner.nino", partner.soleTraderDetails.map(_.ninoOrTrn), None),
@@ -66,7 +66,7 @@
 @partnershipSummary() = @{
     SummaryList(
         rows = Seq(
-            viewUtils.summaryListRow("reviewRegistration.partner.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("reviewRegistration.partner.orgType", Some(displayName(partner.partnerType)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("reviewRegistration.partner.orgName", partner.partnerPartnershipDetails.flatMap(_.name), None),
             viewUtils.summaryListRow("reviewRegistration.partner.sautr", partner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.map(_.sautr)), None),
         ) ++ partnerContactRows().filterNot(_.value.content == Empty)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -56,7 +56,7 @@
 @ukCompanySummary() = @{
     SummaryList(
         rows = Seq(
-            viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("partner.check.orgType", Some(displayName(partner.partnerType)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("partner.check.companyNumber", partner.incorporationDetails.map(_.companyNumber), None),
             viewUtils.summaryListRow("partner.check.orgName", partner.incorporationDetails.map(_.companyName), None),
             viewUtils.summaryListRow("partner.check.utr", partner.incorporationDetails.map(_.ctutr), None),
@@ -67,7 +67,7 @@
 @soleTraderSummary() = @{
     SummaryList(
         rows = Seq(
-            viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("partner.check.orgType", Some(displayName(partner.partnerType)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("partner.check.name", partner.soleTraderDetails.map(_.name), None),
             viewUtils.summaryListRow("partner.check.dob", partner.soleTraderDetails.flatMap(_.dateOfBirth), None),
             viewUtils.summaryListRow("partner.check.nino", partner.soleTraderDetails.map(_.ninoOrTrn), None),
@@ -79,7 +79,7 @@
 @partnershipSummary() = @{
     SummaryList(
         rows = Seq(
-            viewUtils.summaryListRow("partner.check.orgType", partner.partnerType.map(displayName(_)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
+            viewUtils.summaryListRow("partner.check.orgType", Some(displayName(partner.partnerType)), Some(partnerRoutes.PartnerTypeController.displayExistingPartner(partner.id))),
             viewUtils.summaryListRow("partner.check.orgName", Some(partner.name), changePartnerNameLink),
             viewUtils.summaryListRow("partner.check.sautr", partner.partnerPartnershipDetails.flatMap(_.partnershipBusinessDetails.map(_.sautr)), None),
         ) ++ partnerContactRows().filterNot(_.value.content == Empty)

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -269,7 +269,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     partnerPartnershipDetails: Option[PartnerPartnershipDetails] = None
   ): Partner =
     Partner(id = "3534345",
-            partnerType = Some(partnerTypeEnum),
+            partnerType = partnerTypeEnum,
             soleTraderDetails = soleTraderDetails,
             partnerPartnershipDetails = partnerPartnershipDetails,
             incorporationDetails = incorporationDetails
@@ -522,7 +522,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     )
 
   protected def aSoleTraderPartner() =
-    Partner(partnerType = Some(PartnerTypeEnum.SOLE_TRADER),
+    Partner(partnerType = PartnerTypeEnum.SOLE_TRADER,
             id = "123",
             soleTraderDetails = Some(
               SoleTraderDetails(firstName = "Ben",
@@ -555,7 +555,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     )
 
   protected def aLimitedCompanyPartner() =
-    Partner(partnerType = Some(PartnerTypeEnum.UK_COMPANY),
+    Partner(partnerType = PartnerTypeEnum.UK_COMPANY,
             id = "456",
             incorporationDetails = Some(
               IncorporationDetails(companyNumber = "123456",
@@ -588,7 +588,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
     )
 
   protected def aPartnershipPartner() =
-    Partner(partnerType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP),
+    Partner(partnerType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
             partnerPartnershipDetails = Some(
               PartnerPartnershipDetails(partnershipName = Some("The Plastic Partnership"),
                                         partnershipBusinessDetails = Some(

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -590,8 +590,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
   protected def aPartnershipPartner() =
     Partner(partnerType = Some(PartnerTypeEnum.SCOTTISH_PARTNERSHIP),
             partnerPartnershipDetails = Some(
-              PartnerPartnershipDetails(partnershipType = PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
-                                        partnershipName = Some("The Plastic Partnership"),
+              PartnerPartnershipDetails(partnershipName = Some("The Plastic Partnership"),
                                         partnershipBusinessDetails = Some(
                                           PartnershipBusinessDetails(sautr = "234923487362",
                                                                      postcode = "LS1 1HS",

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerSpec.scala
@@ -225,7 +225,7 @@ class PartnerGrsControllerSpec extends ControllerSpec {
         val partnerWithUserSuppliedName =
           nominatedPartner(PartnerTypeEnum.SCOTTISH_PARTNERSHIP).copy(partnerPartnershipDetails =
             Some(
-              PartnerPartnershipDetails(PartnerTypeEnum.SCOTTISH_PARTNERSHIP).copy(partnershipName =
+              PartnerPartnershipDetails().copy(partnershipName =
                 Some("User supplied partnership name")
               )
             )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetailsSpec.scala
@@ -28,8 +28,7 @@ class PartnershipDetailsSpec extends AnyWordSpec with Matchers {
           Partner(id = "3534345",
                   partnerType = Some(PartnerTypeEnum.UK_COMPANY),
                   partnerPartnershipDetails = Some(
-                    PartnerPartnershipDetails(partnershipType =
-                                                PartnerTypeEnum.SCOTTISH_PARTNERSHIP,
+                    PartnerPartnershipDetails(partnershipName = Some("A named partnership"),
                                               partnershipBusinessDetails =
                                                 Some(
                                                   PartnershipBusinessDetails("123456789",
@@ -83,7 +82,9 @@ class PartnershipDetailsSpec extends AnyWordSpec with Matchers {
                                                       ),
                                                     partners = Seq(nominatePartner)
         )
-        partnershipDetails.nominatedPartner.get.partnerPartnershipDetails.get.partnershipType mustBe PartnerTypeEnum.SCOTTISH_PARTNERSHIP
+        partnershipDetails.nominatedPartner.get.partnerPartnershipDetails.get.partnershipName mustBe Some(
+          "A named partnership"
+        )
       }
     }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetailsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnershipDetailsSpec.scala
@@ -26,7 +26,7 @@ class PartnershipDetailsSpec extends AnyWordSpec with Matchers {
       "premises is provided" in {
         val nominatePartner =
           Partner(id = "3534345",
-                  partnerType = Some(PartnerTypeEnum.UK_COMPANY),
+                  partnerType = PartnerTypeEnum.UK_COMPANY,
                   partnerPartnershipDetails = Some(
                     PartnerPartnershipDetails(partnershipName = Some("A named partnership"),
                                               partnershipBusinessDetails =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
@@ -602,7 +602,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
             getValueFor(nominatedPartnerSection,
                         0,
                         partnershipView
-            ) mustBe PartnerTypeEnum.displayName(nominatedPartner.partnerType.get)
+            ) mustBe PartnerTypeEnum.displayName(nominatedPartner.partnerType)
             getValueFor(nominatedPartnerSection, 1, partnershipView) mustBe nominatedPartner.name
             getValueFor(nominatedPartnerSection,
                         2,
@@ -661,7 +661,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
 
                 verifyRowContent(otherPartnerRows.get(0),
                                  messages("reviewRegistration.partner.orgType"),
-                                 PartnerTypeEnum.displayName(partner.partnerType.get),
+                                 PartnerTypeEnum.displayName(partner.partnerType),
                                  None
                 )
                 verifyRowContent(otherPartnerRows.get(1),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
@@ -77,7 +77,7 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
        limitedCompanyPartner,
        Seq(
          (messages("partner.check.orgType"),
-          PartnerTypeEnum.displayName(limitedCompanyPartner.partnerType.get),
+          PartnerTypeEnum.displayName(limitedCompanyPartner.partnerType),
           None: Option[Call]
          ),
          (messages("partner.check.companyNumber"),
@@ -114,7 +114,7 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
        soleTraderPartner,
        Seq(
          (messages("partner.check.orgType"),
-          PartnerTypeEnum.displayName(soleTraderPartner.partnerType.get),
+          PartnerTypeEnum.displayName(soleTraderPartner.partnerType),
           None: Option[Call]
          ),
          (messages("partner.check.name"),
@@ -155,7 +155,7 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
        partnershipPartner,
        Seq(
          (messages("partner.check.orgType"),
-          PartnerTypeEnum.displayName(partnershipPartner.partnerType.get),
+          PartnerTypeEnum.displayName(partnershipPartner.partnerType),
           None: Option[Call]
          ),
          (messages("partner.check.orgName"), partnershipPartner.name, None: Option[Call]),


### PR DESCRIPTION
### Description of Work carried through

Clarify our understanding of how Partner type is recorded.
- Remove unused Partner.partnerPartnershipDetails.partnershipType
- Make Partner.partnershipType mandatory.

Partner type is the first thing we ask when setting up an inflight Partner; partners do not existing without this field.

Remove alot of Some wrapping around this value.
The backend can keep this field as an Optional if it wants but should be aware that we will always set it going forward (probably always have done as well).


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [x] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
