### PR TITLE
PPTP-1426 Adding "Return to account" button to organisation details page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/amend_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/amend_registration_page.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.models.{BackButton, Title}
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.amendment.{organisationDetails, primaryContactDetails}
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.linkButton
 
 @this(
         formHelper: FormWithCSRF,
@@ -30,7 +31,8 @@
         pageHeading: pageHeading,
         appConfig: AppConfig,
         organisationDetails: organisationDetails,
-        primaryContactDetails: primaryContactDetails
+        primaryContactDetails: primaryContactDetails,
+        returnToAccountButton: linkButton
 )
 @(registration: Registration)(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
@@ -56,4 +58,5 @@
 
     @organisationDetails(request.pptReference, registration, Some(amendRoutes.AmendOrganisationDetailsController.changeBusinessAddress()))
     @primaryContactDetails(registration)
+    @returnToAccountButton("amend.backButton.text", appConfig.pptAccountUrl, "hello")
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/amend_registration_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/amend_registration_page.scala.html
@@ -58,5 +58,5 @@
 
     @organisationDetails(request.pptReference, registration, Some(amendRoutes.AmendOrganisationDetailsController.changeBusinessAddress()))
     @primaryContactDetails(registration)
-    @returnToAccountButton("amend.backButton.text", appConfig.pptAccountUrl, "hello")
+    @returnToAccountButton("amend.backButton.text", appConfig.pptAccountUrl, "return-to-account-page")
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/linkButton.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/linkButton.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+
+@this(govukButton: GovukButton)
+
+@(messageKey: String, linkUrl: String, id: String = "link-button")(implicit messages: Messages)
+
+<span class="govuk-button-group">
+    @govukButton(Button(
+        content = Text(messages(messageKey)),
+        classes = "govuk-!-margin-right-1",
+        href = Some(linkUrl),
+        attributes = Map("id" -> id)
+    ))
+</span>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -635,6 +635,7 @@ amend.organisation.subheading = Organisation details
 amend.individual.subheading = Your details
 amend.group.subheading = Organisation details
 amend.partnership.subheading = Partnership details
+amend.backButton.text = Back to account homepage
 
 amend.organisation.label = Organisation name
 amend.individual.label = Your name

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/AmendRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/amendment/AmendRegistrationViewSpec.scala
@@ -231,6 +231,11 @@ class AmendRegistrationViewSpec extends UnitViewSpec with Matchers {
                 )
             }
           }
+
+          "display the back to account page button" in {
+            val element = view.getElementById("return-to-account-page")
+            element must haveHref(realAppConfig.pptAccountUrl)
+          }
         }
       }
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/components/LinkButtonSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/components/LinkButtonSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.components
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Element
+import org.scalatest.matchers.must.Matchers
+import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.linkButton
+
+class LinkButtonSpec extends UnitViewSpec with Matchers {
+
+  val linkButton: linkButton = inject[linkButton]
+
+  val view: Html =
+    linkButton("organisation.checkAnswers.title", "/some/page/somewhere", "example-id")
+
+  "A linkButton" must {
+
+    val a_element: Element = view.select("span a").get(0)
+
+    "show the given text" in {
+      view.text() mustBe messages("organisation.checkAnswers.title")
+    }
+
+    "have the given id" in {
+      a_element.attr("id") mustBe "example-id"
+    }
+
+    "have given href" in {
+      a_element.attr("href") mustBe "/some/page/somewhere"
+    }
+
+    "have class" in {
+      a_element.attr("class") must include("govuk-!-margin-right-1")
+    }
+
+    "wrapped in group class" in {
+      val wrapper_element = view.select("span").get(0)
+      wrapper_element.attr("class") must include("govuk-button-group")
+    }
+
+  }
+
+  override def exerciseGeneratedRenderingMethods(): Unit = {
+    linkButton.f("organisation.checkAnswers.title", "/url", "id")
+    linkButton.render("organisation.checkAnswers.title", "/url", "id", messages)
+  }
+
+}


### PR DESCRIPTION
### Description of Work carried through

Adding "Return to account" button to organisation details page

#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
