### PR TITLE
Feature/pptp 1736

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/config/Features.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/config/Features.scala
@@ -19,4 +19,5 @@ package uk.gov.hmrc.plasticpackagingtax.registration.config
 object Features {
   val isPreLaunch: String            = "isPreLaunch"
   val isUkCompanyPrivateBeta: String = "ukCompanyPrivateBeta"
+  val isPartnershipEnabled: String   = "partnershipEnabled"
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
@@ -74,13 +74,18 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
         getRegisteredSocietyRedirectUrl(memberId)
           .map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
       case (Some(OrgType.PARTNERSHIP), false) =>
-        if (request.registration.isGroup)
-          getRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl,
-                         businessVerificationCheck,
-                         memberId
-          ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
-        else
-          Future(Redirect(partnerRoutes.PartnershipTypeController.displayPage()))
+        // TODO - redirect to not yet available page
+        // Q. Is this on a feature toggle? A configurable?
+
+      Future(Redirect(partnerRoutes.PartnerRegistrationAvailableSoonController.onPageLoad()))
+
+//        if (request.registration.isGroup)
+//          getRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl,
+//                         businessVerificationCheck,
+//                         memberId
+//          ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
+//        else
+//          Future(Redirect(partnerRoutes.PartnershipTypeController.displayPage()))
       case _ =>
         Future(Redirect(organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad()))
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationTypeNotSupportedController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationTypeNotSupportedController.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.organisation_type_not_supported
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -25,11 +26,12 @@ import javax.inject.Inject
 
 class OrganisationTypeNotSupportedController @Inject() (
   mcc: MessagesControllerComponents,
-  page: organisation_type_not_supported
+  page: organisation_type_not_supported,
+  authenticate: AuthAction
 ) extends FrontendController(mcc) with I18nSupport {
 
   def onPageLoad: Action[AnyContent] =
-    Action { implicit request =>
+    authenticate { implicit request =>
       Ok(page())
     }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
+
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_registration_available_soon_page
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+
+class PartnerRegistrationAvailableSoonController @Inject()(
+  mcc: MessagesControllerComponents,
+  page: partner_registration_available_soon_page
+) extends FrontendController(mcc) with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] =
+    Action { implicit request =>
+      Ok(page())
+    }
+}

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
 
-class PartnerRegistrationAvailableSoonController @Inject()(
+class PartnerRegistrationAvailableSoonController @Inject() (
   mcc: MessagesControllerComponents,
   page: partner_registration_available_soon_page
 ) extends FrontendController(mcc) with I18nSupport {
@@ -32,4 +32,5 @@ class PartnerRegistrationAvailableSoonController @Inject()(
     Action { implicit request =>
       Ok(page())
     }
+
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
@@ -18,18 +18,21 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_registration_available_soon_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 
+@Singleton
 class PartnerRegistrationAvailableSoonController @Inject() (
   mcc: MessagesControllerComponents,
-  page: partner_registration_available_soon_page
+  page: partner_registration_available_soon_page,
+  authenticate: AuthAction
 ) extends FrontendController(mcc) with I18nSupport {
 
   def onPageLoad: Action[AnyContent] =
-    Action { implicit request =>
+    authenticate { implicit request =>
       Ok(page())
     }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_registration_available_soon_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_registration_available_soon_page.scala.html
@@ -43,7 +43,7 @@
     }
 }
 
-@linkFeedback = {<a href="@feedbackUrl" class="govuk-link">@messages("organisationDetails.feedback.link")</a>}
+@linkFeedback = {<a href="@feedbackUrl" class="govuk-link" id="govuk-feedback-link">@messages("partnership.registrationAvailableSoon.feedback.link")</a>}
 
 @linkTellUs(key: String) = {
     @link(
@@ -65,6 +65,6 @@
 
     @paragraph(content = Html(messages("partnership.registrationAvailableSoon", linkTellUs("registrationAvailableSoon"))))
 
-    @paragraphBody(messages("organisationDetails.feedback", linkFeedback))
+    @paragraphBody(messages("partnership.registrationAvailableSoon.feedback", linkFeedback))
 }
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_registration_available_soon_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/partner_registration_available_soon_page.scala.html
@@ -1,0 +1,70 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.models.Title
+@import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
+@import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
+@import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AuthenticatedRequest
+
+@this(
+    govukLayout: main_template,
+    pageHeading: pageHeading,
+    paragraphBody: paragraphBody,
+    paragraph: paragraph,
+    govUkLink: govUkLink,
+    govukButton: GovukButton,
+    sectionHeader: sectionHeader,
+    link: link,
+    appConfig: AppConfig
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@isAuthenticated = @{request.isInstanceOf[AuthenticatedRequest[_]]}
+
+@feedbackUrl = @{
+    if (isAuthenticated) {
+        s"${appConfig.authenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
+    } else {
+        s"${appConfig.unauthenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
+    }
+}
+
+@linkFeedback = {<a href="@feedbackUrl" class="govuk-link">@messages("organisationDetails.feedback.link")</a>}
+
+@linkTellUs(key: String) = {
+    @link(
+        id = Some(key.replace(".", "-") + "-link"),
+        newTab = true,
+        text = messages(s"partnership.$key.link"),
+        call = Call(
+        method = "GET",
+        url = messages(s"partnership.$key.href")
+        )
+    )
+}
+
+@govukLayout(title = Title("partnership.registrationAvailableSoon.title")) {
+
+    @sectionHeader(messages("partnership.registrationAvailableSoon.header"))
+
+    @pageHeading(messages("partnership.registrationAvailableSoon.title"))
+
+    @paragraph(content = Html(messages("partnership.registrationAvailableSoon", linkTellUs("registrationAvailableSoon"))))
+
+    @paragraphBody(messages("organisationDetails.feedback", linkFeedback))
+}
+

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -109,6 +109,8 @@ GET        /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingt
 POST       /partnership-partner-type    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitNewPartner()
 POST       /partnership-partner-type/:partnerId    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeController.submitExistingPartner(partnerId: String)
 
+GET        /partnership-registration-available-soon    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerRegistrationAvailableSoonController.onPageLoad()
+
 GET        /partner-name                        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayNewPartner()
 POST       /partner-name                        uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.submitNewPartner()
 GET        /partner-name/:partnerId             uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameController.displayExistingPartner(partnerId: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -204,6 +204,7 @@ go-live-date = "2022-03-01"
 features {
   isPreLaunch = false
   ukCompanyPrivateBeta = true
+  partnershipEnabled = true
 }
 
 # User Specific Feature Flags

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -376,6 +376,12 @@ partnership.name.title = What is the name of the partnership?
 partnership.name.empty.error = Please enter your partnership name
 partnership.name.format.error = Please enter your partnership name in correct format
 
+partnership.registrationAvailableSoon.header = Partnership
+partnership.registrationAvailableSoon.title = Partnership registration will be available soon
+partnership.registrationAvailableSoon = {0} and we’ll contact you when the service becomes available
+partnership.registrationAvailableSoon.link = Tell us you would like to register as a partnership
+partnership.registrationAvailableSoon.href = https://www.gov.uk/guidance/check-if-you-need-to-register-for-plastic-packaging-tax
+
 partner.type.SoleTrader = Sole trader
 partner.type.UkCompany = UK limited company
 partner.type.RegisteredSociety = Registered society
@@ -686,6 +692,8 @@ addPartner.empty.error = Select yes if you need to add another partner
 
 partnership.removePartner.title = Are you sure you want to remove {0} from the partnership?
 partnership.removePartner.error.empty = Please select Yes or No
+
+
 
 amend.organisation.title = Your organisation’s details
 amend.individual.title = Your details

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -381,6 +381,8 @@ partnership.registrationAvailableSoon.title = Partnership registration will be a
 partnership.registrationAvailableSoon = {0} and we’ll contact you when the service becomes available
 partnership.registrationAvailableSoon.link = Tell us you would like to register as a partnership
 partnership.registrationAvailableSoon.href = https://www.gov.uk/guidance/check-if-you-need-to-register-for-plastic-packaging-tax
+partnership.registrationAvailableSoon.feedback = {0}. Your thoughts and ideas will help us to make improvements.
+partnership.registrationAvailableSoon.feedback.link = Send us your feedback
 
 partner.type.SoleTrader = Sole trader
 partner.type.UkCompany = UK limited company

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -695,8 +695,6 @@ addPartner.empty.error = Select yes if you need to add another partner
 partnership.removePartner.title = Are you sure you want to remove {0} from the partnership?
 partnership.removePartner.error.empty = Please select Yes or No
 
-
-
 amend.organisation.title = Your organisation’s details
 amend.individual.title = Your details
 amend.group.title = Representative member’s details

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -378,7 +378,7 @@ partnership.name.format.error = Please enter your partnership name in correct fo
 
 partnership.registrationAvailableSoon.header = Partnership
 partnership.registrationAvailableSoon.title = Partnership registration will be available soon
-partnership.registrationAvailableSoon = {0} and we’ll contact you when the service becomes available
+partnership.registrationAvailableSoon = {0} and we’ll contact you when the service becomes available.
 partnership.registrationAvailableSoon.link = Tell us you would like to register as a partnership
 partnership.registrationAvailableSoon.href = https://www.gov.uk/guidance/check-if-you-need-to-register-for-plastic-packaging-tax
 partnership.registrationAvailableSoon.feedback = {0}. Your thoughts and ideas will help us to make improvements.

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeControllerSpec.scala
@@ -145,7 +145,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         "group user submits organisation type: " + PARTNERSHIP in {
           val registration: Registration =
             aRegistration(withRegistrationType(Some(RegType.GROUP)))
-          authorizedUser()
+          authorizedUser(features = Map(Features.isPartnershipEnabled -> true))
           mockRegistrationFind(registration)
           mockRegistrationUpdate()
 
@@ -158,7 +158,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         "user submits organisation type: " + PARTNERSHIP in {
           val registration: Registration =
             aRegistration(withRegistrationType(Some(RegType.SINGLE_ENTITY)))
-          authorizedUser()
+          authorizedUser(features = Map(Features.isPartnershipEnabled -> true))
           mockRegistrationFind(registration)
           mockRegistrationUpdate()
 
@@ -166,6 +166,21 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
           val result      = controller.submitNewMember()(postJsonRequestEncoded(correctForm: _*))
           redirectLocation(result) mustBe Some(
             partnerRoutes.PartnershipTypeController.displayPage().url
+          )
+        }
+
+        "group user submits organisation type: " + PARTNERSHIP + " journey disabled" in {
+          val registration: Registration =
+            aRegistration(withRegistrationType(Some(RegType.GROUP)))
+          authorizedUser(features = Map(Features.isPartnershipEnabled -> false))
+          mockRegistrationFind(registration)
+          mockRegistrationUpdate()
+
+          val correctForm = Seq("answer" -> PARTNERSHIP.toString, formAction)
+          val result      = controller.submitNewMember()(postJsonRequestEncoded(correctForm: _*))
+          mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
+          redirectLocation(result) mustBe Some(
+            partnerRoutes.PartnerRegistrationAvailableSoonController.onPageLoad().url
           )
         }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
@@ -133,10 +133,18 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
                                    partnerRoutes.PartnershipTypeController.displayPage().url
           )
         }
+        "user submits organisation type: " + PARTNERSHIP + " journey disabled" in {
+          mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
+          assertRedirectForOrgType(
+            PARTNERSHIP,
+            partnerRoutes.PartnerRegistrationAvailableSoonController.onPageLoad().url,
+            false
+          )
+        }
 
         "user submits organisation type Limited Liability Partnership in group: " + PARTNERSHIP in {
           mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
-          authorizedUser()
+          authorizedUser(features = Map(Features.isPartnershipEnabled -> true))
           mockRegistrationFind(aRegistration(withRegistrationType(Some(RegType.GROUP))))
           mockRegistrationUpdate()
 
@@ -157,7 +165,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
 
         "user submits organisation type Limited Liability Partnership in group with partnership details present: " + PARTNERSHIP in {
           mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
-          authorizedUser()
+          authorizedUser(features = Map(Features.isPartnershipEnabled -> true))
           mockRegistrationFind(
             aRegistration(withRegistrationType(Some(RegType.GROUP)),
                           withPartnershipDetails(
@@ -210,8 +218,12 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         }
       }
 
-      def assertRedirectForOrgType(orgType: OrgType, redirectUrl: String): Unit = {
-        authorizedUser()
+      def assertRedirectForOrgType(
+        orgType: OrgType,
+        redirectUrl: String,
+        partnershipEnabled: Boolean = true
+      ): Unit = {
+        authorizedUser(features = Map(Features.isPartnershipEnabled -> partnershipEnabled))
         mockRegistrationFind(aRegistration())
         mockRegistrationUpdate()
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationTypeNotSupportedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationTypeNotSupportedControllerSpec.scala
@@ -30,11 +30,15 @@ class OrganisationTypeNotSupportedControllerSpec extends ControllerSpec {
   private val page = mock[organisation_type_not_supported]
 
   val controller =
-    new OrganisationTypeNotSupportedController(stubMessagesControllerComponents(), page)
+    new OrganisationTypeNotSupportedController(stubMessagesControllerComponents(),
+                                               page,
+                                               authenticate = mockAuthAction
+    )
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+    authorizedUser()
   }
 
   override protected def afterEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonControllerSpec.scala
@@ -30,11 +30,15 @@ class PartnerRegistrationAvailableSoonControllerSpec extends ControllerSpec {
   private val page = mock[partner_registration_available_soon_page]
 
   val controller =
-    new PartnerRegistrationAvailableSoonController(stubMessagesControllerComponents(), page)
+    new PartnerRegistrationAvailableSoonController(stubMessagesControllerComponents(),
+                                                   page,
+                                                   authenticate = mockAuthAction
+    )
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+    authorizedUser()
   }
 
   override protected def afterEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonControllerSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
+
+import base.unit.ControllerSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_registration_available_soon_page
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+
+class PartnerRegistrationAvailableSoonControllerSpec extends ControllerSpec {
+
+  private val page = mock[partner_registration_available_soon_page]
+
+  val controller =
+    new PartnerRegistrationAvailableSoonController(stubMessagesControllerComponents(), page)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(page)
+    super.afterEach()
+  }
+
+  "PartnerRegistrationAvailableSoon controller" should {
+
+    "return 200 (OK)" when {
+
+      "on page load method is invoked" in {
+
+        val result = controller.onPageLoad()(getRequest())
+
+        status(result) must be(OK)
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerRegistrationAvailableSoonPageViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/partner/PartnerRegistrationAvailableSoonPageViewSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.views.partner
+
+import base.unit.UnitViewSpec
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers
+import play.api.test.FakeRequest
+import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_registration_available_soon_page
+import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
+
+@ViewTest
+class PartnerRegistrationAvailableSoonPageViewSpec extends UnitViewSpec with Matchers {
+
+  private val page                   = inject[partner_registration_available_soon_page]
+  private def createView(): Document = page()(journeyRequest, messages)
+
+  "Partner Registration Available Soon Page View" should {
+
+    val view = createView()
+
+    "contain timeout dialog function" in {
+
+      containTimeoutDialogFunction(view) mustBe true
+    }
+
+    "display sign out link" in {
+
+      displaySignOutLink(view)
+    }
+
+    "display title" in {
+
+      view.getElementsByClass(Styles.gdsPageHeading).first() must containMessage(
+        "partnership.registrationAvailableSoon.title"
+      )
+    }
+
+    "display page header" in {
+
+      view.getElementById("section-header") must containMessage(
+        "partnership.registrationAvailableSoon.header"
+      )
+    }
+
+    "display info and link" in {
+
+      view.getElementById("registrationAvailableSoon-link") must haveHref(
+        "https://www.gov.uk/guidance/check-if-you-need-to-register-for-plastic-packaging-tax"
+      )
+      view.getElementById("registrationAvailableSoon-link") must containMessage(
+        "partnership.registrationAvailableSoon.link"
+      )
+    }
+
+    "display feedback link for authenticated users" in {
+
+      view.getElementById("govuk-feedback-link") must haveHref(
+        "http://localhost:9250/contact/beta-feedback?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
+      )
+      view.getElementById("govuk-feedback-link") must containMessage(
+        "partnership.registrationAvailableSoon.feedback.link"
+      )
+    }
+
+    "display feedback link for unauthenticated users" in {
+
+      val unauthenticatedView = page()(FakeRequest(), messages)
+      unauthenticatedView.getElementById("govuk-feedback-link") must haveHref(
+        "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
+      )
+      unauthenticatedView.getElementById("govuk-feedback-link") must containMessage(
+        "partnership.registrationAvailableSoon.feedback.link"
+      )
+    }
+  }
+
+  override def exerciseGeneratedRenderingMethods() = {
+    page.f()(request, messages)
+    page.render(request, messages)
+  }
+
+}


### PR DESCRIPTION
### Description of Work carried through

User Story
As a user with a PPT reference number
I want to be told up front and in the registration journey that partnerships are not available on 1 April
And be able to register my interest 
So that I can be advised when the Partnerships registration facility goes live
 
Scope
Create 'Partnership registration will be available soon' page
Link on page 'Partnership registration will be available soon' page should point to URL 'pptpartnerships@hmrc.gov.uk'

Jira: https://jira.tools.tax.service.gov.uk/browse/PPTP-1736

![Screenshot 2022-03-11 at 12 19 59](https://user-images.githubusercontent.com/40767309/157876764-65e08557-95ea-4236-bd37-f46bcdd2771b.png)

![Screenshot 2022-03-11 at 13 26 56](https://user-images.githubusercontent.com/40767309/157876888-437f3780-28f6-4ab1-ae9f-4b239ee0d7e5.png)

Added feature toggle: **partnershipEnabled**

**_set partnershipEnabled = false to see new new page._**

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [x] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
