### PR TITLE
Upgrade library to resolve accessibility issues

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
   val compile = Seq(
     ws,
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.16.0",
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "1.26.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "3.4.0-play-28",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.56.0",
     "uk.gov.hmrc"             %% "play-conditional-form-mapping" % "1.10.0-play-28"
   )


### PR DESCRIPTION
### Description of Work carried through

Upgrading the `play-frontend-hmrc` library following guidance in the [accessibility test report](https://build.tax.service.gov.uk/job/Plastic%20Packaging%20Tax/job/plastic-packaging-tax-a11y-tests/40/Accessibility_20Check_20Report/) to resolve issues identified by VNU.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
