### PR TITLE
PPTP-1756 : Rework Registration Submitted Confirmation Page

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -48,7 +48,6 @@ class ReviewRegistrationController @Inject() (
   metrics: Metrics,
   override val registrationConnector: RegistrationConnector,
   auditor: Auditor,
-  startRegistrationController: StartRegistrationController,
   reviewRegistrationPage: review_registration_page,
   registrationFilterService: RegistrationGroupFilterService
 )(implicit ec: ExecutionContext)
@@ -107,10 +106,22 @@ class ReviewRegistrationController @Inject() (
     )
     if (response.enrolmentInitiatedSuccessfully.contains(true))
       Redirect(routes.ConfirmationController.displayPage())
-        .flashing(Flash(Map(FlashKeys.referenceId -> response.pptReference)))
+        .flashing(
+          Flash(
+            Map(FlashKeys.referenceId -> response.pptReference,
+                FlashKeys.groupReg    -> registration.isGroup.toString
+            )
+          )
+        )
     else
       Redirect(routes.NotableErrorController.enrolmentFailure())
-        .flashing(Flash(Map(FlashKeys.referenceId -> response.pptReference)))
+        .flashing(
+          Flash(
+            Map(FlashKeys.referenceId -> response.pptReference,
+                FlashKeys.groupReg    -> registration.isGroup.toString
+            )
+          )
+        )
   }
 
   private def handleFailedSubscription(registration: Registration, failures: Seq[EisError])(implicit

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -149,7 +149,8 @@ abstract class AuthActionBase @Inject() (
           SignedInUser(allEnrolments,
                        identityData,
                        allowedUsers.getUserFeatures(email).getOrElse(appConfig.defaultFeatures)
-          )
+          ),
+          appConfig
         )
       )
     else {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AuthenticatedRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AuthenticatedRequest.scala
@@ -17,15 +17,25 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.models.request
 
 import play.api.mvc.{Request, WrappedRequest}
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
 
-class AuthenticatedRequest[+A](request: Request[A], val user: SignedInUser)
-    extends WrappedRequest[A](request) {
+class AuthenticatedRequest[+A](
+  request: Request[A],
+  val user: SignedInUser,
+  val appConfig: AppConfig
+) extends WrappedRequest[A](request) {
 
   def pptReference: Option[String] =
     user.enrolments.getEnrolment(PptEnrolment.Identifier).flatMap(
       enrolment => enrolment.getIdentifier(PptEnrolment.Key)
     ).map(id => id.value)
+
+  val featureFlags: Map[String, Boolean] =
+    user.features
+
+  def isFeatureFlagEnabled(flag: String) =
+    featureFlags.getOrElse(flag, appConfig.isDefaultFeatureFlagEnabled(flag))
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyRequest.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/request/JourneyRequest.scala
@@ -22,13 +22,5 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registra
 final case class JourneyRequest[+A](
   authenticatedRequest: AuthenticatedRequest[A],
   registration: Registration,
-  appConfig: AppConfig
-) extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user) {
-
-  val featureFlags: Map[String, Boolean] =
-    authenticatedRequest.user.features
-
-  def isFeatureFlagEnabled(flag: String) =
-    featureFlags.getOrElse(flag, appConfig.isDefaultFeatureFlagEnabled(flag))
-
-}
+  override val appConfig: AppConfig
+) extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user, appConfig) {}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/response/FlashKeys.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/response/FlashKeys.scala
@@ -18,4 +18,5 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.response
 
 object FlashKeys {
   val referenceId: String = "referenceId"
+  val groupReg: String    = "groupReg"
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/confirmation_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/confirmation_page.scala.html
@@ -15,43 +15,86 @@
  *@
 
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+@import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
 @import uk.gov.hmrc.plasticpackagingtax.registration.models.response.FlashKeys
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.models.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.utils.ViewUtils
+
+@import java.time.LocalDate
 
 @this(
-    govukLayout: main_template,
-    govukPanel : GovukPanel,
-    subHeading: subHeading,
-    paragraphBody: paragraphBody,
-    link: link,
-    appConfig: AppConfig
+        govukLayout: main_template,
+        govukPanel: GovukPanel,
+        subHeading: subHeading,
+        paragraphBody: paragraphBody,
+        paragraph: paragraph,
+        link: link,
+        appConfig: AppConfig,
+        viewUtils: ViewUtils,
+        bulletList: bulletList
 )
 
-@()(implicit request: Request[_], messages: Messages, flash: Flash)
+@()(implicit request: AuthenticatedRequest[_], messages: Messages, flash: Flash)
+
+@heading = {
+    @if(flash.get(FlashKeys.groupReg).contains(true.toString)) {
+        @messages("confirmationPage.group.heading", viewUtils.displayLocalDate(LocalDate.now()))
+    } else {
+        @messages("confirmationPage.heading", viewUtils.displayLocalDate(LocalDate.now()))
+    }
+}
+
+@preLaunchDetail = {
+    @paragraphBody(message = messages("confirmationPage.preLaunch.whatHappensNext.detail"))
+    @paragraphBody(message = messages("confirmationPage.preLaunch.whatHappensNext.link",
+        link(text = messages("confirmationPage.preLaunch.whatHappensNext.link.text"), call = Call("GET", appConfig.pptAccountUrl))))
+}
+
+@postLaunchDetail = {
+    @paragraphBody(message = messages("confirmationPage.whatHappensNext.detail",
+        link(text = messages("confirmationPage.whatHappensNext.detail.link"), call = Call("GET", appConfig.pptAccountUrl))))
+    @bulletList(elements = Seq(
+        Html(messages("confirmationPage.whatHappensNext.detail.item1")),
+        Html(messages("confirmationPage.whatHappensNext.detail.item2"))
+    ))
+}
 
 @govukLayout(title = Title("confirmationPage.title")) {
 
     @govukPanel(Panel(
-        title = Text(messages("confirmationPage.title")),
+        title = HtmlContent(heading),
         content = HtmlContent(
             flash.get(FlashKeys.referenceId)
                     .map(referenceId => messages("confirmationPage.panel.body", referenceId))
                     .getOrElse(messages("confirmationPage.panel.body.default")))
     ))
 
-    @paragraphBody(message = messages("confirmationPage.detail.1"))
-    @paragraphBody(message = messages("confirmationPage.detail.2"))
-    @paragraphBody(message = messages("confirmationPage.detail.3"))
+    <div id="detail">
+        @paragraphBody(message = messages("confirmationPage.detail.1"))
+        @paragraphBody(message = messages("confirmationPage.detail.2"))
+        @paragraphBody(message = messages("confirmationPage.detail.3",
+            link(text = messages("confirmationPage.detail.3.link"), call = Call("GET", appConfig.pptAccountUrl))))
+    </div>
 
-    @subHeading(text = messages("confirmationPage.whatHappensNext.title"))
+    <div id="what-happens-next">
+        @subHeading(text = messages("confirmationPage.whatHappensNext.title"))
 
-    @paragraphBody(message = messages("confirmationPage.whatHappensNext.detail"))
+        @if(request.isFeatureFlagEnabled(Features.isPreLaunch)) {
+            @preLaunchDetail
+        } else {
+            @postLaunchDetail
+        }
+    </div>
 
-    @paragraphBody(message = messages("confirmationPage.whatHappensNext.link",
-        link(text = messages("confirmationPage.whatHappensNext.link.text"), call = Call("GET", appConfig.pptAccountUrl))))
+    <div id="bta">
+        @paragraphBody(message = messages("confirmationPage.whatHappensNext.bta",
+            link(text = messages("confirmationPage.whatHappensNext.bta.link"), call = Call("GET", appConfig.businessAccountUrl))))
+    </div>
 
-    @paragraphBody(message = messages("confirmationPage.exitSurvey.link",
-        link(text = messages("confirmationPage.exitSurvey.link.text"), call = Call("GET", appConfig.exitSurveyUrl))))
-
+    <div id="exit-survey">
+        @paragraphBody(classes = "govuk-body govuk-!-margin-top-8", message = messages("confirmationPage.exitSurvey.link",
+            link(text = messages("confirmationPage.exitSurvey.link.text"), call = Call("GET", appConfig.exitSurveyUrl))))
+    </div>
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/utils/ViewUtils.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/utils/ViewUtils.scala
@@ -98,6 +98,9 @@ class ViewUtils @Inject() (countryService: CountryService) {
     displayLocalDate(date.map(_.date))
 
   def displayLocalDate(date: Option[LocalDate]): Option[String] =
-    date.map(_.format(DateTimeFormatter.ofPattern("dd MMM yyyy")))
+    date.map(displayLocalDate)
+
+  def displayLocalDate(date: LocalDate): String =
+    date.format(DateTimeFormatter.ofPattern("dd MMM yyyy"))
 
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -326,15 +326,26 @@ reviewRegistration.member.contact.phone = Telephone number
 reviewRegistration.member.contact.address = Contact address
 
 confirmationPage.title = Registration submitted
+confirmationPage.heading = Registration submitted on {0}
+confirmationPage.group.heading = Group registration submitted on {0}
 confirmationPage.panel.body = Your Plastic Packaging Tax (PPT) registration number is {0}
 confirmationPage.panel.body.default = Your registration has already been submitted
 confirmationPage.detail.1 = You’ll need this registration number if you contact HMRC about your PPT account.
 confirmationPage.detail.2 = Make sure you keep a record of it because we will not send you a confirmation email.
-confirmationPage.detail.3 = You can also find this registration number on the main screen of your PPT account.
+confirmationPage.detail.3 = You can also find this registration number on the main screen of your {0}.
+confirmationPage.detail.3.link = PPT account
+
 confirmationPage.whatHappensNext.title = What happens next
-confirmationPage.whatHappensNext.detail = PPT starts on 1 April 2022.
-confirmationPage.whatHappensNext.link = Go to your {0} to find out how to prepare your return.
-confirmationPage.whatHappensNext.link.text = PPT account
+confirmationPage.preLaunch.whatHappensNext.detail = PPT starts on 1 April 2022.
+confirmationPage.preLaunch.whatHappensNext.link = Go to your {0} to find out how to prepare your return.
+confirmationPage.preLaunch.whatHappensNext.link.text = PPT account
+confirmationPage.whatHappensNext.detail = Go to your {0} to:
+confirmationPage.whatHappensNext.detail.link = PPT account
+confirmationPage.whatHappensNext.detail.item1 = submit a return
+confirmationPage.whatHappensNext.detail.item2 = find out how to prepare a return
+confirmationPage.whatHappensNext.bta = You can also use {0} to manage your PPT account or allow someone else to manage it for you.
+confirmationPage.whatHappensNext.bta.link = your business tax account
+
 confirmationPage.exitSurvey.link = {0}
 confirmationPage.exitSurvey.link.text = What did you think of this service?
 

--- a/test/base/unit/ControllerSpec.scala
+++ b/test/base/unit/ControllerSpec.scala
@@ -71,10 +71,10 @@ trait ControllerSpec
     headers: Headers = Headers(),
     user: SignedInUser = PptTestData.newUser("123")
   ): AuthenticatedRequest[AnyContentAsEmpty.type] =
-    new AuthenticatedRequest(FakeRequest().withHeaders(headers), user)
+    new AuthenticatedRequest(FakeRequest().withHeaders(headers), user, config)
 
   def authRequest[A](fakeRequest: FakeRequest[A], user: SignedInUser) =
-    new AuthenticatedRequest(fakeRequest, user)
+    new AuthenticatedRequest(fakeRequest, user, config)
 
   protected def viewOf(result: Future[Result]): Html = Html(contentAsString(result))
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/KeepAliveControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/KeepAliveControllerSpec.scala
@@ -62,7 +62,10 @@ class KeepAliveControllerSpec extends ControllerSpec {
         )
         authorizedUser()
         val result = controller.keepAlive()(
-          new AuthenticatedRequest(FakeRequest().withSession(("sessionId", "123")), newUser())
+          new AuthenticatedRequest(FakeRequest().withSession(("sessionId", "123")),
+                                   newUser(),
+                                   appConfig
+          )
         )
 
         status(result) mustBe OK
@@ -92,7 +95,10 @@ class KeepAliveControllerSpec extends ControllerSpec {
         )
         val result =
           controller.keepAlive()(
-            new AuthenticatedRequest(FakeRequest().withSession(("sessionId", "123456")), newUser())
+            new AuthenticatedRequest(FakeRequest().withSession(("sessionId", "123456")),
+                                     newUser(),
+                                     appConfig
+            )
           )
         status(result) mustBe OK
         verify(mockUserDataRepository, never()).put(any[String])(
@@ -109,7 +115,10 @@ class KeepAliveControllerSpec extends ControllerSpec {
         )
         val result =
           controller.keepAlive()(
-            new AuthenticatedRequest(FakeRequest().withSession(("sessionId", "123456")), newUser())
+            new AuthenticatedRequest(FakeRequest().withSession(("sessionId", "123456")),
+                                     newUser(),
+                                     appConfig
+            )
           )
         status(result) mustBe OK
         verify(mockUserDataRepository, never()).put(any[String])(
@@ -121,7 +130,10 @@ class KeepAliveControllerSpec extends ControllerSpec {
         authorizedUser()
         val result =
           controller.keepAlive()(
-            new AuthenticatedRequest(FakeRequest().withSession(("session", "123456")), newUser())
+            new AuthenticatedRequest(FakeRequest().withSession(("session", "123456")),
+                                     newUser(),
+                                     appConfig
+            )
           )
         intercept[RuntimeException](status(result))
       }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewTaskListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewTaskListControllerSpec.scala
@@ -55,12 +55,11 @@ import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import java.util.UUID
 
 class ReviewTaskListControllerSpec extends ControllerSpec with TableDrivenPropertyChecks {
-  private val mockReviewRegistrationPage      = mock[review_registration_page]
-  private val mockDuplicateSubscriptionPage   = mock[duplicate_subscription_page]
-  private val mcc                             = stubMessagesControllerComponents()
-  private val mockStartRegistrationController = mock[StartRegistrationController]
-  private val mockRegistrationFilterService   = mock[RegistrationGroupFilterService]
-  private val liabilityStartLink              = Call("GET", "/startRegistrationLink")
+  private val mockReviewRegistrationPage    = mock[review_registration_page]
+  private val mockDuplicateSubscriptionPage = mock[duplicate_subscription_page]
+  private val mcc                           = stubMessagesControllerComponents()
+  private val mockRegistrationFilterService = mock[RegistrationGroupFilterService]
+  private val liabilityStartLink            = Call("GET", "/startRegistrationLink")
 
   private val controller =
     new ReviewRegistrationController(authenticate = mockAuthAction,
@@ -71,7 +70,6 @@ class ReviewTaskListControllerSpec extends ControllerSpec with TableDrivenProper
                                      auditor = mockAuditor,
                                      reviewRegistrationPage = mockReviewRegistrationPage,
                                      metrics = metricsMock,
-                                     startRegistrationController = mockStartRegistrationController,
                                      registrationFilterService = mockRegistrationFilterService
     )
 
@@ -80,7 +78,6 @@ class ReviewTaskListControllerSpec extends ControllerSpec with TableDrivenProper
     authorizedUser()
     given(mockReviewRegistrationPage.apply(any())(any(), any())).willReturn(HtmlFormat.empty)
     given(mockDuplicateSubscriptionPage.apply()(any(), any())).willReturn(HtmlFormat.empty)
-    given(mockStartRegistrationController.startLink(any())).willReturn(liabilityStartLink)
   }
 
   override protected def afterEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureControllerSpec.scala
@@ -311,7 +311,8 @@ class AddressCaptureControllerSpec
   private def getAuthenticatedRequest() =
     new AuthenticatedRequest(
       request = FakeRequest("GET", "").withSession((AmendmentJourneyAction.SessionId, "123")),
-      user = newUser()
+      user = newUser(),
+      appConfig
     )
 
   private def getRequest() =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/request/AmendmentJourneyActionSpec.scala
@@ -74,7 +74,8 @@ class AmendmentJourneyActionSpec
       "no registration is cached against the user's session" in {
         val request = new AuthenticatedRequest(
           FakeRequest().withSession((AmendmentJourneyAction.SessionId, "123")),
-          enrolledUser
+          enrolledUser,
+          appConfig
         )
 
         status(mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)) mustBe OK
@@ -90,7 +91,8 @@ class AmendmentJourneyActionSpec
         inMemoryRegistrationAmendmentRepository.put("123", cachedRegistration)
         val request = new AuthenticatedRequest(
           FakeRequest().withSession((AmendmentJourneyAction.SessionId, "123")),
-          enrolledUser
+          enrolledUser,
+          appConfig
         )
 
         status(mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)) mustBe OK
@@ -104,7 +106,8 @@ class AmendmentJourneyActionSpec
       "user does not have an internal id" in {
         val request = new AuthenticatedRequest(
           FakeRequest(),
-          user.copy(identityData = user.identityData.copy(internalId = None))
+          user.copy(identityData = user.identityData.copy(internalId = None)),
+          appConfig
         )
 
         intercept[InsufficientEnrolments] {
@@ -113,7 +116,7 @@ class AmendmentJourneyActionSpec
       }
 
       "user does not have a ppt enrolment" in {
-        val request = new AuthenticatedRequest(FakeRequest(), user)
+        val request = new AuthenticatedRequest(FakeRequest(), user, appConfig)
 
         intercept[InsufficientEnrolments] {
           mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)
@@ -125,7 +128,7 @@ class AmendmentJourneyActionSpec
     "throw SessionRecordNotFound" when {
 
       "no active session present" in {
-        val request = new AuthenticatedRequest(FakeRequest(), enrolledUser)
+        val request = new AuthenticatedRequest(FakeRequest(), enrolledUser, appConfig)
 
         intercept[SessionRecordNotFound] {
           mockAmendmentJourneyAction.invokeBlock(request, responseGenerator)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/MongoRegistrationAmendmentRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/MongoRegistrationAmendmentRepositorySpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import play.api.test.Helpers.await
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
 
@@ -35,6 +36,7 @@ class MongoRegistrationAmendmentRepositorySpec
     extends AnyWordSpec with RegistrationBuilder with Matchers with MockitoSugar
     with BeforeAndAfterEach with DefaultAwaitTimeout {
 
+  private val appConfig: AppConfig   = mock[AppConfig]
   private val mockUserDataRepository = mock[UserDataRepository]
 
   private val mongoRegistrationAmendmentRepository = new RegistrationAmendmentRepositoryImpl(
@@ -43,7 +45,7 @@ class MongoRegistrationAmendmentRepositorySpec
 
   private val sessionId        = "123"
   private val registration     = aRegistration()
-  private implicit val request = new AuthenticatedRequest(FakeRequest(), newUser())
+  private implicit val request = new AuthenticatedRequest(FakeRequest(), newUser(), appConfig)
 
   override protected def beforeEach(): Unit = {
     reset(mockUserDataRepository)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/UserDataRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/UserDataRepositorySpec.scala
@@ -30,6 +30,7 @@ import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import uk.gov.hmrc.auth.core.SessionRecordNotFound
 import uk.gov.hmrc.mongo.CurrentTimestampSupport
 import uk.gov.hmrc.mongo.test.MongoSupport
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
 
 import java.util.concurrent.TimeUnit
@@ -40,7 +41,8 @@ class UserDataRepositorySpec
     extends AnyWordSpec with Matchers with ScalaFutures with MockitoSugar with BeforeAndAfterEach
     with DefaultAwaitTimeout with MongoSupport {
 
-  val mockConfig = mock[Configuration]
+  private val appConfig: AppConfig = mock[AppConfig]
+  private val mockConfig           = mock[Configuration]
   when(mockConfig.get[FiniteDuration]("mongodb.userDataCache.expiry")).thenReturn(
     FiniteDuration(1, TimeUnit.MINUTES)
   )
@@ -51,7 +53,8 @@ class UserDataRepositorySpec
 
   def authRequest(sessionId: String): AuthenticatedRequest[Any] =
     new AuthenticatedRequest(FakeRequest().withSession("sessionId" -> sessionId),
-                             PptTestData.newUser("123")
+                             PptTestData.newUser("123"),
+                             appConfig
     )
 
   override def beforeEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/UserEnrolmentDetailsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/repositories/UserEnrolmentDetailsRepositorySpec.scala
@@ -28,6 +28,7 @@ import play.api.test.Helpers.await
 import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import uk.gov.hmrc.mongo.CurrentTimestampSupport
 import uk.gov.hmrc.mongo.test.MongoSupport
+import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.DateData
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.enrolment.{
   IsUkAddress,
@@ -46,7 +47,8 @@ class UserEnrolmentDetailsRepositorySpec
     extends AnyWordSpec with Matchers with ScalaFutures with MockitoSugar with BeforeAndAfterEach
     with DefaultAwaitTimeout with MongoSupport {
 
-  private val mockConfig = mock[Configuration]
+  private val appConfig: AppConfig = mock[AppConfig]
+  private val mockConfig           = mock[Configuration]
   when(mockConfig.get[FiniteDuration]("mongodb.userDataCache.expiry")).thenReturn(
     FiniteDuration(1, TimeUnit.MINUTES)
   )
@@ -62,7 +64,8 @@ class UserEnrolmentDetailsRepositorySpec
 
   def authRequest(sessionId: String): AuthenticatedRequest[Any] =
     new AuthenticatedRequest(FakeRequest().withSession("sessionId" -> sessionId),
-                             PptTestData.newUser("123")
+                             PptTestData.newUser("123"),
+                             appConfig
     )
 
   private val userEnrolmentDetails =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/services/AddressCaptureServiceSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/services/AddressCaptureServiceSpec.scala
@@ -72,7 +72,8 @@ class AddressCaptureServiceSpec
   private def getRequest() =
     new AuthenticatedRequest(
       request = FakeRequest("GET", "").withSession((AmendmentJourneyAction.SessionId, "123")),
-      user = newUser()
+      user = newUser(),
+      appConfig
     )
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ConfirmationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ConfirmationViewSpec.scala
@@ -19,93 +19,182 @@ package uk.gov.hmrc.plasticpackagingtax.registration.views
 import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.mvc.Flash
+import play.api.test.Injecting
 import play.twirl.api.Html
+import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.response.FlashKeys
 import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles._
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.confirmation_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 
-@ViewTest
-class ConfirmationViewSpec extends UnitViewSpec with Matchers {
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
+@ViewTest
+class ConfirmationViewSpec extends UnitViewSpec with Matchers with Injecting {
+
+  private val realAppConfig           = inject[AppConfig]
   private val page: confirmation_page = inject[confirmation_page]
 
+  private val dateFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy")
+
   private def createView(flash: Flash = new Flash(Map.empty)): Html =
-    page()(journeyRequest, messages, flash)
+    page()(authenticatedRequest(Map(Features.isPreLaunch -> false)), messages, flash)
+
+  private def createPreLaunchView(flash: Flash = new Flash(Map.empty)): Html =
+    page()(authenticatedRequest(Map(Features.isPreLaunch -> true)), messages, flash)
 
   "Confirmation Page view" should {
 
     val view: Html = createView()
 
     "contain timeout dialog function" in {
-
       containTimeoutDialogFunction(view) mustBe true
-
     }
 
     "display sign out link" in {
-
       displaySignOutLink(view)
-
     }
 
     "display title" in {
-
       view.select("title").text() must include(messages("confirmationPage.title"))
     }
 
     "display panel" when {
-
-      "no 'referenceId' has been provided" in {
-        view.getElementsByClass(gdsPanelTitle).get(0) must containMessage("confirmationPage.title")
-        view.getElementsByClass(gdsPanelBody).get(0) must containMessage(
-          "confirmationPage.panel.body.default"
-        )
+      "single entity registration" when {
+        "no 'referenceId' has been provided" in {
+          verifyPanelContent(view,
+                             messages("confirmationPage.heading",
+                                      LocalDate.now.format(dateFormatter)
+                             ),
+                             messages("confirmationPage.panel.body.default")
+          )
+        }
+        "a 'referenceId' has been provided" in {
+          val viewWithReferenceId = createView(flash =
+            Flash(Map(FlashKeys.referenceId -> "PPT123", FlashKeys.groupReg -> false.toString))
+          )
+          verifyPanelContent(viewWithReferenceId,
+                             messages("confirmationPage.heading",
+                                      LocalDate.now.format(dateFormatter)
+                             ),
+                             messages("confirmationPage.panel.body", "PPT123")
+          )
+        }
       }
-
-      "a 'referenceId' has been provided" in {
-        val viewWithReferenceId = createView(flash = Flash(Map(FlashKeys.referenceId -> "PPT123")))
-        viewWithReferenceId.getElementsByClass(gdsPanelTitle).get(0) must containMessage(
-          "confirmationPage.title"
-        )
-        viewWithReferenceId.getElementsByClass(gdsPanelBody).get(0) must containMessage(
-          "confirmationPage.panel.body",
-          "PPT123"
-        )
+      "group registration" when {
+        "no 'referenceId' has been provided" in {
+          val groupView = createView(flash =
+            Flash(Map(FlashKeys.groupReg -> true.toString))
+          )
+          verifyPanelContent(groupView,
+                             messages("confirmationPage.group.heading",
+                                      LocalDate.now.format(dateFormatter)
+                             ),
+                             messages("confirmationPage.panel.body.default")
+          )
+        }
+        "a 'referenceId' has been provided" in {
+          val groupViewWithReferenceId = createView(flash =
+            Flash(Map(FlashKeys.referenceId -> "PPT123", FlashKeys.groupReg -> true.toString))
+          )
+          verifyPanelContent(groupViewWithReferenceId,
+                             messages("confirmationPage.group.heading",
+                                      LocalDate.now.format(dateFormatter)
+                             ),
+                             messages("confirmationPage.panel.body", "PPT123")
+          )
+        }
       }
     }
 
-    "display body" in {
-
-      val mainDetail = view.getElementsByClass(gdsPageBodyText)
+    "display main body" in {
+      val mainDetail = createView().select("div#detail p")
       mainDetail.get(0) must containMessage("confirmationPage.detail.1")
       mainDetail.get(1) must containMessage("confirmationPage.detail.2")
-      mainDetail.get(2) must containMessage("confirmationPage.detail.3")
+      mainDetail.get(2).text must include(
+        messages("confirmationPage.detail.3", messages("confirmationPage.detail.3.link"))
+      )
+
+      mainDetail.select("a").get(0) must haveHref(realAppConfig.pptAccountUrl)
     }
 
-    "display 'What happens next'" in {
+    "display 'What happens next'" when {
 
-      view.getElementsByClass(gdsPageSubHeading).get(0) must containMessage(
-        "confirmationPage.whatHappensNext.title"
-      )
+      "pre-launch" in {
+        val preLaunchView = createPreLaunchView()
 
-      val whatHappensNextDetail = view.getElementsByClass(gdsPageBodyText)
-      whatHappensNextDetail.get(3) must containMessage("confirmationPage.whatHappensNext.detail")
-      whatHappensNextDetail.get(4) must containMessage(
-        "confirmationPage.whatHappensNext.link",
-        messages("confirmationPage.whatHappensNext.link.text")
-      )
-      whatHappensNextDetail.get(5) must containMessage(
-        "confirmationPage.exitSurvey.link",
-        messages("confirmationPage.exitSurvey.link.text")
-      )
+        preLaunchView.getElementsByClass(gdsPageSubHeading).get(0) must containMessage(
+          "confirmationPage.whatHappensNext.title"
+        )
+
+        val whatHappensNextDetail = preLaunchView.select("div#what-happens-next p")
+        whatHappensNextDetail.get(0) must containMessage(
+          "confirmationPage.preLaunch.whatHappensNext.detail"
+        )
+        whatHappensNextDetail.get(1).text must include(
+          messages("confirmationPage.preLaunch.whatHappensNext.link",
+                   messages("confirmationPage.preLaunch.whatHappensNext.link.text")
+          )
+        )
+
+        whatHappensNextDetail.select("a").get(0) must haveHref(realAppConfig.pptAccountUrl)
+      }
+
+      "post-launch" in {
+        view.getElementsByClass(gdsPageSubHeading).get(0) must containMessage(
+          "confirmationPage.whatHappensNext.title"
+        )
+
+        val whatHappensNextDetail = view.select("div#what-happens-next p")
+        whatHappensNextDetail.get(0).text must include(
+          messages("confirmationPage.whatHappensNext.detail",
+                   messages("confirmationPage.whatHappensNext.detail.link")
+          )
+        )
+        whatHappensNextDetail.select("a").get(0) must haveHref(realAppConfig.pptAccountUrl)
+
+        val whatHappensNextDetailList = view.select("div#what-happens-next li")
+        whatHappensNextDetailList.get(0).text must include(
+          messages("confirmationPage.whatHappensNext.detail.item1")
+        )
+        whatHappensNextDetailList.get(1).text must include(
+          messages("confirmationPage.whatHappensNext.detail.item2")
+        )
+      }
     }
 
+    "display BTA info and link" in {
+      val btaDetail = view.select("div#bta p")
+      btaDetail.get(0).text must include(
+        messages("confirmationPage.whatHappensNext.bta",
+                 messages("confirmationPage.whatHappensNext.bta.link")
+        )
+      )
+
+      btaDetail.select("a").get(0) must haveHref(realAppConfig.businessAccountUrl)
+    }
+
+    "display exit survey link" in {
+      val exitSurveyDetail = view.select("div#exit-survey p")
+      exitSurveyDetail.get(0).text must include(
+        messages("confirmationPage.exitSurvey.link",
+                 messages("confirmationPage.exitSurvey.link.text")
+        )
+      )
+
+      exitSurveyDetail.select("a").get(0) must haveHref(realAppConfig.exitSurveyUrl)
+    }
+  }
+
+  private def verifyPanelContent(view: Html, panelTitle: String, panelContent: String) = {
+    view.getElementsByClass(gdsPanelTitle).get(0).text() must include(panelTitle)
+    view.getElementsByClass(gdsPanelBody).get(0).text() must include(panelContent)
   }
 
   override def exerciseGeneratedRenderingMethods() = {
-    page.f()(request, messages, new Flash(Map.empty))
-    page.render(request, messages, new Flash(Map.empty))
+    page.f()(authenticatedRequest, messages, new Flash(Map.empty))
+    page.render(authenticatedRequest, messages, new Flash(Map.empty))
   }
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/ReviewRegistrationViewSpec.scala
@@ -222,7 +222,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
                       isLiable = Some(true)
                     )
                   )
-                )(generateRequest(userFeatureFlags = Map(Features.isPreLaunch -> true)),
+                )(journeyRequest(userFeatureFlags = Map(Features.isPreLaunch -> true)),
                   messages = messages
                 )
 
@@ -247,7 +247,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
                                      startDate = Some(OldDate(Some(1), Some(4), Some(2022)))
                     )
                   )
-                )(generateRequest(userFeatureFlags = Map(Features.isPreLaunch -> false)),
+                )(journeyRequest(userFeatureFlags = Map(Features.isPreLaunch -> false)),
                   messages = messages
                 )
 
@@ -285,7 +285,7 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
                                      startDate = Some(OldDate(Some(6), Some(3), Some(2022)))
                     )
                   )
-                )(generateRequest(userFeatureFlags = Map(Features.isPreLaunch -> false)),
+                )(journeyRequest(userFeatureFlags = Map(Features.isPreLaunch -> false)),
                   messages = messages
                 )
 
@@ -595,7 +595,10 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
             )
             val journeyRequestWithEnrolledUser: JourneyRequest[AnyContent] =
               JourneyRequest(authenticatedRequest =
-                               new AuthenticatedRequest(FakeRequest(), userWithPPTEnrolment),
+                               new AuthenticatedRequest(FakeRequest(),
+                                                        userWithPPTEnrolment,
+                                                        appConfig
+                               ),
                              registration = partnershipRegistration,
                              appConfig = appConfig
               )
@@ -688,7 +691,10 @@ class ReviewRegistrationViewSpec extends UnitViewSpec with Matchers with TableDr
             )
             val journeyRequestWithEnrolledUser: JourneyRequest[AnyContent] =
               JourneyRequest(authenticatedRequest =
-                               new AuthenticatedRequest(FakeRequest(), userWithPPTEnrolment),
+                               new AuthenticatedRequest(FakeRequest(),
+                                                        userWithPPTEnrolment,
+                                                        appConfig
+                               ),
                              registration = partnershipRegistration,
                              appConfig = appConfig
               )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/address/AddressViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/address/AddressViewSpec.scala
@@ -42,7 +42,7 @@ class AddressViewSpec extends UnitViewSpec with Matchers {
     userFeatureFlags: Map[String, Boolean] = Map.empty
   ): Document =
     page(form, countryService.getAll(), backLink, updateLink, headingKey, contactName)(
-      generateRequest(userFeatureFlags),
+      journeyRequest(userFeatureFlags),
       messages
     )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -58,7 +58,7 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
                                     reg = registration,
                                     backLink =
                                       liabilityRoutes.RegistrationTypeController.displayPage()
-    )(generateRequest(userFeatureFlags = Map(Features.isPreLaunch -> false)))
+    )(journeyRequest(userFeatureFlags = Map(Features.isPreLaunch -> false)))
 
     "have the correct title" in {
       List(preLaunchView, postLaunchView).foreach { view =>

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/CheckAnswersPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/CheckAnswersPageViewSpec.scala
@@ -169,7 +169,8 @@ class CheckAnswersPageViewSpec extends UnitViewSpec with Matchers with TableDriv
             )
           )
           val journeyReq = JourneyRequest(new AuthenticatedRequest(FakeRequest().withCSRFToken,
-                                                                   PptTestData.newUser()
+                                                                   PptTestData.newUser(),
+                                                                   appConfig
                                           ),
                                           soleTraderRegistration,
                                           appConfig
@@ -224,7 +225,8 @@ class CheckAnswersPageViewSpec extends UnitViewSpec with Matchers with TableDriv
             )
           )
           val journeyReq = JourneyRequest(new AuthenticatedRequest(FakeRequest().withCSRFToken,
-                                                                   PptTestData.newUser()
+                                                                   PptTestData.newUser(),
+                                                                   appConfig
                                           ),
                                           updatedRegistation,
                                           appConfig

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/PartnershipPartnerTypeViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/PartnershipPartnerTypeViewSpec.scala
@@ -56,7 +56,7 @@ class PartnershipPartnerTypeViewSpec extends UnitViewSpec with Matchers {
   )
 
   val journeyReqForOthers = JourneyRequest(
-    new AuthenticatedRequest(FakeRequest().withCSRFToken, PptTestData.newUser()),
+    new AuthenticatedRequest(FakeRequest().withCSRFToken, PptTestData.newUser(), appConfig),
     registrationWithOtherPartners,
     appConfig
   )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/PhaseBannerSpec.scala
@@ -66,7 +66,8 @@ class PhaseBannerSpec extends UnitViewSpec with Matchers {
         import utils.FakeRequestCSRFSupport._
 
         val request = new AuthenticatedRequest(FakeRequest("GET", requestPath).withCSRFToken,
-                                               PptTestData.newUser()
+                                               PptTestData.newUser(),
+                                               appConfig
         )
         createBanner(request)
           .getElementsByClass("govuk-phase-banner__text").first()


### PR DESCRIPTION
Access to feature flag state migrated from JourneyRequest to AuthenticatedRequest. This was necessary since we do not want to use JourneyAction in the confirmation controller as we do not want a shell registration creating. This had a knock-on effect in a lot of tests which were creating AuthenticatedRequests and JourneyRequests.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added - N/A
 - [ ] Links to dependencies have been included (BE/FE work) - N/A
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave

WAVE does report a single warning but this is due to close links having the same target. I'm guessing the content folks are aware and happy with it.

<img width="1600" alt="image" src="https://user-images.githubusercontent.com/87077443/157711374-9f64f0c4-73ca-463d-ba3d-0e588f9560e4.png">

<img width="1588" alt="image" src="https://user-images.githubusercontent.com/87077443/157711866-99ce7405-1dd3-4d64-a5a1-cd87807ff7fa.png">
