### PR TITLE
PPTP-1664 Prompt nominated partners for job title

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameController.scala
@@ -188,11 +188,13 @@ class PartnerContactNameController @Inject() (
       )
     }
 
-  private def nextPage(request: JourneyRequest[AnyContent], partner: Partner) =
-    if (isEditingNominatedPartner(request, partner))
+  private def nextPage(request: JourneyRequest[AnyContent], partner: Partner) = {
+    val alreadyHasJobTitle = partner.contactDetails.flatMap(_.jobTitle).nonEmpty
+    if (isEditingNominatedPartner(request, partner) || alreadyHasJobTitle)
       partnerRoutes.PartnerJobTitleController.displayNewPartner()
     else
       partnerRoutes.PartnerEmailAddressController.displayNewPartner()
+  }
 
   private def isEditingNominatedPartner(request: JourneyRequest[AnyContent], partner: Partner) =
     request.registration.nominatedPartner.forall(_.id == partner.id)

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleController.scala
@@ -90,7 +90,7 @@ class PartnerJobTitleController @Inject() (
       request.registration.inflightPartner.map { partner =>
         handleSubmission(partner,
                          partnerRoutes.PartnerTypeController.displayNewPartner(),
-                         partnerRoutes.PartnerContactNameController.submitNewPartner(),
+                         partnerRoutes.PartnerJobTitleController.submitNewPartner(),
                          partnerRoutes.PartnerEmailAddressController.displayNewPartner(),
                          commonRoutes.TaskListController.displayPage(),
                          updateInflightPartner
@@ -127,7 +127,7 @@ class PartnerJobTitleController @Inject() (
     onwardsCall: Call,
     dropoutCall: Call,
     updateAction: JobTitle => Future[Either[ServiceError, Registration]]
-  )(implicit request: JourneyRequest[AnyContent]): Future[Result] =
+  )(implicit request: JourneyRequest[AnyContent]): Future[Result] = {
     JobTitle.form()
       .bindFromRequest()
       .fold(
@@ -152,6 +152,7 @@ class PartnerJobTitleController @Inject() (
             case Left(error) => throw error
           }
       )
+  }
 
   private def updateInflightPartner(
     formData: JobTitle

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleController.scala
@@ -127,7 +127,7 @@ class PartnerJobTitleController @Inject() (
     onwardsCall: Call,
     dropoutCall: Call,
     updateAction: JobTitle => Future[Either[ServiceError, Registration]]
-  )(implicit request: JourneyRequest[AnyContent]): Future[Result] = {
+  )(implicit request: JourneyRequest[AnyContent]): Future[Result] =
     JobTitle.form()
       .bindFromRequest()
       .fold(
@@ -152,7 +152,6 @@ class PartnerJobTitleController @Inject() (
             case Left(error) => throw error
           }
       )
-  }
 
   private def updateInflightPartner(
     formData: JobTitle

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnerContactDetails.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/genericregistration/PartnerContactDetails.scala
@@ -24,7 +24,8 @@ case class PartnerContactDetails(
   lastName: Option[String] = None,
   emailAddress: Option[String] = None,
   phoneNumber: Option[String] = None,
-  address: Option[Address] = None
+  address: Option[Address] = None,
+  jobTitle: Option[String] = None
 ) {
 
   lazy val name: Option[String] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -45,13 +45,15 @@
 
 @partnerContactRows() = @{
     Seq(
-        viewUtils.summaryListRow("partner.check.contact.name", partner.contactDetails.flatMap(_.name), Some(partnerRoutes.PartnerContactNameController.displayExistingPartner(partner.id))),
-        viewUtils.summaryListRow("partner.check.contact.jobTitle", partner.contactDetails.flatMap(_.jobTitle), Some(partnerRoutes.PartnerJobTitleController.displayExistingPartner(partner.id))),
-        viewUtils.summaryListRow("partner.check.contact.email", partner.contactDetails.flatMap(_.emailAddress), Some(partnerRoutes.PartnerEmailAddressController.displayExistingPartner(partner.id))),
-        viewUtils.summaryListRow("partner.check.contact.phone", partner.contactDetails.flatMap(_.phoneNumber), Some(partnerRoutes.PartnerPhoneNumberController.displayExistingPartner(partner.id))),
-        viewUtils.summaryListRow("partner.check.contact.address", partner.contactDetails.flatMap(_.address.map(viewUtils.extractAddress)),
-            Some(partnerRoutes.PartnerContactAddressController.captureExistingPartner(partner.id))),
-    )
+        Some(viewUtils.summaryListRow("partner.check.contact.name", partner.contactDetails.flatMap(_.name), Some(partnerRoutes.PartnerContactNameController.displayExistingPartner(partner.id)))),
+        partner.contactDetails.flatMap(_.jobTitle).map { jobTitle =>
+            viewUtils.summaryListRow("partner.check.contact.jobTitle", Some(jobTitle), Some(partnerRoutes.PartnerJobTitleController.displayExistingPartner(partner.id)))
+        },
+        Some(viewUtils.summaryListRow("partner.check.contact.email", partner.contactDetails.flatMap(_.emailAddress), Some(partnerRoutes.PartnerEmailAddressController.displayExistingPartner(partner.id)))),
+        Some(viewUtils.summaryListRow("partner.check.contact.phone", partner.contactDetails.flatMap(_.phoneNumber), Some(partnerRoutes.PartnerPhoneNumberController.displayExistingPartner(partner.id)))),
+        Some(viewUtils.summaryListRow("partner.check.contact.address", partner.contactDetails.flatMap(_.address.map(viewUtils.extractAddress)),
+            Some(partnerRoutes.PartnerContactAddressController.captureExistingPartner(partner.id)))),
+    ).flatten
 }
 
 @ukCompanySummary() = @{

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_check_answers_page.scala.html
@@ -46,6 +46,7 @@
 @partnerContactRows() = @{
     Seq(
         viewUtils.summaryListRow("partner.check.contact.name", partner.contactDetails.flatMap(_.name), Some(partnerRoutes.PartnerContactNameController.displayExistingPartner(partner.id))),
+        viewUtils.summaryListRow("partner.check.contact.jobTitle", partner.contactDetails.flatMap(_.jobTitle), Some(partnerRoutes.PartnerJobTitleController.displayExistingPartner(partner.id))),
         viewUtils.summaryListRow("partner.check.contact.email", partner.contactDetails.flatMap(_.emailAddress), Some(partnerRoutes.PartnerEmailAddressController.displayExistingPartner(partner.id))),
         viewUtils.summaryListRow("partner.check.contact.phone", partner.contactDetails.flatMap(_.phoneNumber), Some(partnerRoutes.PartnerPhoneNumberController.displayExistingPartner(partner.id))),
         viewUtils.summaryListRow("partner.check.contact.address", partner.contactDetails.flatMap(_.address.map(viewUtils.extractAddress)),

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_job_title_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_job_title_page.scala.html
@@ -1,0 +1,54 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyRequest
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.models.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.models.BackButton
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.JobTitle
+
+@this(
+  govukLayout: main_template,
+  saveButtons: saveButtons,
+  govukInput: GovukInput,
+  sectionHeader: sectionHeader,
+  errorSummary: errorSummary,
+  formHelper: FormWithCSRF
+)
+@(form: Form[JobTitle], contactName: String, backLink: Call, updateCall: Call)(implicit request: JourneyRequest[_], messages: Messages)
+
+@jobTitleField = @{form("value")}
+
+@govukLayout(
+  title = Title(headingKey = "partnership.otherPartners.jobTitlePage.title", contactName),
+  backButton = Some(BackButton(messages("site.back"), backLink, messages("site.back.hiddenText")))) {
+  @errorSummary(form.errors)
+
+  @formHelper(action = updateCall, 'autoComplete -> "off") {
+    @govukInput(
+        Input(
+            id = s"${jobTitleField.name}",
+            name = jobTitleField.name,
+            value = jobTitleField.value,
+            errorMessage = jobTitleField.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+            label = Label(
+                isPageHeading = true,
+                classes = gdsLabelPageHeading,
+                content = Text(messages("partnership.otherPartners.jobTitlePage.title", contactName))))
+            )
+        @saveButtons()
+    }
+ }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -105,6 +105,11 @@ POST       /partner-contact-name                uk.gov.hmrc.plasticpackagingtax.
 GET        /partner-contact-name/:partnerId     uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerContactNameController.displayExistingPartner(partnerId: String)
 POST       /partner-contact-name/:partnerId     uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerContactNameController.submitExistingPartner(partnerId: String)
 
+GET        /partner-job-title                   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerJobTitleController.displayNewPartner()
+POST       /partner-job-title                   uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerJobTitleController.submitNewPartner()
+GET        /partner-job-title/:partnerId        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerJobTitleController.displayExistingPartner(partnerId: String)
+POST       /partner-job-title/:partnerId        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerJobTitleController.submitExistingPartner(partnerId: String)
+
 GET        /partner-email-address               uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerEmailAddressController.displayNewPartner()
 POST       /partner-email-address               uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerEmailAddressController.submitNewPartner()
 GET        /partner-email-address/:partnerId    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerEmailAddressController.displayExistingPartner(partnerId: String)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -363,6 +363,7 @@ other.partner.type.title = What type of organisation is the next partner you wan
 
 partnerships.otherPartners.title = You have {0} partners in your partnership
 partnership.otherPartners.contactNamePage.title = Who is the main contact for {0}?
+partnership.otherPartners.jobTitlePage.title = What is {0}’s job title?
 partnership.otherPartners.contactEmailAddressPage.title = What is {0}’s email address?
 partnership.otherPartners.contactPhoneNumberPage.title = What is {0}’s telephone number?
 partnership.otherPartners.checkAnswers.contactName = Name
@@ -614,6 +615,7 @@ partner.check.name = Name
 partner.check.nino = National Insurance Number
 partner.check.contact.name = Contact name
 partner.check.contact.email = Contact email
+partner.check.contact.jobTitle = Job title
 partner.check.contact.phone = Phone number
 partner.check.contact.address = Contact address
 

--- a/test/spec/PptTestData.scala
+++ b/test/spec/PptTestData.scala
@@ -585,6 +585,7 @@ trait PptTestData extends RegistrationBuilder with MockAuthAction {
             contactDetails = Some(
               PartnerContactDetails(firstName = Some("Jon"),
                                     lastName = Some("Jobson"),
+                                    jobTitle = Some("Director"),
                                     emailAddress = Some("jon@pp.com"),
                                     phoneNumber = Some("07876235834"),
                                     address = Some(

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerSpec.scala
@@ -62,7 +62,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
   private def registrationWithPartnershipDetailsAndNonNominatedInflightPartner =
     aRegistration(withPartnershipDetails(Some(generalPartnershipDetails))).addOtherPartner(
       aSoleTraderPartner
-    ).withInflightPartner(Some(aLimitedCompanyPartner()))
+    ).withInflightPartner(Some(aPartnershipPartner()))
 
   private val existingPartner =
     aLimitedCompanyPartner()

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleControllerSpec.scala
@@ -26,22 +26,22 @@ import play.api.test.DefaultAwaitTimeout
 import play.api.test.Helpers.{redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
-import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.MemberName
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_member_name_page
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.JobTitle
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_job_title_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitTimeout {
+class PartnerJobTitleControllerSpec extends ControllerSpec with DefaultAwaitTimeout {
 
-  private val page = mock[partner_member_name_page]
+  private val page = mock[partner_job_title_page]
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new PartnerContactNameController(authenticate = mockAuthAction,
-                                     journeyAction = mockJourneyAction,
-                                     registrationConnector =
-                                       mockRegistrationConnector,
-                                     mcc = mcc,
-                                     page = page
+    new PartnerJobTitleController(authenticate = mockAuthAction,
+                                  journeyAction = mockJourneyAction,
+                                  registrationConnector =
+                                    mockRegistrationConnector,
+                                  mcc = mcc,
+                                  page = page
     )
 
   override protected def beforeEach(): Unit = {
@@ -72,7 +72,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
       withPartnershipDetails(Some(generalPartnershipDetails.copy(partners = Seq(existingPartner))))
     )
 
-  "PartnerContactNameController" should {
+  "PartnerJobTitleController" should {
 
     "return 200" when {
       "user is authorised, a registration already exists with already collected nominated partner" in {
@@ -84,7 +84,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
         status(result) mustBe OK
       }
 
-      "displaying an existing partner to edit their contact name" in {
+      "displaying an existing partner to edit their job title" in {
         authorizedUser()
         mockRegistrationFind(registrationWithExistingPartner)
 
@@ -95,13 +95,13 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
     }
 
     "update inflight registration" when {
-      "user submits a complete contact name" in {
+      "user submits a complete job title" in {
         authorizedUser()
         mockRegistrationFind(registrationWithPartnershipDetailsAndNonNominatedInflightPartner)
         mockRegistrationUpdate()
 
         val result = controller.submitNewPartner()(
-          postRequestEncoded(MemberName("John", "Smith"), saveAndContinueFormAction)
+          postRequestEncoded(JobTitle("Director"), saveAndContinueFormAction)
         )
 
         status(result) mustBe SEE_OTHER
@@ -110,43 +110,24 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
         )
 
         modifiedRegistration.inflightPartner.flatMap(
-          _.contactDetails.flatMap(_.firstName)
-        ) mustBe Some("John")
-        modifiedRegistration.inflightPartner.flatMap(
-          _.contactDetails.flatMap(_.lastName)
-        ) mustBe Some("Smith")
+          _.contactDetails.flatMap(_.jobTitle)
+        ) mustBe Some("Director")
       }
 
-      "nominated partner submits a contact name and is prompted for job title" in {
-        authorizedUser()
-        mockRegistrationFind(registrationWithPartnershipDetailsAndInflightPartner)
-        mockRegistrationUpdate()
-
-        val result = controller.submitNewPartner()(
-          postRequestEncoded(MemberName("John", "Smith"), saveAndContinueFormAction)
-        )
-
-        status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(
-          routes.PartnerJobTitleController.displayNewPartner().url
-        )
-      }
-
-      "user submits an amendment to an existing partners contact name" in {
+      "user submits an amendment to an existing partners job title" in {
         authorizedUser()
         mockRegistrationFind(registrationWithExistingPartner)
         mockRegistrationUpdate()
 
         val result = controller.submitExistingPartner(existingPartner.id)(
-          postRequest(Json.toJson(MemberName("Jane", "Smith")))
+          postRequest(Json.toJson(JobTitle("Company secretary")))
         )
 
         status(result) mustBe SEE_OTHER
 
         val modifiedContactDetails =
           modifiedRegistration.findPartner(existingPartner.id).flatMap(_.contactDetails)
-        modifiedContactDetails.flatMap(_.firstName) mustBe Some("Jane")
-        modifiedContactDetails.flatMap(_.lastName) mustBe Some("Smith")
+        modifiedContactDetails.flatMap(_.jobTitle) mustBe Some("Company secretary")
       }
     }
 
@@ -156,19 +137,17 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
         mockRegistrationFind(registrationWithPartnershipDetailsAndInflightPartner)
 
         val result =
-          controller.submitNewPartner()(
-            postRequestEncoded(MemberName("John", ""), saveAndContinueFormAction)
-          )
+          controller.submitNewPartner()(postRequestEncoded(JobTitle(""), saveAndContinueFormAction))
 
         status(result) mustBe BAD_REQUEST
       }
 
-      "user enters a long name" in {
+      "user enters a long title" in {
         authorizedUser()
         mockRegistrationFind(registrationWithPartnershipDetailsAndInflightPartner)
 
         val result = controller.submitNewPartner()(
-          postRequestEncoded(MemberName("abced" * 40, "Smith"), saveAndContinueFormAction)
+          postRequestEncoded(JobTitle("abced" * 40), saveAndContinueFormAction)
         )
 
         status(result) mustBe BAD_REQUEST
@@ -180,9 +159,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
 
         val result =
           controller.submitNewPartner()(
-            postRequestEncoded(MemberName("FirstNam807980234£$", "LastName"),
-                               saveAndContinueFormAction
-            )
+            postRequestEncoded(JobTitle("Director 123"), saveAndContinueFormAction)
           )
 
         status(result) mustBe BAD_REQUEST
@@ -214,7 +191,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
         mockRegistrationUpdate()
 
         val result = controller.submitExistingPartner("not-an-existing-partners-id")(
-          postRequestEncoded(MemberName("Jane", "Smith"), saveAndContinueFormAction)
+          postRequestEncoded(JobTitle("Director"), saveAndContinueFormAction)
         )
 
         intercept[RuntimeException](status(result))
@@ -226,7 +203,7 @@ class PartnerContactNameControllerSpec extends ControllerSpec with DefaultAwaitT
         mockRegistrationUpdateFailure()
 
         val result =
-          controller.submitNewPartner()(postRequest(Json.toJson(MemberName("John", "Smith"))))
+          controller.submitNewPartner()(postRequest(Json.toJson(JobTitle("Director"))))
 
         intercept[DownstreamServiceError](status(result))
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
@@ -96,6 +96,10 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
           limitedCompanyPartner.contactDetails.get.name.get,
           None: Option[Call]
          ),
+         (messages("partner.check.contact.jobTitle"),
+          limitedCompanyPartner.contactDetails.get.jobTitle.getOrElse(""),
+          None: Option[Call]
+         ),
          (messages("partner.check.contact.email"),
           limitedCompanyPartner.contactDetails.get.emailAddress.get,
           None: Option[Call]
@@ -137,6 +141,10 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
           soleTraderPartner.contactDetails.get.name.get,
           None: Option[Call]
          ),
+         (messages("partner.check.contact.jobTitle"),
+          limitedCompanyPartner.contactDetails.get.jobTitle.getOrElse(""),
+          None: Option[Call]
+         ),
          (messages("partner.check.contact.email"),
           soleTraderPartner.contactDetails.get.emailAddress.get,
           None: Option[Call]
@@ -165,6 +173,10 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
          ),
          (messages("partner.check.contact.name"),
           partnershipPartner.contactDetails.get.name.get,
+          None: Option[Call]
+         ),
+         (messages("partner.check.contact.jobTitle"),
+          limitedCompanyPartner.contactDetails.get.jobTitle.getOrElse(""),
           None: Option[Call]
          ),
          (messages("partner.check.contact.email"),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerCheckAnswersViewSpec.scala
@@ -141,10 +141,6 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
           soleTraderPartner.contactDetails.get.name.get,
           None: Option[Call]
          ),
-         (messages("partner.check.contact.jobTitle"),
-          limitedCompanyPartner.contactDetails.get.jobTitle.getOrElse(""),
-          None: Option[Call]
-         ),
          (messages("partner.check.contact.email"),
           soleTraderPartner.contactDetails.get.emailAddress.get,
           None: Option[Call]
@@ -173,10 +169,6 @@ class PartnerCheckAnswersViewSpec extends UnitViewSpec with Matchers {
          ),
          (messages("partner.check.contact.name"),
           partnershipPartner.contactDetails.get.name.get,
-          None: Option[Call]
-         ),
-         (messages("partner.check.contact.jobTitle"),
-          limitedCompanyPartner.contactDetails.get.jobTitle.getOrElse(""),
           None: Option[Call]
          ),
          (messages("partner.check.contact.email"),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerJobTitlePageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerJobTitlePageViewSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.partner
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.data.Form
+import play.api.mvc.Call
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.JobTitle
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_job_title_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class PartnerJobTitlePageViewSpec extends UnitViewSpec with Matchers {
+
+  private val page = instanceOf[partner_job_title_page]
+
+  private val backLink   = Call("GET", "/back-link")
+  private val updateLink = Call("PUT", "/update")
+
+  private val contactName = "A Contact"
+
+  private def createView(form: Form[JobTitle] = JobTitle.form()): Document =
+    page(form, contactName, backLink, updateLink)(journeyRequest, messages)
+
+  "Job title View" should {
+
+    val view = createView()
+
+    "contain timeout dialog function" in {
+
+      containTimeoutDialogFunction(view) mustBe true
+
+    }
+
+    "display sign out link" in {
+
+      displaySignOutLink(view)
+
+    }
+
+    "display 'Back' button" in {
+
+      view.getElementById("back-link") must haveHref(backLink.url)
+    }
+
+    "display title" in {
+
+      view.select("title").text() must include(
+        messages("partnership.otherPartners.jobTitlePage.title", contactName)
+      )
+    }
+
+    "display job title input box" in {
+
+      view must containElementWithID("value")
+    }
+
+    "display 'Save and continue' button" in {
+
+      view must containElementWithID("submit")
+      view.getElementById("submit").text() mustBe "Save and continue"
+    }
+
+  }
+
+  "display error" when {
+
+    "job title is not entered" in {
+
+      val form = JobTitle
+        .form()
+        .fillAndValidate(JobTitle(""))
+      val view = createView(form)
+
+      view must haveGovukGlobalErrorSummary
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    page.f(JobTitle.form(), contactName, backLink, updateLink)(journeyRequest, messages)
+    page.render(JobTitle.form(), contactName, backLink, updateLink, journeyRequest, messages)
+  }
+
+}


### PR DESCRIPTION
### Description of Work carried through

Nominated partners (or the first in flight partner been added) are prompted for the contact's job title.

Check answers page renders the job title if it is present.
Any partner whom we hold a job title for has the option to edit it (guards against partner moving around; been promoted or demoted from been the nominated partner)

Known limitations - the back link from content email address still links to contact name.


![Screenshot from 2022-02-15 15-56-30](https://user-images.githubusercontent.com/95688374/154101746-717a79d4-0261-4a8e-8f29-7b664e2b0d12.png)

![Screenshot from 2022-02-15 16-09-45](https://user-images.githubusercontent.com/95688374/154101803-ba8d2956-344a-425f-815b-62059896d6f3.png)


Brief description of what/why/how.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
