### PR TITLE
PPTP-1911 - Removing save and come back later button from views

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/saveButtons.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/saveButtons.scala.html
@@ -25,7 +25,7 @@
 
 <div class="govuk-button-group">
     @saveAndContinue(saveAndContinueKey)
-    @if(!appConfig.isDefaultFeatureFlagEnabled(isUkCompanyPrivateBeta)) {
-        @saveAndComeBackLater(saveAndComeBackLaterKey)
-    }
+<!--    @if(!appConfig.isDefaultFeatureFlagEnabled(isUkCompanyPrivateBeta)) {-->
+<!--        @saveAndComeBackLater(saveAndComeBackLaterKey)-->
+<!--    }-->
 </div>

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/saveButtons.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/saveButtons.scala.html
@@ -25,7 +25,4 @@
 
 <div class="govuk-button-group">
     @saveAndContinue(saveAndContinueKey)
-<!--    @if(!appConfig.isDefaultFeatureFlagEnabled(isUkCompanyPrivateBeta)) {-->
-<!--        @saveAndComeBackLater(saveAndComeBackLaterKey)-->
-<!--    }-->
 </div>

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/components/SaveButtonsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/components/SaveButtonsSpec.scala
@@ -17,15 +17,9 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.views.components
 
 import base.unit.UnitViewSpec
-import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.registration.config.Features.isUkCompanyPrivateBeta
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{
-  saveAndComeBackLater,
-  saveAndContinue,
-  saveButtons
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{saveAndComeBackLater, saveAndContinue, saveButtons}
 
 class SaveButtonsSpec extends UnitViewSpec with Matchers {
 
@@ -37,27 +31,12 @@ class SaveButtonsSpec extends UnitViewSpec with Matchers {
     new saveButtons(saveAndContinueButton, saveAndComeBackLaterButton, mockConfig)
 
   "Save Buttons Component" should {
-    "render both buttons" when {
-      "outside of private BETA" in {
-        when(mockConfig.isDefaultFeatureFlagEnabled(isUkCompanyPrivateBeta)).thenReturn(false)
-        val view = component()(messages)
+    "render only the save button" in {
+      val view = component()(messages)
 
-        val buttons = view.select("button")
-        buttons.size() mustBe 2
-        buttons.get(0).text() mustBe messages("site.button.saveAndContinue")
-        buttons.get(1).text() mustBe messages("site.button.saveAndComeBackLater")
-      }
-    }
-
-    "render only the save button" when {
-      "during private BETA" in {
-        when(mockConfig.isDefaultFeatureFlagEnabled(isUkCompanyPrivateBeta)).thenReturn(true)
-        val view = component()(messages)
-
-        val buttons = view.select("button")
-        buttons.size() mustBe 1
-        buttons.get(0).text() mustBe messages("site.button.saveAndContinue")
-      }
+      val buttons = view.select("button")
+      buttons.size() mustBe 1
+      buttons.get(0).text() mustBe messages("site.button.saveAndContinue")
     }
   }
 

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/components/SaveButtonsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/components/SaveButtonsSpec.scala
@@ -19,7 +19,11 @@ package uk.gov.hmrc.plasticpackagingtax.registration.views.components
 import base.unit.UnitViewSpec
 import org.scalatest.matchers.must.Matchers
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{saveAndComeBackLater, saveAndContinue, saveButtons}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.components.{
+  saveAndComeBackLater,
+  saveAndContinue,
+  saveButtons
+}
 
 class SaveButtonsSpec extends UnitViewSpec with Matchers {
 


### PR DESCRIPTION
### Description of Work carried through

Removing save and come back later from views.

Note - full removal of component will be carried out as part of https://jira.tools.tax.service.gov.uk/browse/PPTP-1917

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
