### PR TITLE
Move pre-launch liability controller and view to own package

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/StartRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/StartRegistrationController.scala
@@ -24,6 +24,9 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{
   routes => liabilityRoutes
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{
+  routes => prelaunchLiabilityRoutes
+}
 
 import javax.inject.{Inject, Singleton}
 
@@ -44,7 +47,7 @@ class StartRegistrationController @Inject() (
 
   def startLink(implicit request: JourneyRequest[AnyContent]): Call =
     if (request.isFeatureFlagEnabled(Features.isPreLaunch))
-      liabilityRoutes.LiabilityWeightExpectedController.displayPage()
+      prelaunchLiabilityRoutes.LiabilityWeightExpectedController.displayPage()
     else liabilityRoutes.LiabilityWeightController.displayPage()
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/TaskListController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/TaskListController.scala
@@ -30,6 +30,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
   task_list_single_entity
 }
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{
+  routes => prelaunchLiabilityRoutes
+}
 
 import javax.inject.{Inject, Singleton}
 
@@ -55,7 +58,7 @@ class TaskListController @Inject() (
 
   private def startLink(implicit request: JourneyRequest[AnyContent]) =
     if (request.isFeatureFlagEnabled(Features.isPreLaunch))
-      liabilityRoutes.LiabilityWeightExpectedController.displayPage()
+      prelaunchLiabilityRoutes.LiabilityWeightExpectedController.displayPage()
     else liabilityRoutes.LiabilityWeightController.displayPage()
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/BackwardLookTestController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/BackwardLookTestController.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
+
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{
+  DownstreamServiceError,
+  RegistrationConnector,
+  ServiceError
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
+  AuthAction,
+  FormAction,
+  SaveAndContinue
+}
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.ExpectToExceedThresholdWeight
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.liability_expect_to_exceed_threshold_weight_page
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class BackwardLookTestController @Inject() (
+  authenticate: AuthAction,
+  journeyAction: JourneyAction,
+  override val registrationConnector: RegistrationConnector,
+  mcc: MessagesControllerComponents,
+  page: liability_expect_to_exceed_threshold_weight_page
+)(implicit ec: ExecutionContext)
+    extends LiabilityController(mcc) with Cacheable with I18nSupport {
+
+  def displayPage(): Action[AnyContent] =
+    (authenticate andThen journeyAction).async { implicit request =>
+      Future.successful(Ok)
+    }
+
+  def submit(): Action[AnyContent] =
+    (authenticate andThen journeyAction).async { implicit request =>
+      Future.successful(Ok)
+    }
+
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/RegistrationTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/RegistrationTypeController.scala
@@ -25,6 +25,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.{RegType, Re
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.registration_type_page
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{
+  routes => prelaunchLiabilityRoutes
+}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -73,7 +76,7 @@ class RegistrationTypeController @Inject() (
 
   private def backLink()(implicit request: JourneyRequest[AnyContent]): Call =
     if (isPreLaunch)
-      routes.LiabilityWeightExpectedController.displayPage()
+      prelaunchLiabilityRoutes.LiabilityWeightExpectedController.displayPage()
     else
       routes.LiabilityStartDateController.displayPage()
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/prelaunch/LiabilityWeightExpectedController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/prelaunch/LiabilityWeightExpectedController.scala
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch
 
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityController
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{
+  routes => liabilityRoutes
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.Date
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.LiabilityExpectedWeight
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.liability_weight_expected_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.prelaunch.liability_weight_expected_page
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -83,8 +87,8 @@ class LiabilityWeightExpectedController @Inject() (
     formData: LiabilityExpectedWeight
   )(implicit req: JourneyRequest[AnyContent]): Result =
     if (formData.overLiabilityThreshold)
-      Redirect(routes.RegistrationTypeController.displayPage())
+      Redirect(liabilityRoutes.RegistrationTypeController.displayPage())
     else
-      Redirect(routes.NotLiableController.displayPage())
+      Redirect(liabilityRoutes.NotLiableController.displayPage())
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/prelaunch/liability_weight_expected_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/prelaunch/liability_weight_expected_page.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{routes => pptRoutes}
 @import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.LiabilityExpectedWeight
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.models.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{routes => prelaunchLiabilityRoutes}
 
 @this(
         govukLayout: main_template,
@@ -68,7 +68,7 @@
 
     @sectionHeader(messages("liabilityExpectedWeightPage.sectionHeader"))
 
-    @formHelper(action = pptRoutes.LiabilityWeightExpectedController.submit(), 'autoComplete -> "off") {
+    @formHelper(action = prelaunchLiabilityRoutes.LiabilityWeightExpectedController.submit(), 'autoComplete -> "off") {
 
         @govukRadios(Radios(
             fieldset = Some(Fieldset(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,12 +7,11 @@ GET        /assets/*file            controllers.Assets.versioned(path="/public",
 GET        /start                uk.gov.hmrc.plasticpackagingtax.registration.controllers.StartController.displayStartPage()
 GET        /start-registration   uk.gov.hmrc.plasticpackagingtax.registration.controllers.StartRegistrationController.startRegistration()
 
-# Liability
-GET        /packaging-weight-next-12months        uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityWeightExpectedController.displayPage()
-POST       /packaging-weight-next-12months        uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityWeightExpectedController.submit()
+# Pre-launch liability
+GET        /packaging-weight-next-12months        uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.LiabilityWeightExpectedController.displayPage()
+POST       /packaging-weight-next-12months        uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.LiabilityWeightExpectedController.submit()
 
-GET        /registration-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.RegistrationTypeController.displayPage()
-POST       /registration-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.RegistrationTypeController.submit()
+# Post-launch liability
 
 GET        /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityStartDateController.displayPage()
 POST       /liable-date    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityStartDateController.submit()
@@ -26,7 +25,15 @@ POST       /threshold-next-30-days       uk.gov.hmrc.plasticpackagingtax.registr
 GET        /weight-next-12-months        uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityWeightController.displayPage()
 POST       /weight-next-12-months        uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.LiabilityWeightController.submit()
 
+GET        /backward-look    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.BackwardLookTestController.displayPage()
+POST       /backward-look    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.BackwardLookTestController.submit()
+
+# Liability used both pre and post launch
 GET        /not-liable  uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.NotLiableController.displayPage()
+
+GET        /registration-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.RegistrationTypeController.displayPage()
+POST       /registration-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.RegistrationTypeController.submit()
+
 
 GET        /check-plastic-packaging-answers    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.CheckLiabilityDetailsAnswersController.displayPage()
 POST       /check-plastic-packaging-answers    uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.CheckLiabilityDetailsAnswersController.submit()

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/StartTaskListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/StartTaskListControllerSpec.scala
@@ -24,6 +24,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{
   routes => liabilityRoutes
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{
+  routes => preLaunchLiabilityRoutes
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.LiabilityWeight
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   LiabilityDetails,
@@ -50,7 +53,9 @@ class StartTaskListControllerSpec extends ControllerSpec {
       "no existing registration" when {
         "preLaunch" in {
           authorizedUser(features = Map(Features.isPreLaunch -> true))
-          verifyRedirect(liabilityRoutes.LiabilityWeightExpectedController.displayPage().url)
+          verifyRedirect(
+            preLaunchLiabilityRoutes.LiabilityWeightExpectedController.displayPage().url
+          )
         }
         "postLaunch" in {
           authorizedUser(features = Map(Features.isPreLaunch -> false))

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/TaskListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/TaskListControllerSpec.scala
@@ -29,6 +29,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{
   routes => liabilityRoutes
 }
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{
+  routes => prelaunchLiabilityRoutes
+}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.{
   task_list_group,
@@ -137,7 +140,9 @@ class TaskListControllerSpec extends ControllerSpec {
       mockRegistrationFind(aRegistration())
       "preLaunch" in {
         authorizedUser(features = Map(Features.isPreLaunch -> true))
-        verifyStartLink(liabilityRoutes.LiabilityWeightExpectedController.displayPage().url)
+        verifyStartLink(
+          prelaunchLiabilityRoutes.LiabilityWeightExpectedController.displayPage().url
+        )
       }
       "postLaunch" in {
         authorizedUser(features = Map(Features.isPreLaunch -> false))

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/LiabilityWeightExpectedControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/LiabilityWeightExpectedControllerTest.scala
@@ -26,8 +26,9 @@ import play.api.http.Status.{BAD_REQUEST, OK, SEE_OTHER}
 import play.api.test.Helpers.{redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamServiceError
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.LiabilityWeightExpectedController
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.LiabilityExpectedWeight
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.liability_weight_expected_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.prelaunch.liability_weight_expected_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 class LiabilityWeightExpectedControllerTest extends ControllerSpec {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/RegistrationTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/RegistrationTypeControllerSpec.scala
@@ -31,6 +31,9 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType.GROU
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegistrationType
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.registration_type_page
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.prelaunch.{
+  routes => prelaunchLiabilityRoutes
+}
 
 class RegistrationTypeControllerSpec extends ControllerSpec {
 
@@ -94,7 +97,9 @@ class RegistrationTypeControllerSpec extends ControllerSpec {
 
       "preLaunch" in {
         authorizedUser(features = Map(Features.isPreLaunch -> true))
-        verifyExpectedBackLink(routes.LiabilityWeightExpectedController.displayPage().url)
+        verifyExpectedBackLink(
+          prelaunchLiabilityRoutes.LiabilityWeightExpectedController.displayPage().url
+        )
       }
 
       "postLaunch" in {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/LiabilityExpectedWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/LiabilityExpectedWeightViewSpec.scala
@@ -21,7 +21,7 @@ import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
 import play.api.data.Form
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.LiabilityExpectedWeight
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.liability_weight_expected_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.prelaunch.liability_weight_expected_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 
 @ViewTest


### PR DESCRIPTION
…laceholder url and controller for backwards-look test

Move pre-launch liability controller and view to own package, add placeholder url and controller for backwards-look test

Brief description of what/why/how.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
