### PR TITLE
Restrict agents from registration journey

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -196,11 +196,12 @@ abstract class AuthActionBase @Inject() (
       }
     }
 
-    if (identityData.affinityGroup.contains(AffinityGroup.Agent) && !agentsAllowed) {
+    if (identityData.affinityGroup.contains(AffinityGroup.Agent) && !agentsAllowed)
       throw UnsupportedAffinityGroup()
-    }
 
     if (pptReference.isDefined && redirectEnrolledUsersToReturns)
+      Future.successful(Results.Redirect(appConfig.pptAccountUrl))
+    else if (identityData.affinityGroup.contains(AffinityGroup.Agent) && pptReference.isEmpty)
       Future.successful(Results.Redirect(appConfig.pptAccountUrl))
     else if (
       allowedUsers.isAllowed(email) || identityData.affinityGroup.contains(AffinityGroup.Agent)

--- a/test/base/PptTestData.scala
+++ b/test/base/PptTestData.scala
@@ -18,7 +18,7 @@ package base
 
 import org.joda.time.{DateTime, LocalDate}
 import uk.gov.hmrc.auth.core.ConfidenceLevel.L50
-import uk.gov.hmrc.auth.core.Enrolments
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
 import uk.gov.hmrc.auth.core.retrieve.{AgentInformation, Credentials, LoginTimes, Name}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.Features
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
@@ -33,7 +33,8 @@ object PptTestData {
 
   def newUser(
     internalId: String = "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b",
-    featureFlags: Map[String, Boolean] = testUserFeatures
+    featureFlags: Map[String, Boolean] = testUserFeatures,
+    affinityGroup: Option[AffinityGroup] = None
   ): SignedInUser =
     SignedInUser(Enrolments(Set()),
                  IdentityData(Some(internalId),
@@ -58,11 +59,14 @@ object PptTestData {
                               None,
                               None,
                               None,
-                              None,
+                              affinityGroup,
                               Some("credentialStrength 50"),
                               Some(LoginTimes(DateTime.now, None))
                  ),
                  featureFlags
     )
+
+  def newAgent(externalId: String = "123") =
+    newUser(externalId, affinityGroup = Some(AffinityGroup.Agent))
 
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -174,6 +174,18 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
     }
 
+    "redirect agents to unauthorised page if when try at access registration pages" in {
+      val agent = PptTestData.newAgent("456")
+      authorizedUser(agent)
+      println("!!!!!!!!!!!!!! A " + agent.identityData.affinityGroup)
+      val result =
+        registrationAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+          okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
+    }
+
     "redirect the user to MFA Uplift page if the user has incorrect credential strength " in {
       when(appConfig.mfaUpliftUrl).thenReturn("mfa-uplift-url")
       when(appConfig.loginContinueUrl).thenReturn("login-continue-url")

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -177,10 +177,9 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
     "redirect agents to unauthorised page if when try at access registration pages" in {
       val agent = PptTestData.newAgent("456")
       authorizedUser(agent)
-      println("!!!!!!!!!!!!!! A " + agent.identityData.affinityGroup)
       val result =
         registrationAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
-          okResponseGenerator
+                                             okResponseGenerator
         )
 
       redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
@@ -218,6 +217,25 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
           okResponseGenerator
         )
       ) mustBe Results.Ok
+    }
+
+    "agents accessing an amendment screen without a selected client should be redirected back to plastics account" in {
+      // The plastics accounts UI will take the required actions; we will not duplicate them here
+      val agent = PptTestData.newAgent("456")
+      authorizedUser(
+        agent,
+        expectedPredicate = Some(
+          Enrolment(PptEnrolment.Identifier).and(CredentialStrength(CredentialStrength.strong))
+        )
+      )
+
+      val result =
+        amendmentAuthAction(new AllowedUsers(Seq.empty)).invokeBlock(authRequest(Headers(), agent),
+                                                                     okResponseGenerator
+        )
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some("/ppt-accounts-url")
     }
 
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -57,6 +57,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     reset(mockAuthConnector)
+    reset(appConfig)
   }
 
   "Auth Action" should {
@@ -221,6 +222,8 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
     "agents accessing an amendment screen without a selected client should be redirected back to plastics account" in {
       // The plastics accounts UI will take the required actions; we will not duplicate them here
+      when(appConfig.pptAccountUrl).thenReturn("/ppt-accounts-url")
+
       val agent = PptTestData.newAgent("456")
       authorizedUser(
         agent,


### PR DESCRIPTION
### Description of Work carried through

Adjust the registration auth action to prevent Agents from accidentally registering themselves; block them from all registration journey screens.

Adjust the amendment auth action to send Agents who have not identified their client back to returns. The returns UI will prompt them todo this and land them back on the account page.



#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
