### PR TITLE
Pptp 1421 Correct exit redirect

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -20,6 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.RemoveMember
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.group.confirm_remove_member_page
@@ -39,7 +40,7 @@ class ConfirmRemoveMemberController @Inject() (
   def displayPage(memberId: String): Action[AnyContent] =
     (authenticate andThen amendmentJourneyAction) { implicit request =>
       request.registration.findMember(memberId).map { member =>
-        Ok(page(member))
+        Ok(page(member, RemoveMember.form()))
       }.getOrElse {
         throw new IllegalStateException("Could not find member")
       }
@@ -49,7 +50,7 @@ class ConfirmRemoveMemberController @Inject() (
     (authenticate andThen amendmentJourneyAction) { implicit request =>
       // TODO: handle form submission and remove member
       request.registration.findMember(memberId).map { member =>
-        Ok(page(member))
+        Ok(page(member, RemoveMember.form()))
       }.getOrElse {
         throw new IllegalStateException("Could not find member")
       }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -41,7 +41,7 @@ class ConfirmRemoveMemberController @Inject() (
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) with I18nSupport {
 
-  private val onwardCall = routes.GroupMembersListController.displayPage()
+  private val onwardCall = routes.GroupMembersListController.displayPage().url
 
   def displayPage(memberId: String): Action[AnyContent] =
     (authenticate andThen amendmentJourneyAction) { implicit request =>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -42,7 +42,7 @@ class ConfirmRemoveMemberController @Inject() (
   def displayPage(memberId: String): Action[AnyContent] =
     (authenticate andThen amendmentJourneyAction) { implicit request =>
       request.registration.findMember(memberId).map { member =>
-        Ok(page(member, RemoveMember.form()))
+        Ok(page(RemoveMember.form(), member))
       }.getOrElse {
         throw new IllegalStateException("Could not find member")
       }
@@ -53,11 +53,11 @@ class ConfirmRemoveMemberController @Inject() (
       request.registration.findMember(memberId).map { member =>
         RemoveMember.form().bindFromRequest().fold(
           { formWithErrors: Form[RemoveMember] =>
-            Future.successful(BadRequest(page(member, formWithErrors)))
+            Future.successful(BadRequest(page(formWithErrors, member)))
           },
           { removeMember: RemoveMember =>
             // TODO: handle form submission and remove member
-            Future.successful(Ok(page(member, RemoveMember.form())))
+            Future.successful(Ok(page(RemoveMember.form(), member)))
           }
         )
       }.getOrElse {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -38,13 +38,21 @@ class ConfirmRemoveMemberController @Inject() (
 
   def displayPage(memberId: String): Action[AnyContent] =
     (authenticate andThen amendmentJourneyAction) { implicit request =>
-      Ok(page())
+      request.registration.findMember(memberId).map { member =>
+        Ok(page(member))
+      }.getOrElse {
+        throw new IllegalStateException("Could not find member")
+      }
     }
 
   def submit(memberId: String): Action[AnyContent] =
     (authenticate andThen amendmentJourneyAction) { implicit request =>
       // TODO: handle form submission and remove member
-      Ok(page())
+      request.registration.findMember(memberId).map { member =>
+        Ok(page(member))
+      }.getOrElse {
+        throw new IllegalStateException("Could not find member")
+      }
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -79,7 +79,7 @@ class ConfirmRemoveMemberController @Inject() (
   )(implicit req: JourneyRequest[AnyContent]): Future[Result] = {
     // TODO Duplication with RemoveMemberController
     def doAction(registration: Registration): Registration =
-      req.registration.copy(groupDetail =
+      registration.copy(groupDetail =
         registration.groupDetail.map(
           groupDetail =>
             groupDetail.copy(members = groupDetail.members.filter(_.id != groupMemberId))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -62,8 +62,7 @@ class ConfirmRemoveMemberController @Inject() (
           { removeMember: RemoveMember =>
             removeMember.value match {
               case Some(true) =>
-                val eventualResult = removeGroupMember(member.id)
-                eventualResult
+                removeGroupMember(member.id)
               case _ =>
                 Future.successful(Redirect(onwardCall))
             }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
@@ -30,11 +30,12 @@
         govukFieldset: GovukFieldset,
         govukRadios: GovukRadios,
         paragraph: paragraph,
+        saveButtons: saveButtons,
         errorSummary: errorSummary,
         continueButton: continue
 )
 
-@(member: GroupMember, removeMember: Form[RemoveMember])(implicit request: JourneyRequest[AnyContent], messages: Messages)
+@(removeMember: Form[RemoveMember], member: GroupMember)(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
 @govukLayout(
     title = Title("amend.group.remove.title"),

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
@@ -34,11 +34,34 @@
         errorSummary: errorSummary
 )
 
-@(member: GroupMember)(implicit request: JourneyRequest[AnyContent], messages: Messages)
+@(member: GroupMember, removeMember: Form[RemoveMember])(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
 @govukLayout(
     title = Title("amend.group.remove.title"),
-    backButton = Some(BackButton(messages("site.back"), routes.GroupMembersListController.displayPage(), messages("site.back.hiddenText")))) {
+    backButton = Some(BackButton(messages("site.back"), routes.ConfirmRemoveMemberController.displayPage(member.id), messages("site.back.hiddenText")))) {
 
     @pageHeading(text = messages("amend.group.remove.title", member.businessName))
+
+    @formHelper(action = routes.ConfirmRemoveMemberController.submit(member.id), 'autoComplete -> "off") {
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("group.removeMember.title", member.businessName)),
+                classes = gdsFieldsetPageHeading,
+                isPageHeading = true
+            )),
+            html = govukRadios(Radios(
+                hint = None,
+                name = "value",
+                items = Seq(
+                    RadioItem(content = HtmlContent(messages("general.true")), value = Some(YES), checked = removeMember.value.contains(YES)),
+                    RadioItem(content = HtmlContent(messages("general.false")), value = Some(NO), checked = removeMember.value.contains(NO))
+                ),
+                classes = "govuk-radios--inline",
+                errorMessage = removeMember("value").error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+            ))
+        ))
+
+        @saveButtons()
+    }
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
@@ -30,25 +30,20 @@
         govukFieldset: GovukFieldset,
         govukRadios: GovukRadios,
         paragraph: paragraph,
-        saveButtons: saveButtons,
-        errorSummary: errorSummary
+        errorSummary: errorSummary,
+        continueButton: continue
 )
 
 @(member: GroupMember, removeMember: Form[RemoveMember])(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
 @govukLayout(
     title = Title("amend.group.remove.title"),
-    backButton = Some(BackButton(messages("site.back"), routes.ConfirmRemoveMemberController.displayPage(member.id), messages("site.back.hiddenText")))) {
+    backButton = Some(BackButton(messages("site.back"), routes.GroupMembersListController.displayPage(), messages("site.back.hiddenText")))) {
 
     @pageHeading(text = messages("amend.group.remove.title", member.businessName))
 
     @formHelper(action = routes.ConfirmRemoveMemberController.submit(member.id), 'autoComplete -> "off") {
         @govukFieldset(Fieldset(
-            legend = Some(Legend(
-                content = Text(messages("group.removeMember.title", member.businessName)),
-                classes = gdsFieldsetPageHeading,
-                isPageHeading = true
-            )),
             html = govukRadios(Radios(
                 hint = None,
                 name = "value",
@@ -61,7 +56,7 @@
             ))
         ))
 
-        @saveButtons()
+        @continueButton()
     }
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
@@ -38,7 +38,7 @@
 @(removeMember: Form[RemoveMember], member: GroupMember)(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
 @govukLayout(
-    title = Title("amend.group.remove.title"),
+    title = Title(headingKey = "amend.group.remove.title", member.businessName),
     backButton = Some(BackButton(messages("site.back"), routes.GroupMembersListController.displayPage(), messages("site.back.hiddenText")))) {
 
     @pageHeading(text = messages("amend.group.remove.title", member.businessName))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/confirm_remove_member_page.scala.html
@@ -17,6 +17,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group.routes
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.ConfirmAddress.{NO, YES}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.RemoveMember
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupMember
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components._
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
@@ -33,11 +34,11 @@
         errorSummary: errorSummary
 )
 
-@()(implicit request: JourneyRequest[AnyContent], messages: Messages)
+@(member: GroupMember)(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
 @govukLayout(
     title = Title("amend.group.remove.title"),
     backButton = Some(BackButton(messages("site.back"), routes.GroupMembersListController.displayPage(), messages("site.back.hiddenText")))) {
 
-    @pageHeading(text = messages("amend.group.remove.title", "TODO"))
+    @pageHeading(text = messages("amend.group.remove.title", member.businessName))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,6 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     "logger.*\\(.*\\)",
     // TODO: remove these as required as we build out the post reg group amendment
     ".*.controllers.amendment.group.AddGroupMemberController",
-    ".*.controllers.amendment.group.ConfirmRemoveMemberController",
     ".*.controllers.amendment.group.GroupMembersListController",
     ".*.controllers.amendment.group.ManageGroupMembersController",
     ".*.views.html.amendment.group.confirm_remove_member_page.*",

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     ".*.controllers.amendment.group.AddGroupMemberController",
     ".*.controllers.amendment.group.GroupMembersListController",
     ".*.controllers.amendment.group.ManageGroupMembersController",
-    ".*.views.html.amendment.group.confirm_remove_member_page.*",
     ".*.views.html.amendment.group.list_group_members_page.*",
     ".*.views.html.amendment.group.manage_group_members_page.*",
   ).mkString(";"),

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -92,12 +92,18 @@ trait ControllerSpec
     form: AnyRef,
     formAction: (String, String) = saveAndContinueFormAction,
     sessionId: String = "123"
-  ): Request[AnyContentAsFormUrlEncoded] = {
-    val bodyForm: Seq[(String, String)] = getTuples(form) :+ formAction
+  ): Request[AnyContentAsFormUrlEncoded] =
+    postRequestTuplesEncoded(getTuples(form), formAction, sessionId)
+
+  // This function exists because getTuples used in the above may not always encode values correctly
+  protected def postRequestTuplesEncoded(
+    formTuples: Seq[(String, String)],
+    formAction: (String, String) = saveAndContinueFormAction,
+    sessionId: String = "123"
+  ): Request[AnyContentAsFormUrlEncoded] =
     postRequest(sessionId)
-      .withFormUrlEncodedBody(bodyForm: _*)
+      .withFormUrlEncodedBody(formTuples :+ formAction: _*)
       .withCSRFToken
-  }
 
   protected def getTuples(cc: AnyRef): Seq[(String, String)] =
     cc.getClass.getDeclaredFields.foldLeft(Map.empty[String, String]) { (a, f) =>
@@ -107,9 +113,16 @@ trait ControllerSpec
 
   private def getValue(field: Field, cc: AnyRef): String =
     field.get(cc) match {
-      case c: Option[_] if c.isDefined => c.get.toString
-      case c: String                   => c
-      case _                           => ""
+      case c: Option[_] if c.isDefined =>
+        c.get match {
+          case _: Boolean =>
+            throw new RuntimeException(
+              "This test helper function was probably about to bypass fromForm and return 'true' rather than 'yes' and is not able to properly encode boolean forms where the controller expects yes"
+            )
+          case v => v.toString
+        }
+      case c: String => c
+      case _         => ""
     }
 
   protected def postJsonRequestEncoded(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.http.Status.{OK, SEE_OTHER}
 import play.api.mvc.{AnyContentAsEmpty, Request}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{await, status}
+import play.api.test.Helpers.{await, redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
@@ -117,6 +117,9 @@ class ConfirmRemoveMemberControllerSpec
           val updatedReg = await(inMemoryRegistrationAmendmentRepository.get(sessionId)).get
           updatedReg.groupDetail.get.members.size mustBe 1
           updatedReg.groupDetail.get.members.head mustBe groupMember
+
+          // Redirect back to manage group members so that the user can see the change
+          redirectLocation(resp) mustBe Some(routes.GroupMembersListController.displayPage())
         }
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -118,8 +118,7 @@ class ConfirmRemoveMemberControllerSpec
           updatedReg.groupDetail.get.members.size mustBe 1
           updatedReg.groupDetail.get.members.head mustBe groupMember
 
-          // Redirect back to manage group members so that the user can see the change
-          redirectLocation(resp) mustBe Some(routes.GroupMembersListController.displayPage())
+          redirectLocation(resp) mustBe Some(routes.GroupMembersListController.displayPage().url)
         }
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -86,7 +86,7 @@ class ConfirmRemoveMemberControllerSpec
   }
 
   "Confirm Remove Member Controller" when {
-    "signed in user has a ppt registration to amend" should { // TODO what if it isn't a group registration?
+    "signed in user has a ppt registration to amend" should {
       "show page" in {
         authorisedUserWithPptSubscription()
         simulateGetSubscriptionSuccess(populatedRegistrationWithGroupMembers)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -45,7 +45,6 @@ class ConfirmRemoveMemberControllerSpec
   private val controller =
     new ConfirmRemoveMemberController(mockAuthAllowEnrolmentAction,
                                       mockAmendmentJourneyAction,
-                                      mockRegistrationConnector,
                                       mcc,
                                       page
     )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
+
+import base.PptTestData.newUser
+import base.unit.{ControllerSpec, MockAmendmentJourneyAction}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.prop.TableDrivenPropertyChecks
+import play.api.http.Status.OK
+import play.api.mvc.{AnyContentAsEmpty, Request}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.status
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.GroupDetail
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupMember
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.group.confirm_remove_member_page
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import utils.FakeRequestCSRFSupport.CSRFFakeRequest
+
+class ConfirmRemoveMemberControllerSpec
+    extends ControllerSpec with MockAmendmentJourneyAction with TableDrivenPropertyChecks {
+
+  private val mcc  = stubMessagesControllerComponents()
+  private val page = mock[confirm_remove_member_page]
+
+  private val controller =
+    new ConfirmRemoveMemberController(mockAuthAllowEnrolmentAction,
+                                      mockAmendmentJourneyAction,
+                                      mockRegistrationConnector,
+                                      mcc,
+                                      page
+    )
+
+  private def authorisedUserWithPptSubscription() =
+    authorizedUser(user =
+      newUser().copy(enrolments =
+        Enrolments(
+          Set(
+            new Enrolment(PptEnrolment.Identifier,
+                          Seq(EnrolmentIdentifier(PptEnrolment.Key, "XMPPT0000000123")),
+                          "activated"
+            )
+          )
+        )
+      )
+    )
+
+  val anotherGroupMember                     = groupMember.copy(id = "another-group-member-id")
+  private val groupMembers: Seq[GroupMember] = Seq(groupMember, anotherGroupMember)
+
+  val populatedGroupDetails =
+    GroupDetail(membersUnderGroupControl = Some(true), members = groupMembers)
+
+  private val populatedRegistrationWithGroupMembers =
+    aRegistration().copy(groupDetail = Some(populatedGroupDetails))
+
+  override protected def beforeEach(): Unit = {
+    inMemoryRegistrationAmendmentRepository.reset()
+    reset(mockSubscriptionConnector)
+    simulateGetSubscriptionSuccess(populatedRegistrationWithGroupMembers)
+    when(page.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.raw("Confirm remove member"))
+  }
+
+  "Confirm Remove Member Controller" should {
+    "show page" when {
+      "signed in user has a ppt registration to amend" in { // TODO what if it isn't a group registration?
+        authorisedUserWithPptSubscription()
+        simulateGetSubscriptionSuccess(populatedRegistrationWithGroupMembers)
+
+        val resp =
+          controller.displayPage(groupMember.id)(getRequest())
+
+        status(resp) mustBe OK
+      }
+    }
+  }
+
+  "return an error" when {
+
+    "user is not authorised" in {
+      unAuthorizedUser()
+
+      val result = controller.displayPage(groupMember.id)(getRequest())
+
+      intercept[RuntimeException](status(result))
+    }
+
+    "user tries to display an non existent group member" in {
+      authorisedUserWithPptSubscription()
+
+      val result = controller.displayPage("not-an-existing-group-member-id")(getRequest())
+
+      intercept[RuntimeException](status(result))
+    }
+
+  }
+
+  private def getRequest(): Request[AnyContentAsEmpty.type] =
+    FakeRequest("GET", "").withSession((AmendmentJourneyAction.SessionId, "123")).withCSRFToken
+
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/group/RemoveMemberSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/forms/group/RemoveMemberSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.forms.group
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.CommonFormValues
+
+class RemoveMemberSpec extends AnyWordSpec with Matchers with CommonFormValues {
+
+  "Remove Member Form" should {
+    "round trip" when {
+      "yes is selected" in {
+        val yes = RemoveMember.toForm(Some(YES))
+
+        val fromYesForm = RemoveMember.fromForm(yes).flatten
+        fromYesForm mustBe Some("yes")
+
+        val backToForm = RemoveMember.toForm(fromYesForm)
+        RemoveMember.fromForm(backToForm).flatten mustBe Some("yes")
+      }
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/ConfirmRemoveMemberPageSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/group/ConfirmRemoveMemberPageSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.amendment.group
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.data.Form
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.RemoveMember
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.RemoveMember.form
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.group.confirm_remove_member_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class ConfirmRemoveMemberPageSpec extends UnitViewSpec with Matchers {
+
+  private val page = instanceOf[confirm_remove_member_page]
+
+  private def createView(form: Form[RemoveMember] = RemoveMember.form()): Document =
+    page(form, groupMember)(journeyRequest, messages)
+
+  "Confirm Remove Member  page" should {
+
+    val view = createView()
+
+    "contain title" in {
+      view.select("title").text() must include(
+        messages("amend.group.remove.title", groupMember.businessName)
+      )
+    }
+
+    "contain heading" in {
+      view.select("h1").text() mustBe messages("amend.group.remove.title", groupMember.businessName)
+    }
+
+    "contain radio groups with yes option" in {
+      view must containElementWithID("value")
+      val yesRadio = view.getElementById("value")
+      yesRadio.attr("type") mustBe "radio"
+      yesRadio.attr("value") mustBe "yes"
+    }
+
+    "display 'Continue' button" in {
+      view must containElementWithID("submit")
+      view.getElementById("submit").text() mustBe "Continue"
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods() = {
+    page.f(form(), groupMember)(journeyRequest, messages)
+    page.render(form(), groupMember, journeyRequest, messages)
+  }
+
+}


### PR DESCRIPTION
### Description of Work carried through

On exit from confirming remove member redirect to:
`/register-for-plastic-packaging-taxc`
not
`/manage-group-members`

Assigning a route Call to a val givens difference result than inlining that Call.


#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
