### PR TITLE
PPTP-1910 Task list liability details step is not completed until a registration type has been entered

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/CheckLiabilityDetailsAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/CheckLiabilityDetailsAnswersController.scala
@@ -19,10 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{
-  StartRegistrationController,
-  routes => commonRoutes
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.check_liability_details_answers_page
@@ -35,7 +32,6 @@ class CheckLiabilityDetailsAnswersController @Inject() (
   authenticate: AuthAction,
   journeyAction: JourneyAction,
   mcc: MessagesControllerComponents,
-  startRegistrationController: StartRegistrationController,
   page: check_liability_details_answers_page
 ) extends LiabilityController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/Registration.scala
@@ -109,12 +109,17 @@ case class Registration(
   def isLiabilityDetailsComplete: Boolean = liabilityDetailsStatus == TaskStatus.Completed
 
   def liabilityDetailsStatus: TaskStatus =
-    if (this.liabilityDetails.isCompleted && registrationType.contains(GROUP))
+    if (liabilityDetails.isCompleted && registrationType.contains(GROUP))
       if (groupDetail.flatMap(_.membersUnderGroupControl).contains(true))
         TaskStatus.Completed
       else TaskStatus.InProgress
+    else if (liabilityDetails.status == TaskStatus.Completed)
+      if (registrationType.nonEmpty)
+        TaskStatus.Completed
+      else
+        TaskStatus.InProgress
     else
-      this.liabilityDetails.status
+      liabilityDetails.status
 
   def isPrimaryContactDetailsComplete: Boolean = primaryContactDetailsStatus == TaskStatus.Completed
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/CheckLiabilityDetailsAnswersControllerTest.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/CheckLiabilityDetailsAnswersControllerTest.scala
@@ -47,8 +47,6 @@ class CheckLiabilityDetailsAnswersControllerTest extends ControllerSpec {
     new CheckLiabilityDetailsAnswersController(authenticate = mockAuthAction,
                                                mockJourneyAction,
                                                mcc = mcc,
-                                               startRegistrationController =
-                                                 mockStartRegistrationController,
                                                page = page
     )
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/RegistrationSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/RegistrationSpec.scala
@@ -25,7 +25,8 @@ import uk.gov.hmrc.plasticpackagingtax.registration.forms.{Date, OldDate}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType.GROUP
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.{
   LiabilityExpectedWeight,
-  LiabilityWeight
+  LiabilityWeight,
+  RegType
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType
 import uk.gov.hmrc.plasticpackagingtax.registration.views.models.TaskStatus
@@ -158,11 +159,20 @@ class RegistrationSpec
       )
     completedLiabilityDetails.isCompleted mustBe true
 
-    "be complete for single organisation registration with completed liability details" in {
+    "be complete for single organisation registration with completed liability details and selected registration type" in {
       Registration(id = "123",
                    liabilityDetails =
-                     completedLiabilityDetails
+                     completedLiabilityDetails,
+                   registrationType = Some(RegType.SINGLE_ENTITY)
       ).liabilityDetailsStatus mustBe TaskStatus.Completed
+    }
+
+    "be incomplete for registration with completed liability details but no registration type" in {
+      Registration(id = "123",
+                   liabilityDetails =
+                     completedLiabilityDetails,
+                   registrationType = None
+      ).liabilityDetailsStatus mustBe TaskStatus.InProgress
     }
 
     "be in progress for single organisation registration with incomplete liability details" in {


### PR DESCRIPTION
### Description of Work carried through

The completeness of the Liability Details task list section needs to check if the registration type has been completed.

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
