### PR TITLE
PPTP-1854 Agents are allowed into amend screens with weak credentials

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -103,7 +103,7 @@ abstract class AuthActionBase @Inject() (
     val strongCredentials = CredentialStrength(CredentialStrength.strong)
     // Agents are allowed to use weak credentials
     // The order of this clause is important if we wish to preserve the MFA uplift of non agents.
-    // If an auth OR clause evaluates to false, the auth AlternateAuthPredicate with response with an exception
+    // If an auth OR clause evaluates to false, the auth AlternateAuthPredicate will respond with an exception
     // matching the last clause it evaluated. Strong credentials needs to be the last clause if we want to catch it
     AffinityGroup.Agent.or(strongCredentials)
   }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -34,6 +34,9 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
 
   private val okResponseGenerator = (_: AuthenticatedRequest[_]) => Future(Results.Ok)
 
+  private val expectedAcceptableCredentialsPredicate =
+    AffinityGroup.Agent.or(CredentialStrength(CredentialStrength.strong))
+
   private def registrationAuthAction(
     emailAllowedList: AllowedUsers = new AllowedUsers(Seq.empty)
   ): AuthAction =
@@ -84,7 +87,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
     "process request when use email number is allowed" in {
       val allowedEmail = "amina@hmrc.co.uk"
       val user         = PptTestData.newUser("123")
-      authorizedUser(user, expectedPredicate = Some(CredentialStrength(CredentialStrength.strong)))
+      authorizedUser(user, expectedPredicate = Some(expectedAcceptableCredentialsPredicate))
 
       await(
         registrationAuthAction(
@@ -120,7 +123,7 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
     "allow users with no existing enrolment to access registration screens by not enforcing an enrolment predicate" in {
       val allowedEmail = "amina@hmrc.co.uk"
       val user         = PptTestData.newUser("123")
-      authorizedUser(user, expectedPredicate = Some(CredentialStrength(CredentialStrength.strong)))
+      authorizedUser(user, expectedPredicate = Some(expectedAcceptableCredentialsPredicate))
 
       await(
         registrationAuthAction(
@@ -207,9 +210,8 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       val user         = PptTestData.newUser("123")
       authorizedUser(
         user,
-        expectedPredicate = Some(
-          Enrolment(PptEnrolment.Identifier).and(CredentialStrength(CredentialStrength.strong))
-        )
+        expectedPredicate =
+          Some(Enrolment(PptEnrolment.Identifier).and(expectedAcceptableCredentialsPredicate))
       )
 
       await(
@@ -227,9 +229,8 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       val agent = PptTestData.newAgent("456")
       authorizedUser(
         agent,
-        expectedPredicate = Some(
-          Enrolment(PptEnrolment.Identifier).and(CredentialStrength(CredentialStrength.strong))
-        )
+        expectedPredicate =
+          Some(Enrolment(PptEnrolment.Identifier).and(expectedAcceptableCredentialsPredicate))
       )
 
       val result =


### PR DESCRIPTION
### Description of Work carried through

Same change as applied to Returns.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
