### PR TITLE
PPTP-1911: remove placeholder start page, add redirect for /start url

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfigV2.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/addresslookup/AddressLookupConfigV2.scala
@@ -41,7 +41,7 @@ object AddressLookupConfigV2 {
     new AddressLookupConfigV2(options = JourneyOptions(continueUrl = appConfig.selfUrl(continue),
                                                        signOutHref = appConfig.signOutLink,
                                                        serviceHref = appConfig.selfUrl(
-                                                         commonRoutes.StartController.displayStartPage
+                                                         commonRoutes.StartRegistrationController.startRegistration
                                                        )
                               ),
                               labels = JourneyLabels(en =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
@@ -34,7 +34,7 @@
 
 @govukLayout(
     title = Title("liability.exceededThresholdWeight.title"),
-    backButton = Some(BackButton(messages("site.back"), pptRoutes.StartController.displayStartPage(), messages("site.back.hiddenText")))) {
+    backButton = None) {
 
     @errorSummary(form.errors)
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/siteHeader.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/partials/siteHeader.scala.html
@@ -38,7 +38,7 @@
 @hmrcHeader(Header(
     homepageUrl = "https://www.gov.uk",
     serviceName = Some(messages("service.name")),
-    serviceUrl = pptRoutes.StartController.displayStartPage.url,
+    serviceUrl = pptRoutes.StartRegistrationController.startRegistration.url,
     language = language.En,
     containerClasses = "govuk-width-container",
     signOutHref = signOutHref

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/unauthorised.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/unauthorised.scala.html
@@ -17,7 +17,7 @@
 @import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.html.main_template
 @import uk.gov.hmrc.plasticpackagingtax.registration.views.models.Title
-@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes.StartController
+@import uk.gov.hmrc.plasticpackagingtax.registration.controllers.routes.StartRegistrationController
 
 @this(
         govukLayout: main_template,
@@ -33,7 +33,7 @@
 @link(
         id = Some("register_for_ppt_link"),
         text = messages("unauthorised.paragraph.1.link"),
-        call = StartController.displayStartPage()
+        call = StartRegistrationController.startRegistration()
     )
 }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,7 +8,7 @@ GET        /assets/*file            controllers.Assets.versioned(path="/public",
 GET        /lang/enGb             uk.gov.hmrc.plasticpackagingtax.registration.controllers.LanguageController.enGb()
 GET        /lang/cyGb             uk.gov.hmrc.plasticpackagingtax.registration.controllers.LanguageController.cyGb()
 
-GET        /start                uk.gov.hmrc.plasticpackagingtax.registration.controllers.StartController.displayStartPage()
+GET        /start                controllers.Default.redirect(to = "/register-for-plastic-packaging-tax/start-registration")
 GET        /start-registration   uk.gov.hmrc.plasticpackagingtax.registration.controllers.StartRegistrationController.startRegistration()
 
 # Liability : pre-launch

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/ExceededThresholdWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/ExceededThresholdWeightViewSpec.scala
@@ -44,8 +44,8 @@ class ExceededThresholdWeightViewSpec extends UnitViewSpec with Matchers {
       displaySignOutLink(view)
     }
 
-    "display 'Back' button" in {
-      view.getElementById("back-link") must haveHref(routes.StartController.displayStartPage())
+    "should not have a 'Back' button" in {
+      view.getElementById("back-link") mustBe null
     }
 
     "display title" in {


### PR DESCRIPTION
### Description of Work carried through

PPTP-1911: remove placeholder start page, add redirect for /start url

#### Check list 
 - [ ] `./precheck` was executed (Integration/Component/Unit tests)
 - [ ] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
