### PR TITLE
PPTP-1854 Users hitting amendment screens with no enrolments are bounced back to Returns

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -167,7 +167,7 @@ abstract class AuthActionBase @Inject() (
       case _: IncorrectCredentialStrength =>
         upliftCredentialStrength()
       case _: InsufficientEnrolments =>
-        // Returns has the best not enrolled explanation page and know what todo with agents in this state
+        // Returns has the best not enrolled explanation page and knows how to handle agents in this state
         Results.Redirect(appConfig.pptAccountUrl)
       case _: UnsupportedAffinityGroup =>
         Results.Redirect(routes.UnauthorisedController.onPageLoad())

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthAction.scala
@@ -166,6 +166,9 @@ abstract class AuthActionBase @Inject() (
         Results.Redirect(appConfig.loginUrl, Map("continue" -> Seq(appConfig.loginContinueUrl)))
       case _: IncorrectCredentialStrength =>
         upliftCredentialStrength()
+      case _: InsufficientEnrolments =>
+        // Returns has the best not enrolled explanation page and know what todo with agents in this state
+        Results.Redirect(appConfig.pptAccountUrl)
       case _: UnsupportedAffinityGroup =>
         Results.Redirect(routes.UnauthorisedController.onPageLoad())
       case _: AuthorisationException =>

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/AuthActionSpec.scala
@@ -166,9 +166,20 @@ class AuthActionSpec extends ControllerSpec with MetricsMocks {
       redirectLocation(result) mustBe Some("login-url?continue=login-continue-url")
     }
 
-    "redirect to unauthorised page when user not authorised" in {
-
+    "redirect to returns accounts to use its not enrolled page when user is not enrolled" in {
+      when(appConfig.pptAccountUrl).thenReturn("/ppt-accounts-url")
       whenAuthFailsWith(InsufficientEnrolments())
+
+      val result =
+        registrationAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),
+                                             okResponseGenerator
+        )
+
+      redirectLocation(result) mustBe Some("/ppt-accounts-url")
+    }
+
+    "redirect to unauthorised page when user not authorised" in {
+      whenAuthFailsWith(InternalError("Some general auth exception"))
 
       val result =
         registrationAuthAction().invokeBlock(authRequest(Headers(), PptTestData.newUser()),


### PR DESCRIPTION
### Description of Work carried through

Users hitting amendment screens with no enrolments are bounced back to Returns and ultimately the not enrolled screen.

Returns not enrolled prompts unregistered normal users to register and prompts agents to select a client.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
