### PR TITLE
Fix correctly prefixed redirect to /register-for-plastic-packaging-ta…

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -41,7 +41,7 @@ class ConfirmRemoveMemberController @Inject() (
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) with I18nSupport {
 
-  private val onwardCall = routes.GroupMembersListController.displayPage()
+  private def onwardCall = routes.GroupMembersListController.displayPage()
 
   def displayPage(memberId: String): Action[AnyContent] =
     (authenticate andThen amendmentJourneyAction) { implicit request =>

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.http.Status.{OK, SEE_OTHER}
 import play.api.mvc.{AnyContentAsEmpty, Request}
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{await, status}
+import play.api.test.Helpers.{await, redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
@@ -117,6 +117,8 @@ class ConfirmRemoveMemberControllerSpec
           val updatedReg = await(inMemoryRegistrationAmendmentRepository.get(sessionId)).get
           updatedReg.groupDetail.get.members.size mustBe 1
           updatedReg.groupDetail.get.members.head mustBe groupMember
+
+          redirectLocation(resp) mustBe Some(routes.GroupMembersListController.displayPage().url)
         }
       }
     }


### PR DESCRIPTION
…x/manage-group-members

Call behaves oddly when assigned to a field val?

### Description of Work carried through

Brief description of what/why/how.

#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
