### PR TITLE
PPTP-1732 : Trap ALF Addresses with Missing Postcodes

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureController.scala
@@ -149,7 +149,7 @@ class AddressCaptureController @Inject() (
         ).flatMap {
           confirmedAddress =>
             val pptAddress  = Address(confirmedAddress)
-            val addressForm = Address.form().fillAndValidate(pptAddress)
+            val addressForm = Address.fillAndValidate(pptAddress)
             if (addressForm.errors.nonEmpty)
               Future.successful(BadRequest(buildAddressPage(addressForm, config)))
             else

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureControllerSpec.scala
@@ -186,6 +186,17 @@ class AddressCaptureControllerSpec
         status(resp) mustBe BAD_REQUEST
         contentAsString(resp) mustBe "Address Capture"
       }
+      "ALF address is missing a postcode" in {
+        val validAlfAddress = aValidAlfAddress()
+        val invalidAlfAddress =
+          validAlfAddress.copy(address = validAlfAddress.address.copy(postcode = None))
+        simulateAlfCallback(invalidAlfAddress)
+
+        val resp = addressCaptureController.alfCallback(Some("123"))(getRequest())
+
+        status(resp) mustBe BAD_REQUEST
+        contentAsString(resp) mustBe "Address Capture"
+      }
     }
 
     "redirect to the PPT address capture page" when {


### PR DESCRIPTION
The standard form fillAndValidate() call was not spotting missing postcodes for UK addresses entered via ALF. I suspect this was connected to our use of a mandatoryIfEqual mapping validator. This is a work-around to bypass this shortcoming.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [ ] User Acceptance Tests (UAT) were run locally and have passed - N/A
 - [ ] No Accessibility errors/warnings reported by Wave - N/A
