### PR TITLE
PPTP-1915 Continue is a more accurate label for the check liability page action

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/check_liability_details_answers_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/check_liability_details_answers_page.scala.html
@@ -28,7 +28,7 @@
         govukButton: GovukButton,
         govukSummaryList: GovukSummaryList,
         pageHeading: pageHeading,
-        saveAndContinue: saveAndContinue,
+        continue: continue,
         viewUtils: ViewUtils,
         sectionHeader: sectionHeader,
         liabilityCheckAnswers: liabilityCheckAnswers
@@ -44,6 +44,6 @@
 
         @formHelper(action = pptRoutes.CheckLiabilityDetailsAnswersController.submit(), 'autoComplete -> "off") {
             @liabilityCheckAnswers(registration)
-            @saveAndContinue()
+            @continue()
         }
     }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/CheckLiabilityDetailsAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/CheckLiabilityDetailsAnswersViewSpec.scala
@@ -161,9 +161,9 @@ class CheckLiabilityDetailsAnswersViewSpec extends UnitViewSpec with Matchers {
       }
     }
 
-    "display 'Save and continue' button" in {
+    "display 'Continue' button" in {
       preLaunchView must containElementWithID("submit")
-      preLaunchView.getElementById("submit").text() mustBe "Save and continue"
+      preLaunchView.getElementById("submit").text() mustBe "Continue"
     }
 
   }


### PR DESCRIPTION
### Description of Work carried through

This click does nothing; the save has already happened.

Confirm and continue was another suggestion but it's not currently used anywhere in Registration.
Continue is also consistent with the your tax date confirm screen which proceeds this screen.


#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [x] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
