### PR TITLE
PPTP-1829: renamed & re-worked /organisation-not-supported to /register-as-other-organisation

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeHelper.scala
@@ -76,7 +76,7 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
       case (Some(OrgType.PARTNERSHIP), false) =>
         getPartnershipRedirectUrl(memberId, businessVerificationCheck)
       case _ =>
-        Future(Redirect(organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad()))
+        Future(Redirect(organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad()))
     }
 
   def grsCallbackUrl(organisationId: Option[String] = None): String

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsController.scala
@@ -109,7 +109,7 @@ class GrsController @Inject() (
                   else
                     Redirect(commonRoutes.NotableErrorController.duplicateRegistration())
                 case UNSUPPORTED_ORGANISATION =>
-                  Redirect(orgRoutes.OrganisationTypeNotSupportedController.onPageLoad())
+                  Redirect(orgRoutes.RegisterAsOtherOrganisationController.onPageLoad())
               }
             }
           case Left(error) => throw error

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/RegisterAsOtherOrganisationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/RegisterAsOtherOrganisationController.scala
@@ -19,14 +19,14 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.organisation_type_not_supported
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.register_as_other_organisation
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
 
-class OrganisationTypeNotSupportedController @Inject() (
+class RegisterAsOtherOrganisationController @Inject() (
   mcc: MessagesControllerComponents,
-  page: organisation_type_not_supported,
+  page: register_as_other_organisation,
   authenticate: AuthAction
 ) extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
@@ -85,7 +85,7 @@ abstract class PartnerGrsControllerBase(
                 case DUPLICATE_SUBSCRIPTION =>
                   Redirect(commonRoutes.NotableErrorController.duplicateRegistration())
                 case UNSUPPORTED_ORGANISATION =>
-                  Redirect(orgRoutes.OrganisationTypeNotSupportedController.onPageLoad())
+                  Redirect(orgRoutes.RegisterAsOtherOrganisationController.onPageLoad())
               }
             }
           case Left(error) => throw error

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameControllerBase.scala
@@ -144,10 +144,9 @@ abstract class PartnerNameControllerBase(
                                                 grsCallbackUrl(existingPartnerId)
                       ).map(journeyStartUrl => SeeOther(journeyStartUrl).addingToSession())
                     case _ =>
-                      //TODO later CHARITABLE_INCORPORATED_ORGANISATION & OVERSEAS_COMPANY_NO_UK_BRANCH will have their own not supported page
                       Future(
                         Redirect(
-                          organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad()
+                          organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad()
                         )
                       )
                   }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerBase.scala
@@ -121,10 +121,9 @@ abstract class PartnerTypeControllerBase(
                         case SCOTTISH_PARTNERSHIP | GENERAL_PARTNERSHIP =>
                           redirectToPartnerNamePrompt(partnerId)
                         case _ =>
-                          //TODO later CHARITABLE_INCORPORATED_ORGANISATION & OVERSEAS_COMPANY_NO_UK_BRANCH will have their own not supported page
                           Future(
                             Redirect(
-                              organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad()
+                              organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad()
                             )
                           )
                       }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipTypeController.scala
@@ -111,7 +111,7 @@ class PartnershipTypeController @Inject() (
                           case _ =>
                             Future(
                               Redirect(
-                                organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad()
+                                organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad()
                               )
                             )
                         }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/register_as_other_organisation.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/register_as_other_organisation.scala.html
@@ -23,34 +23,41 @@
     govukLayout: main_template,
     pageHeading: pageHeading,
     paragraphBody: paragraphBody,
+    paragraph: paragraph,
     govUkLink: govUkLink,
     govukButton: GovukButton,
     sectionHeader: sectionHeader,
-    link: link,
-    appConfig: AppConfig
+    link: link
 )
 
 @()(implicit request: Request[_], messages: Messages)
 
