### PR TITLE
Verify check on additional partners results in proper handling

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
@@ -80,11 +80,6 @@ abstract class PartnerGrsControllerBase(
                 case SOLE_TRADER_VERIFICATION_FAILED =>
                   Redirect(commonRoutes.NotableErrorController.soleTraderVerificationFailure())
                 case DUPLICATE_SUBSCRIPTION =>
-                  if (registration.isGroup)
-                    Redirect(
-                      groupRoutes.NotableErrorController.nominatedOrganisationAlreadyRegistered()
-                    )
-                  else
                     Redirect(commonRoutes.NotableErrorController.duplicateRegistration())
                 case UNSUPPORTED_ORGANISATION =>
                   Redirect(orgRoutes.RegisterAsOtherOrganisationController.onPageLoad())

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
@@ -80,7 +80,7 @@ abstract class PartnerGrsControllerBase(
                 case SOLE_TRADER_VERIFICATION_FAILED =>
                   Redirect(commonRoutes.NotableErrorController.soleTraderVerificationFailure())
                 case DUPLICATE_SUBSCRIPTION =>
-                    Redirect(commonRoutes.NotableErrorController.duplicateRegistration())
+                  Redirect(commonRoutes.NotableErrorController.duplicateRegistration())
                 case UNSUPPORTED_ORGANISATION =>
                   Redirect(orgRoutes.RegisterAsOtherOrganisationController.onPageLoad())
               }


### PR DESCRIPTION
I think we can do this. 

registration.organisationDetails.grsRegistration is set in the saveRegistrationDetails by a get details call. 

Which _should_ mean the match is relevant to the speicific partner in question, rather than the partnership as a whole.