### PR TITLE
PPTP-1949 - Removing group details from single entity

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -161,9 +161,11 @@ class ReviewRegistrationController @Inject() (
 
   private def reviewRegistration()(implicit request: JourneyRequest[AnyContent]): Future[Result] = {
 
-    val reg: Registration = removePartialGroupMembersIfGroup(request.registration)
+    val reg2: Registration = removePartialGroupMembersIfGroup(request.registration)
 
-    if (reg.isFirstGroupMember)
+    val reg = removeGroupDetailsIfNotGroup(reg2)
+
+    if (reg.isGroup && reg.isFirstGroupMember)
       markAsCannotYetStarted(reg).map { _ =>
         Redirect(routes.TaskListController.displayPage())
       }
@@ -192,6 +194,11 @@ class ReviewRegistrationController @Inject() (
   private def removePartialGroupMembersIfGroup(registration: Registration): Registration =
     if (registration.isGroup)
       registrationFilterService.removePartialGroupMembers(registration)
+    else registration
+
+  private def removeGroupDetailsIfNotGroup(registration: Registration): Registration =
+    if (!registration.isGroup)
+      registrationFilterService.removeGroupDetails(registration)
     else registration
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/services/RegistrationGroupFilterService.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/services/RegistrationGroupFilterService.scala
@@ -25,4 +25,7 @@ class RegistrationGroupFilterService {
       registration.groupDetail.map(gd => gd.copy(members = gd.members.filter(_.isValid)))
     )
 
+  def removeGroupDetails(registration: Registration): Registration =
+    registration.copy(groupDetail = None)
+
 }

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewTaskListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewTaskListControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import base.unit.ControllerSpec
+import org.mockito.AdditionalAnswers.returnsFirstArg
 import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito.`given`
 import org.mockito.Mockito.{reset, verify, when}
@@ -78,6 +79,7 @@ class ReviewTaskListControllerSpec extends ControllerSpec with TableDrivenProper
     authorizedUser()
     given(mockReviewRegistrationPage.apply(any())(any(), any())).willReturn(HtmlFormat.empty)
     given(mockDuplicateSubscriptionPage.apply()(any(), any())).willReturn(HtmlFormat.empty)
+    when(mockRegistrationFilterService.removeGroupDetails(any())).then(returnsFirstArg())
   }
 
   override protected def afterEach(): Unit = {


### PR DESCRIPTION
### Description of Work carried through

- Adding guard to check entity is group and contains multiple members
- Removing group details if entity is not Group.

TODO - add unit tests when single entity contains groupDetails

#### Check list 
 - [x] `./precheck` was executed (Integration/Component/Unit tests)
 - [x] `sbt scalafmt test:scalafmt` was executed
 - [ ] Required Environment Config has been amended/added
 - [ ] Links to dependencies have been included (BE/FE work)
 - [ ] User Acceptance Tests (UAT) were run locally and have passed.
 - [ ] No Accessibility errors/warnings reported by Wave