-@isAuthenticated = @{request.isInstanceOf[AuthenticatedRequest[_]]}
-
-@feedbackUrl = @{
-    if (isAuthenticated) {
-        s"${appConfig.authenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
-    } else {
-        s"${appConfig.unauthenticatedFeedbackUrl()}&backUrl=${appConfig.selfBaseUrl}${request.uri}"
-    }
+@gformLink = @{
+    link(
+        id = Some("gform-link"),
+        newTab = true,
+        text = messages("organisationDetails.registerAsOtherOrganisation.gform.link.description"),
+        call = Call(
+            method = "GET",
+            url = messages("organisationDetails.registerAsOtherOrganisation.gform.link")
+        )
+    )
 }
 
-@link = {<a href="@feedbackUrl" class="govuk-link">@messages("organisationDetails.feedback.link")</a>}
+@gformParagraph = {
+    @paragraph(
+        content = Html(messages("organisationDetails.registerAsOtherOrganisation.paragraph.2", gformLink) + "."),
+        id = Some("gform-text")
+    )
+}
 
-@govukLayout(title = Title("organisationDetails.notSupportCompanyTypePage.title")) {
+@govukLayout(title = Title("organisationDetails.registerAsOtherOrganisation.title")) {
 
     @sectionHeader(messages("organisationDetails.sectionHeader"))
 
-    @pageHeading(messages("organisationDetails.notSupportCompanyTypePage.title"))
+    @pageHeading(messages("organisationDetails.registerAsOtherOrganisation.title"))
 
-    @paragraphBody(messages("organisationDetails.notSupportCompanyTypePage.detail"))
-
-    @paragraphBody(messages("organisationDetails.feedback", link))
+    @paragraphBody(messages("organisationDetails.registerAsOtherOrganisation.paragraph.1"))
+    @gformParagraph
+    @paragraphBody(messages("organisationDetails.registerAsOtherOrganisation.paragraph.3"))
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -61,7 +61,7 @@ POST       /partnership    uk.gov.hmrc.plasticpackagingtax.registration.controll
 GET        /partnership-name    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnershipNameController.displayPage()
 POST       /partnership-name    uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnershipNameController.submit()
 
-GET        /organisation-not-supported    uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.OrganisationTypeNotSupportedController.onPageLoad()
+GET        /register-as-other-organisation    uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.RegisterAsOtherOrganisationController.onPageLoad()
 
 GET        /confirm-address      uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.ConfirmBusinessAddressController.displayPage()
 GET        /confirm-address-callback    uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.ConfirmBusinessAddressController.addressCaptureCallback()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -430,10 +430,12 @@ unauthorised.paragraph.1 = The Plastic Packaging Tax (PPT) service will launch i
 unauthorised.paragraph.2 = If you would like to provide your feedback too, you can {0}. We will respond to you within two working days.
 unauthorised.paragraph.2.link = request to join PPT’s list of users
 
-organisationDetails.notSupportCompanyTypePage.title = This type of organisation is not supported yet
-organisationDetails.notSupportCompanyTypePage.detail = This is a new service and different types of organisation will be added as the service develops.
-organisationDetails.feedback = {0}. Your thoughts and ideas will help us to make improvements.
-organisationDetails.feedback.link = Send us your feedback
+organisationDetails.registerAsOtherOrganisation.title = Register as a charitable incorporated organisation, trust or overseas company without a UK establishment
+organisationDetails.registerAsOtherOrganisation.paragraph.1 = This is a new service and this organisation type is not supported yet.
+organisationDetails.registerAsOtherOrganisation.paragraph.2 = You can still register for Plastic Packaging Tax by {0}
+organisationDetails.registerAsOtherOrganisation.paragraph.3 = You will be asked some questions about your organisation and your plastic packaging tax again.
+organisationDetails.registerAsOtherOrganisation.gform.link.description = completing this online form
+organisationDetails.registerAsOtherOrganisation.gform.link = https://www.tax.service.gov.uk/submissions/new-form/register-for-plastic-packaging-tax
 
 notLiable.pageTitle = You do not currently need to register at this time
 notLiable.title = You do not currently need to register for Plastic Packaging Tax

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeControllerSpec.scala
@@ -187,7 +187,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         "user submits organisation type: " + CHARITABLE_INCORPORATED_ORGANISATION in {
           assertRedirectForOrgType(
             CHARITABLE_INCORPORATED_ORGANISATION,
-            organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+            organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
         }
         "user submits organisation type: " + OVERSEAS_COMPANY_UK_BRANCH in {
@@ -199,7 +199,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         "user submits organisation type: " + OVERSEAS_COMPANY_NO_UK_BRANCH in {
           assertRedirectForOrgType(
             OVERSEAS_COMPANY_NO_UK_BRANCH,
-            organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+            organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
         }
       }
@@ -320,11 +320,11 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         status(result) mustBe SEE_OTHER
         if (supported)
           redirectLocation(result) must not be Some(
-            organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+            organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
         else
           redirectLocation(result) mustBe Some(
-            organisationRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+            organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
       }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsControllerSpec.scala
@@ -347,7 +347,7 @@ class GrsControllerSpec extends ControllerSpec {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(
-          orgRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+          orgRoutes.RegisterAsOtherOrganisationController.onPageLoad().url
         )
       }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
@@ -222,7 +222,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
 
         "user submits organisation type: " + CHARITABLE_INCORPORATED_ORGANISATION in {
           assertRedirectForOrgType(CHARITABLE_INCORPORATED_ORGANISATION,
-                                   routes.OrganisationTypeNotSupportedController.onPageLoad().url
+                                   routes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
         }
         "user submits organisation type: " + OVERSEAS_COMPANY_UK_BRANCH in {
@@ -234,7 +234,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
 
         "user submits organisation type: " + TRUST in {
           assertRedirectForOrgType(TRUST,
-                                   routes.OrganisationTypeNotSupportedController.onPageLoad().url
+                                   routes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
         }
 
@@ -432,11 +432,11 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         status(result) mustBe SEE_OTHER
         if (supported)
           redirectLocation(result) must not be Some(
-            routes.OrganisationTypeNotSupportedController.onPageLoad().url
+            routes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
         else
           redirectLocation(result) mustBe Some(
-            routes.OrganisationTypeNotSupportedController.onPageLoad().url
+            routes.RegisterAsOtherOrganisationController.onPageLoad().url
           )
       }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/RegisterAsOtherOrganisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/RegisterAsOtherOrganisationControllerSpec.scala
@@ -22,17 +22,17 @@ import org.mockito.Mockito.{reset, when}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.organisation_type_not_supported
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.register_as_other_organisation
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class OrganisationTypeNotSupportedControllerSpec extends ControllerSpec {
+class RegisterAsOtherOrganisationControllerSpec extends ControllerSpec {
 
-  private val page = mock[organisation_type_not_supported]
+  private val page = mock[register_as_other_organisation]
 
   val controller =
-    new OrganisationTypeNotSupportedController(stubMessagesControllerComponents(),
-                                               page,
-                                               authenticate = mockAuthAction
+    new RegisterAsOtherOrganisationController(stubMessagesControllerComponents(),
+                                              page,
+                                              authenticate = mockAuthAction
     )
 
   override protected def beforeEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeControllerSpec.scala
@@ -216,7 +216,7 @@ class PartnerTypeControllerSpec extends ControllerSpec {
                 partnerGrsCreateRequest.getValue.businessVerificationCheck mustBe false
               case _ =>
                 redirectLocation(result) mustBe Some(
-                  orgRoutes.OrganisationTypeNotSupportedController.onPageLoad().url
+                  orgRoutes.RegisterAsOtherOrganisationController.onPageLoad().url
                 )
             }
           }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/RegisterAsOtherOrganisationViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/organisation/RegisterAsOtherOrganisationViewSpec.scala
@@ -19,18 +19,17 @@ package uk.gov.hmrc.plasticpackagingtax.registration.views.organisation
 import base.unit.UnitViewSpec
 import org.jsoup.nodes.Document
 import org.scalatest.matchers.must.Matchers
-import play.api.test.FakeRequest
 import uk.gov.hmrc.plasticpackagingtax.registration.views.components.Styles
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.organisation_type_not_supported
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.register_as_other_organisation
 import uk.gov.hmrc.plasticpackagingtax.registration.views.tags.ViewTest
 
 @ViewTest
-class OrganisationTypeNotSupportedViewSpec extends UnitViewSpec with Matchers {
+class RegisterAsOtherOrganisationViewSpec extends UnitViewSpec with Matchers {
 
-  private val page                   = inject[organisation_type_not_supported]
+  private val page                   = inject[register_as_other_organisation]
   private def createView(): Document = page()(journeyRequest, messages)
 
-  "Organisation Type Not Supported View" should {
+  "Register As Other Organisation View" should {
 
     val view = createView()
 
@@ -47,7 +46,7 @@ class OrganisationTypeNotSupportedViewSpec extends UnitViewSpec with Matchers {
     "display title" in {
 
       view.getElementsByClass(Styles.gdsPageHeading).first() must containMessage(
-        "organisationDetails.notSupportCompanyTypePage.title"
+        "organisationDetails.registerAsOtherOrganisation.title"
       )
     }
 
@@ -56,31 +55,30 @@ class OrganisationTypeNotSupportedViewSpec extends UnitViewSpec with Matchers {
       view.getElementById("section-header") must containMessage("organisationDetails.sectionHeader")
     }
 
-    "display info paragraph" in {
+    "display paragraphs" in {
 
       view.getElementsByClass(Styles.gdsPageBodyText).first() must containMessage(
-        "organisationDetails.notSupportCompanyTypePage.detail"
+        "organisationDetails.registerAsOtherOrganisation.paragraph.1"
+      )
+
+      view.getElementsByClass(Styles.gdsPageBodyText).get(1).text() must include(
+        messages("organisationDetails.registerAsOtherOrganisation.paragraph.2",
+                 messages("organisationDetails.registerAsOtherOrganisation.gform.link.description")
+        )
+      )
+
+      view.getElementsByClass(Styles.gdsPageBodyText).get(2) must containMessage(
+        "organisationDetails.registerAsOtherOrganisation.paragraph.3"
       )
     }
 
-    "display feedback link for authenticated users" in {
+    "display gform link" in {
 
-      view.getElementsByClass("govuk-link").get(3) must haveHref(
-        "http://localhost:9250/contact/beta-feedback?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
+      view.getElementById("gform-link") must haveHref(
+        "https://www.tax.service.gov.uk/submissions/new-form/register-for-plastic-packaging-tax"
       )
-      view.getElementsByClass("govuk-link").get(3) must containMessage(
-        "organisationDetails.feedback.link"
-      )
-    }
-
-    "display feedback link for unauthenticated users" in {
-
-      val unauthenticatedView = page()(FakeRequest(), messages)
-      unauthenticatedView.getElementsByClass("govuk-link").get(2) must haveHref(
-        "http://localhost:9250/contact/beta-feedback-unauthenticated?service=plastic-packaging-tax&backUrl=http://localhost:8503/"
-      )
-      unauthenticatedView.getElementsByClass("govuk-link").get(2) must containMessage(
-        "organisationDetails.feedback.link"
+      view.getElementById("gform-text") must containMessage(
+        "organisationDetails.registerAsOtherOrganisation.gform.link.description"
       )
     }
   }


### PR DESCRIPTION
### Description of Work carried through

New url and content for when org is not supported. Now users are directed to a gform.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [x] No Accessibility errors/warnings reported by Wave
