### PR TITLE
relaxed the auth on groups notable exceptions controller and renamed auth actions.

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ConfirmationController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthActionImpl
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthActionImpl
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.confirmation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -26,9 +26,9 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class ConfirmationController @Inject() (
-  authenticate: AuthActionImpl,
-  mcc: MessagesControllerComponents,
-  page: confirmation_page
+                                         authenticate: NotEnrolledAuthActionImpl,
+                                         mcc: MessagesControllerComponents,
+                                         page: confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/KeepAliveController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/KeepAliveController.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.JsValue
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.auth.core.SessionRecordNotFound
 import uk.gov.hmrc.mongo.cache.{DataKey, MongoCacheRepository}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.MongoUserDataRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success}
 class KeepAliveController @Inject() (
   mcc: MessagesControllerComponents,
   userDataRepository: MongoUserDataRepository,
-  authenticate: AuthNoEnrolmentCheckAction
+  authenticate: EnrolledAuthAction
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/NotableErrorController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.enrolment_failure_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.grs_failure_page
@@ -34,15 +34,15 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class NotableErrorController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  errorPage: error_page,
-  errorNoSavePage: enrolment_failure_page,
-  grsFailurePage: grs_failure_page,
-  businessVerificationFailurePage: business_verification_failure_page,
-  soleTraderVerificationFailurePage: sole_trader_verification_failure_page,
-  duplicateSubscriptionPage: duplicate_subscription_page
+                                         authenticate: NotEnrolledAuthAction,
+                                         journeyAction: JourneyAction,
+                                         mcc: MessagesControllerComponents,
+                                         errorPage: error_page,
+                                         errorNoSavePage: enrolment_failure_page,
+                                         grsFailurePage: grs_failure_page,
+                                         businessVerificationFailurePage: business_verification_failure_page,
+                                         soleTraderVerificationFailurePage: sole_trader_verification_failure_page,
+                                         duplicateSubscriptionPage: duplicate_subscription_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def subscriptionFailure(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewRegistrationController.scala
@@ -22,7 +22,7 @@ import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.audit.Auditor
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.nrs.NrsDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -41,15 +41,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ReviewRegistrationController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  subscriptionsConnector: SubscriptionsConnector,
-  metrics: Metrics,
-  override val registrationConnector: RegistrationConnector,
-  auditor: Auditor,
-  reviewRegistrationPage: review_registration_page,
-  registrationFilterService: RegistrationGroupFilterService
+                                               authenticate: NotEnrolledAuthAction,
+                                               journeyAction: JourneyAction,
+                                               mcc: MessagesControllerComponents,
+                                               subscriptionsConnector: SubscriptionsConnector,
+                                               metrics: Metrics,
+                                               override val registrationConnector: RegistrationConnector,
+                                               auditor: Auditor,
+                                               reviewRegistrationPage: review_registration_page,
+                                               registrationFilterService: RegistrationGroupFilterService
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/StartRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/StartRegistrationController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{
   routes => liabilityRoutes
 }
@@ -28,9 +28,9 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class StartRegistrationController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents
+                                              authenticate: NotEnrolledAuthAction,
+                                              journeyAction: JourneyAction,
+                                              mcc: MessagesControllerComponents
 ) extends FrontendController(mcc) {
 
   def startRegistration(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/TaskListController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/TaskListController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability.{
   routes => liabilityRoutes
 }
@@ -34,12 +34,12 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class TaskListController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  singleEntityPage: task_list_single_entity,
-  groupPage: task_list_group,
-  partnershipPage: task_list_partnership
+                                     authenticate: NotEnrolledAuthAction,
+                                     journeyAction: JourneyAction,
+                                     mcc: MessagesControllerComponents,
+                                     singleEntityPage: task_list_single_entity,
+                                     groupPage: task_list_group,
+                                     partnershipPage: task_list_partnership
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/NotEnrolledAuthAction.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/NotEnrolledAuthAction.scala
@@ -38,34 +38,34 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuthActionImpl @Inject() (
+class NotEnrolledAuthActionImpl @Inject()(
   override val authConnector: AuthConnector,
   metrics: Metrics,
   mcc: MessagesControllerComponents,
   appConfig: AppConfig
-) extends AuthActionBase(authConnector, metrics, mcc, appConfig) with AuthAction {
+) extends AuthActionBase(authConnector, metrics, mcc, appConfig) with NotEnrolledAuthAction {
   override val mustBeEnrolled: Boolean                 = false
   override val redirectEnrolledUsersToReturns: Boolean = true
   override val agentsAllowed: Boolean                  = false
 }
 
-class AuthNoEnrolmentCheckActionImpl @Inject() (
+class EnrolledAuthActionImpl @Inject()(
   override val authConnector: AuthConnector,
   metrics: Metrics,
   mcc: MessagesControllerComponents,
   appConfig: AppConfig
-) extends AuthActionBase(authConnector, metrics, mcc, appConfig) with AuthNoEnrolmentCheckAction {
+) extends AuthActionBase(authConnector, metrics, mcc, appConfig) with EnrolledAuthAction {
   override val mustBeEnrolled: Boolean                 = true
   override val redirectEnrolledUsersToReturns: Boolean = false
   override val agentsAllowed: Boolean                  = true
 }
 
-class AuthRegistrationOrAmendmentActionImpl @Inject() (
+class PermissiveAuthActionImpl @Inject()(
   override val authConnector: AuthConnector,
   metrics: Metrics,
   mcc: MessagesControllerComponents,
   appConfig: AppConfig
-) extends AuthActionBase(authConnector, metrics, mcc, appConfig) with AuthNoEnrolmentCheckAction {
+) extends AuthActionBase(authConnector, metrics, mcc, appConfig) with PermissiveAuthAction {
   override val mustBeEnrolled: Boolean                 = false
   override val redirectEnrolledUsersToReturns: Boolean = false
   override val agentsAllowed: Boolean                  = true
@@ -222,11 +222,11 @@ trait AuthActioning
     extends ActionBuilder[AuthenticatedRequest, AnyContent]
     with ActionFunction[Request, AuthenticatedRequest]
 
-@ImplementedBy(classOf[AuthActionImpl])
-trait AuthAction extends AuthActioning
+@ImplementedBy(classOf[NotEnrolledAuthActionImpl])
+trait NotEnrolledAuthAction extends AuthActioning
 
-@ImplementedBy(classOf[AuthNoEnrolmentCheckActionImpl])
-trait AuthNoEnrolmentCheckAction extends AuthActioning
+@ImplementedBy(classOf[EnrolledAuthActionImpl])
+trait EnrolledAuthAction extends AuthActioning
 
-@ImplementedBy(classOf[AuthRegistrationOrAmendmentActionImpl])
-trait AuthRegistrationOrAmendmentAction extends AuthActioning
+@ImplementedBy(classOf[PermissiveAuthActionImpl])
+trait PermissiveAuthAction extends AuthActioning

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.addresslookup.AddressLookupFrontendConnector
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.AddressLookupIntegration
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthRegistrationOrAmendmentActionImpl
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.PermissiveAuthActionImpl
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.address.UkAddressForm
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.models.addresslookup.{AddressLookupOnRamp, MissingAddressIdException}
@@ -38,15 +38,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AddressCaptureController @Inject() (
-  authenticate: AuthRegistrationOrAmendmentActionImpl,
-  mcc: MessagesControllerComponents,
-  addressCaptureService: AddressCaptureService,
-  addressLookupFrontendConnector: AddressLookupFrontendConnector,
-  appConfig: AppConfig,
-  addressInUkPage: uk_address_page,
-  addressPage: address_page,
-  countryService: CountryService,
-  addressConversionUtils: AddressConversionUtils
+                                           authenticate: PermissiveAuthActionImpl,
+                                           mcc: MessagesControllerComponents,
+                                           addressCaptureService: AddressCaptureService,
+                                           addressLookupFrontendConnector: AddressLookupFrontendConnector,
+                                           appConfig: AppConfig,
+                                           addressInUkPage: uk_address_page,
+                                           addressPage: address_page,
+                                           countryService: CountryService,
+                                           addressConversionUtils: AddressConversionUtils
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with AddressLookupIntegration {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendContactDetailsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendContactDetailsController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment
 
 import play.api.data.Form
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact._
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{
@@ -36,13 +36,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AmendContactDetailsController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  contactNamePage: full_name_page,
-  jobTitlePage: job_title_page,
-  phoneNumberPage: phone_number_page,
-  addressCaptureService: AddressCaptureService
+                                                authenticate: EnrolledAuthAction,
+                                                mcc: MessagesControllerComponents,
+                                                amendmentJourneyAction: AmendmentJourneyAction,
+                                                contactNamePage: full_name_page,
+                                                jobTitlePage: job_title_page,
+                                                phoneNumberPage: phone_number_page,
+                                                addressCaptureService: AddressCaptureService
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment
 import play.api.data.Form
 import play.api.mvc._
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.EmailVerificationActions
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact._
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   AmendRegistrationUpdateService,
@@ -37,15 +37,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AmendEmailAddressController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  emailPage: email_address_page,
-  val emailPasscodePage: email_address_passcode_page,
-  val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
-  val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
-  val emailVerificationService: EmailVerificationService,
-  val registrationUpdater: AmendRegistrationUpdateService
+                                              authenticate: EnrolledAuthAction,
+                                              mcc: MessagesControllerComponents,
+                                              amendmentJourneyAction: AmendmentJourneyAction,
+                                              emailPage: email_address_page,
+                                              val emailPasscodePage: email_address_passcode_page,
+                                              val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
+                                              val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
+                                              val emailVerificationService: EmailVerificationService,
+                                              val registrationUpdater: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) with EmailVerificationActions {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendOrganisationDetailsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendOrganisationDetailsController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{
@@ -35,10 +35,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AmendOrganisationDetailsController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  addressCaptureService: AddressCaptureService,
-  amendmentJourneyAction: AmendmentJourneyAction
+                                                     authenticate: EnrolledAuthAction,
+                                                     mcc: MessagesControllerComponents,
+                                                     addressCaptureService: AddressCaptureService,
+                                                     amendmentJourneyAction: AmendmentJourneyAction
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment
 
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.amend_registration_page
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partials.amendment.amend_error_page
@@ -27,11 +27,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AmendRegistrationController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  amendRegistrationPage: amend_registration_page,
-  amendErrorPage: amend_error_page
+                                              authenticate: EnrolledAuthAction,
+                                              mcc: MessagesControllerComponents,
+                                              amendmentJourneyAction: AmendmentJourneyAction,
+                                              amendRegistrationPage: amend_registration_page,
+                                              amendErrorPage: amend_error_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsCheckAnswersController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.AmendmentController
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.{routes => amendRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -32,10 +32,10 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberContactDetailsCheckAnswersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: amend_member_contact_check_answers_page
+                                                                     authenticate: EnrolledAuthAction,
+                                                                     journeyAction: AmendmentJourneyAction,
+                                                                     mcc: MessagesControllerComponents,
+                                                                     page: amend_member_contact_check_answers_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, journeyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsConfirmAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsConfirmAddressController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.ContactDetailsConfirmAddressControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -28,11 +28,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberContactDetailsConfirmAddressController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents,
-  registrationUpdater: AmendRegistrationUpdateService
+                                                                       authenticate: EnrolledAuthAction,
+                                                                       journeyAction: AmendmentJourneyAction,
+                                                                       addressCaptureService: AddressCaptureService,
+                                                                       mcc: MessagesControllerComponents,
+                                                                       registrationUpdater: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsConfirmAddressControllerBase(authenticate, journeyAction, addressCaptureService, mcc, registrationUpdater) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsEmailAddressController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.ContactDetailsEmailAddressControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -28,11 +28,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberContactDetailsEmailAddressController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_email_address_page,
-  registrationUpdater: AmendRegistrationUpdateService
+                                                                     authenticate: EnrolledAuthAction,
+                                                                     journeyAction: AmendmentJourneyAction,
+                                                                     mcc: MessagesControllerComponents,
+                                                                     page: member_email_address_page,
+                                                                     registrationUpdater: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsEmailAddressControllerBase(authenticate, journeyAction, mcc, page, registrationUpdater) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsNameController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.ContactDetailsNameControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -28,11 +28,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberContactDetailsNameController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_name_page,
-  registrationUpdater: AmendRegistrationUpdateService
+                                                             authenticate: EnrolledAuthAction,
+                                                             journeyAction: AmendmentJourneyAction,
+                                                             mcc: MessagesControllerComponents,
+                                                             page: member_name_page,
+                                                             registrationUpdater: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsNameControllerBase(authenticate, journeyAction, mcc, page, registrationUpdater) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsTelephoneNumberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsTelephoneNumberController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.ContactDetailsTelephoneNumberControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -28,11 +28,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberContactDetailsTelephoneNumberController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_phone_number_page,
-  registrationUpdater: AmendRegistrationUpdateService
+                                                                        authenticate: EnrolledAuthAction,
+                                                                        journeyAction: AmendmentJourneyAction,
+                                                                        mcc: MessagesControllerComponents,
+                                                                        page: member_phone_number_page,
+                                                                        registrationUpdater: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsTelephoneNumberControllerBase(authenticate, journeyAction, mcc, page, registrationUpdater) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberGrsController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.GroupMemberGrsControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -30,14 +30,14 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberGrsController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  ukCompanyGrsConnector: UkCompanyGrsConnector,
-  subscriptionsConnector: SubscriptionsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  registrationUpdater: AmendRegistrationUpdateService,
-  addressConversionUtils: AddressConversionUtils,
-  mcc: MessagesControllerComponents
+                                              authenticate: EnrolledAuthAction,
+                                              journeyAction: AmendmentJourneyAction,
+                                              ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                              subscriptionsConnector: SubscriptionsConnector,
+                                              partnershipGrsConnector: PartnershipGrsConnector,
+                                              registrationUpdater: AmendRegistrationUpdateService,
+                                              addressConversionUtils: AddressConversionUtils,
+                                              mcc: MessagesControllerComponents
 )(implicit val executionContext: ExecutionContext)
     extends GroupMemberGrsControllerBase(
       authenticate,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberOrganisationDetailsTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberOrganisationDetailsTypeController.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.OrganisationDetailsTypeControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -36,17 +36,17 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddGroupMemberOrganisationDetailsTypeController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  appConfig: AppConfig,
-  page: organisation_type,
-  registrationUpdater: AmendRegistrationUpdateService,
-  val soleTraderGrsConnector: SoleTraderGrsConnector,
-  val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  val partnershipGrsConnector: PartnershipGrsConnector,
-  val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  val registrationConnector: RegistrationConnector
+                                                                  authenticate: EnrolledAuthAction,
+                                                                  journeyAction: AmendmentJourneyAction,
+                                                                  mcc: MessagesControllerComponents,
+                                                                  appConfig: AppConfig,
+                                                                  page: organisation_type,
+                                                                  registrationUpdater: AmendRegistrationUpdateService,
+                                                                  val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                                                  val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                                                  val partnershipGrsConnector: PartnershipGrsConnector,
+                                                                  val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                                                  val registrationConnector: RegistrationConnector
 )(implicit ec: ExecutionContext)
     extends OrganisationDetailsTypeControllerBase(authenticate, journeyAction, appConfig, page, registrationUpdater, mcc) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AmendMemberContactDetailsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AmendMemberContactDetailsController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.data.Form
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.{
   AmendmentController,
   routes => amendRoutes
@@ -45,13 +45,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AmendMemberContactDetailsController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  addressCaptureService: AddressCaptureService,
-  contactNamePage: member_name_page,
-  phoneNumberPage: member_phone_number_page,
-  emailAddressPage: member_email_address_page
+                                                      authenticate: EnrolledAuthAction,
+                                                      mcc: MessagesControllerComponents,
+                                                      amendmentJourneyAction: AmendmentJourneyAction,
+                                                      addressCaptureService: AddressCaptureService,
+                                                      contactNamePage: member_name_page,
+                                                      phoneNumberPage: member_phone_number_page,
+                                                      emailAddressPage: member_email_address_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.AmendmentController
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.RemoveMemberAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.RemoveMember
@@ -35,10 +35,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmRemoveMemberController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: confirm_remove_member_page
+                                                authenticate: EnrolledAuthAction,
+                                                amendmentJourneyAction: AmendmentJourneyAction,
+                                                mcc: MessagesControllerComponents,
+                                                page: confirm_remove_member_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) with I18nSupport
     with RemoveMemberAction {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ContactDetailsCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ContactDetailsCheckAnswersController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.AmendmentController
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.group.member_contact_check_answers_page
@@ -27,10 +27,10 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class ContactDetailsCheckAnswersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_contact_check_answers_page
+                                                       authenticate: EnrolledAuthAction,
+                                                       amendmentJourneyAction: AmendmentJourneyAction,
+                                                       mcc: MessagesControllerComponents,
+                                                       page: member_contact_check_answers_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/GroupMembersListController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/GroupMembersListController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.AddOrganisationForm
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -30,10 +30,10 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class GroupMembersListController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: list_group_members_page
+                                             authenticate: EnrolledAuthAction,
+                                             amendmentJourneyAction: AmendmentJourneyAction,
+                                             mcc: MessagesControllerComponents,
+                                             page: list_group_members_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ManageGroupMembersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ManageGroupMembersController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.group
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.group.manage_group_members_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -27,10 +27,10 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class ManageGroupMembersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: manage_group_members_page
+                                               authenticate: EnrolledAuthAction,
+                                               amendmentJourneyAction: AmendmentJourneyAction,
+                                               mcc: MessagesControllerComponents,
+                                               page: manage_group_members_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsCheckAnswersController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partner
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.{AmendmentController, routes => amendRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.{
@@ -31,10 +31,10 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddPartnerContactDetailsCheckAnswersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: amend_add_partner_contact_check_answers_page
+                                                                 authenticate: EnrolledAuthAction,
+                                                                 journeyAction: AmendmentJourneyAction,
+                                                                 mcc: MessagesControllerComponents,
+                                                                 page: amend_add_partner_contact_check_answers_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, journeyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsConfirmAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsConfirmAddressController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partn
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   AmendRegistrationUpdateService,
@@ -36,11 +36,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddPartnerContactDetailsConfirmAddressController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents,
-  registrationUpdater: AmendRegistrationUpdateService
+                                                                   authenticate: EnrolledAuthAction,
+                                                                   journeyAction: AmendmentJourneyAction,
+                                                                   addressCaptureService: AddressCaptureService,
+                                                                   mcc: MessagesControllerComponents,
+                                                                   registrationUpdater: AmendRegistrationUpdateService
 )(implicit val ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsEmailAddressController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partner
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerEmailAddressControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.EmailAddressPasscode
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
@@ -38,15 +38,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AddPartnerContactDetailsEmailAddressController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: partner_email_address_page,
-  val emailPasscodePage: email_address_passcode_page,
-  val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
-  val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
-  registrationUpdateService: AmendRegistrationUpdateService,
-  val emailVerificationService: EmailVerificationService
+                                                                 authenticate: EnrolledAuthAction,
+                                                                 journeyAction: AmendmentJourneyAction,
+                                                                 mcc: MessagesControllerComponents,
+                                                                 page: partner_email_address_page,
+                                                                 val emailPasscodePage: email_address_passcode_page,
+                                                                 val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
+                                                                 val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
+                                                                 registrationUpdateService: AmendRegistrationUpdateService,
+                                                                 val emailVerificationService: EmailVerificationService
 )(implicit ec: ExecutionContext)
     extends PartnerEmailAddressControllerBase(authenticate = authenticate,
                                               journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsNameController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partner
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerContactNameControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{
@@ -31,11 +31,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddPartnerContactDetailsNameController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: partner_member_name_page,
-  registrationUpdateService: AmendRegistrationUpdateService
+                                                         authenticate: EnrolledAuthAction,
+                                                         journeyAction: AmendmentJourneyAction,
+                                                         mcc: MessagesControllerComponents,
+                                                         page: partner_member_name_page,
+                                                         registrationUpdateService: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends PartnerContactNameControllerBase(authenticate = authenticate,
                                              journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsTelephoneNumberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsTelephoneNumberController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partner
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerPhoneNumberControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -28,11 +28,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddPartnerContactDetailsTelephoneNumberController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: partner_phone_number_page,
-  registrationUpdateService: AmendRegistrationUpdateService
+                                                                    authenticate: EnrolledAuthAction,
+                                                                    journeyAction: AmendmentJourneyAction,
+                                                                    mcc: MessagesControllerComponents,
+                                                                    page: partner_phone_number_page,
+                                                                    registrationUpdateService: AmendRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends PartnerPhoneNumberControllerBase(authenticate = authenticate,
                                              journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerGrsController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerGrsControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -34,15 +34,15 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddPartnerGrsController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  ukCompanyGrsConnector: UkCompanyGrsConnector,
-  soleTraderGrsConnector: SoleTraderGrsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  registrationUpdater: AmendRegistrationUpdateService,
-  subscriptionsConnector: SubscriptionsConnector,
-  mcc: MessagesControllerComponents
+                                          authenticate: EnrolledAuthAction,
+                                          journeyAction: AmendmentJourneyAction,
+                                          ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                          soleTraderGrsConnector: SoleTraderGrsConnector,
+                                          partnershipGrsConnector: PartnershipGrsConnector,
+                                          registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                          registrationUpdater: AmendRegistrationUpdateService,
+                                          subscriptionsConnector: SubscriptionsConnector,
+                                          mcc: MessagesControllerComponents
 )(implicit val executionContext: ExecutionContext)
     extends PartnerGrsControllerBase(authenticate = authenticate,
                                      journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerNameController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerNameControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -35,16 +35,16 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class AddPartnerNameController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  override val appConfig: AppConfig,
-  ukCompanyGrsConnector: UkCompanyGrsConnector,
-  soleTraderGrsConnector: SoleTraderGrsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  registrationUpdater: AmendRegistrationUpdateService,
-  mcc: MessagesControllerComponents,
-  page: partner_name_page
+                                           authenticate: EnrolledAuthAction,
+                                           journeyAction: AmendmentJourneyAction,
+                                           override val appConfig: AppConfig,
+                                           ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                           soleTraderGrsConnector: SoleTraderGrsConnector,
+                                           partnershipGrsConnector: PartnershipGrsConnector,
+                                           registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                           registrationUpdater: AmendRegistrationUpdateService,
+                                           mcc: MessagesControllerComponents,
+                                           page: partner_name_page
 )(implicit val executionContext: ExecutionContext)
     extends PartnerNameControllerBase(authenticate = authenticate,
                                       journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerOrganisationDetailsTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerOrganisationDetailsTypeController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.PartnerTypeControllerBase
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.AmendRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
@@ -35,16 +35,16 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AddPartnerOrganisationDetailsTypeController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: AmendmentJourneyAction,
-  registrationUpdater: AmendRegistrationUpdateService,
-  mcc: MessagesControllerComponents,
-  page: partner_type,
-  val appConfig: AppConfig,
-  val soleTraderGrsConnector: SoleTraderGrsConnector,
-  val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  val partnershipGrsConnector: PartnershipGrsConnector
+                                                              authenticate: EnrolledAuthAction,
+                                                              journeyAction: AmendmentJourneyAction,
+                                                              registrationUpdater: AmendRegistrationUpdateService,
+                                                              mcc: MessagesControllerComponents,
+                                                              page: partner_type,
+                                                              val appConfig: AppConfig,
+                                                              val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                                              val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                                              val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                                              val partnershipGrsConnector: PartnershipGrsConnector
 )(implicit ec: ExecutionContext)
     extends PartnerTypeControllerBase(authenticate,
                                       journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AmendPartnerContactDetailsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AmendPartnerContactDetailsController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partn
 
 import play.api.data.Form
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.{AmendmentController, routes => amendmentRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{AddressLookupIntegration, EmailVerificationActions}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.{EmailAddress, EmailAddressPasscode, JobTitle, PhoneNumber}
@@ -35,19 +35,19 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class AmendPartnerContactDetailsController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  contactNamePage: partner_member_name_page,
-  contactEmailPage: partner_email_address_page,
-  val emailPasscodePage: email_address_passcode_page,
-  val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
-  val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
-  val registrationUpdater: AmendRegistrationUpdateService,
-  val emailVerificationService: EmailVerificationService,
-  contactPhoneNumberPage: partner_phone_number_page,
-  jobTitlePage: partner_job_title_page,
-  addressCaptureService: AddressCaptureService
+                                                       authenticate: EnrolledAuthAction,
+                                                       mcc: MessagesControllerComponents,
+                                                       amendmentJourneyAction: AmendmentJourneyAction,
+                                                       contactNamePage: partner_member_name_page,
+                                                       contactEmailPage: partner_email_address_page,
+                                                       val emailPasscodePage: email_address_passcode_page,
+                                                       val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
+                                                       val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
+                                                       val registrationUpdater: AmendRegistrationUpdateService,
+                                                       val emailVerificationService: EmailVerificationService,
+                                                       contactPhoneNumberPage: partner_phone_number_page,
+                                                       jobTitlePage: partner_job_title_page,
+                                                       addressCaptureService: AddressCaptureService
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) with AddressLookupIntegration with EmailVerificationActions {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ConfirmRemovePartnerController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ConfirmRemovePartnerController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partn
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.AmendmentController
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.RemovePartner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Registration
@@ -34,10 +34,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmRemovePartnerController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: confirm_remove_partner_page
+                                                 authenticate: EnrolledAuthAction,
+                                                 amendmentJourneyAction: AmendmentJourneyAction,
+                                                 mcc: MessagesControllerComponents,
+                                                 page: confirm_remove_partner_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ManagePartnersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ManagePartnersController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partn
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.partner.manage_partners_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -27,10 +27,10 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class ManagePartnersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: manage_partners_page
+                                           authenticate: EnrolledAuthAction,
+                                           amendmentJourneyAction: AmendmentJourneyAction,
+                                           mcc: MessagesControllerComponents,
+                                           page: manage_partners_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnerContactDetailsCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnerContactDetailsCheckAnswersController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partner
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.AmendmentController
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.partner.amend_partner_contact_check_answers_page
@@ -27,10 +27,10 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class PartnerContactDetailsCheckAnswersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: amend_partner_contact_check_answers_page
+                                                              authenticate: EnrolledAuthAction,
+                                                              amendmentJourneyAction: AmendmentJourneyAction,
+                                                              mcc: MessagesControllerComponents,
+                                                              page: amend_partner_contact_check_answers_page
 )(implicit ec: ExecutionContext)
     extends AmendmentController(mcc, amendmentJourneyAction) {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnersListController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnersListController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.amendment.partn
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.AddOrganisationForm
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.AmendmentJourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.amendment.partner.list_partners_page
@@ -28,10 +28,10 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class PartnersListController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  amendmentJourneyAction: AmendmentJourneyAction,
-  mcc: MessagesControllerComponents,
-  page: list_partners_page
+                                         authenticate: EnrolledAuthAction,
+                                         amendmentJourneyAction: AmendmentJourneyAction,
+                                         mcc: MessagesControllerComponents,
+                                         page: list_partners_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsAddressController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   Cacheable,
@@ -38,11 +38,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ContactDetailsAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents
+                                                  authenticate: NotEnrolledAuthAction,
+                                                  journeyAction: JourneyAction,
+                                                  override val registrationConnector: RegistrationConnector,
+                                                  addressCaptureService: AddressCaptureService,
+                                                  mcc: MessagesControllerComponents
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsCheckAnswersController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.contact.check_primary_contact_details_page
@@ -28,10 +28,10 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class ContactDetailsCheckAnswersController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: check_primary_contact_details_page
+                                                       authenticate: NotEnrolledAuthAction,
+                                                       journeyAction: JourneyAction,
+                                                       mcc: MessagesControllerComponents,
+                                                       page: check_primary_contact_details_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsConfirmAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsConfirmAddressController.scala
@@ -21,7 +21,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -37,11 +37,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ContactDetailsConfirmAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: confirm_address
+                                                         authenticate: NotEnrolledAuthAction,
+                                                         journeyAction: JourneyAction,
+                                                         override val registrationConnector: RegistrationConnector,
+                                                         mcc: MessagesControllerComponents,
+                                                         page: confirm_address
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressController.scala
@@ -22,7 +22,7 @@ import play.api.mvc._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -45,12 +45,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ContactDetailsEmailAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  emailVerificationService: EmailVerificationService,
-  mcc: MessagesControllerComponents,
-  page: email_address_page
+                                                       authenticate: NotEnrolledAuthAction,
+                                                       journeyAction: JourneyAction,
+                                                       override val registrationConnector: RegistrationConnector,
+                                                       emailVerificationService: EmailVerificationService,
+                                                       mcc: MessagesControllerComponents,
+                                                       page: email_address_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeConfirmationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeConfirmationController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.contact
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.contact.email_address_passcode_confirmation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -27,10 +27,10 @@ import play.api.i18n.Messages
 import javax.inject.Inject
 
 class ContactDetailsEmailAddressPasscodeConfirmationController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: email_address_passcode_confirmation_page
+                                                                           authenticate: NotEnrolledAuthAction,
+                                                                           journeyAction: JourneyAction,
+                                                                           mcc: MessagesControllerComponents,
+                                                                           page: email_address_passcode_confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsEmailAddressPasscodeController.scala
@@ -22,7 +22,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   Continue => ContinueAction
 }
@@ -47,12 +47,12 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ContactDetailsEmailAddressPasscodeController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  emailVerificationService: EmailVerificationService,
-  override val registrationConnector: RegistrationConnector,
-  page: email_address_passcode_page
+                                                               authenticate: NotEnrolledAuthAction,
+                                                               journeyAction: JourneyAction,
+                                                               mcc: MessagesControllerComponents,
+                                                               emailVerificationService: EmailVerificationService,
+                                                               override val registrationConnector: RegistrationConnector,
+                                                               page: email_address_passcode_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsFullNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsFullNameController.scala
@@ -21,7 +21,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -37,11 +37,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ContactDetailsFullNameController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: full_name_page
+                                                   authenticate: NotEnrolledAuthAction,
+                                                   journeyAction: JourneyAction,
+                                                   override val registrationConnector: RegistrationConnector,
+                                                   mcc: MessagesControllerComponents,
+                                                   page: full_name_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsJobTitleController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsJobTitleController.scala
@@ -21,7 +21,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -37,11 +37,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ContactDetailsJobTitleController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: job_title_page
+                                                   authenticate: NotEnrolledAuthAction,
+                                                   journeyAction: JourneyAction,
+                                                   override val registrationConnector: RegistrationConnector,
+                                                   mcc: MessagesControllerComponents,
+                                                   page: job_title_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsTelephoneNumberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/contact/ContactDetailsTelephoneNumberController.scala
@@ -21,7 +21,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -37,11 +37,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ContactDetailsTelephoneNumberController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: phone_number_page
+                                                          authenticate: NotEnrolledAuthAction,
+                                                          journeyAction: JourneyAction,
+                                                          override val registrationConnector: RegistrationConnector,
+                                                          mcc: MessagesControllerComponents,
+                                                          page: phone_number_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterCheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterCheckYourAnswersController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.deregistration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DeregistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.DeregistrationDetailRepository
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.deregistration.deregister_check_your_answers_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -29,11 +29,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class DeregisterCheckYourAnswersController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  deregistrationDetailRepository: DeregistrationDetailRepository,
-  deregistrationConnector: DeregistrationConnector,
-  page: deregister_check_your_answers_page
+                                                       authenticate: EnrolledAuthAction,
+                                                       mcc: MessagesControllerComponents,
+                                                       deregistrationDetailRepository: DeregistrationDetailRepository,
+                                                       deregistrationConnector: DeregistrationConnector,
+                                                       page: deregister_check_your_answers_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.deregistration.DeregisterForm
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.DeregistrationDetailRepository
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.deregistration.deregister_page
@@ -31,11 +31,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class DeregisterController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  deregistrationDetailRepository: DeregistrationDetailRepository,
-  appConfig: AppConfig,
-  page: deregister_page
+                                       authenticate: EnrolledAuthAction,
+                                       mcc: MessagesControllerComponents,
+                                       deregistrationDetailRepository: DeregistrationDetailRepository,
+                                       appConfig: AppConfig,
+                                       page: deregister_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterReasonController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterReasonController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.deregistration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.deregistration.DeregisterReasonForm
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.DeregistrationDetailRepository
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.deregistration.deregister_reason_page
@@ -30,10 +30,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class DeregisterReasonController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  deregistrationDetailRepository: DeregistrationDetailRepository,
-  page: deregister_reason_page
+                                             authenticate: EnrolledAuthAction,
+                                             mcc: MessagesControllerComponents,
+                                             deregistrationDetailRepository: DeregistrationDetailRepository,
+                                             page: deregister_reason_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregistrationSubmittedController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregistrationSubmittedController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.deregistration
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.deregistration.deregistration_submitted_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -27,9 +27,9 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class DeregistrationSubmittedController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  page: deregistration_submitted_page
+                                                    authenticate: EnrolledAuthAction,
+                                                    mcc: MessagesControllerComponents,
+                                                    page: deregistration_submitted_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/CheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/CheckAnswersController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.enrolment.UserEnrolmentConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.{
   EnrolmentFailureCode,
   UserEnrolmentFailedResponse,
@@ -34,11 +34,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class CheckAnswersController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  cache: UserEnrolmentDetailsRepository,
-  userEnrolmentConnector: UserEnrolmentConnector,
-  page: check_answers_page
+                                         authenticate: NotEnrolledAuthAction,
+                                         mcc: MessagesControllerComponents,
+                                         cache: UserEnrolmentDetailsRepository,
+                                         userEnrolmentConnector: UserEnrolmentConnector,
+                                         page: check_answers_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationController.scala
@@ -19,15 +19,15 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.EnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.confirmation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 @Singleton
 class ConfirmationController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  mcc: MessagesControllerComponents,
-  page: confirmation_page
+                                         authenticate: EnrolledAuthAction,
+                                         mcc: MessagesControllerComponents,
+                                         page: confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/IsUkAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/IsUkAddressController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.enrolment.IsUkAddress
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.UserEnrolmentDetailsRepository
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.is_uk_address_page
@@ -30,10 +30,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class IsUkAddressController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  cache: UserEnrolmentDetailsRepository,
-  page: is_uk_address_page
+                                        authenticate: NotEnrolledAuthAction,
+                                        mcc: MessagesControllerComponents,
+                                        cache: UserEnrolmentDetailsRepository,
+                                        page: is_uk_address_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/NotableErrorController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/NotableErrorController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.{
   reference_number_already_used_failure_page,
   verification_failure_page
@@ -28,10 +28,10 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import javax.inject.Inject
 
 class NotableErrorController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  verificationFailurePage: verification_failure_page,
-  referenceNumberAlreadyUsedPage: reference_number_already_used_failure_page
+                                         authenticate: NotEnrolledAuthAction,
+                                         mcc: MessagesControllerComponents,
+                                         verificationFailurePage: verification_failure_page,
+                                         referenceNumberAlreadyUsedPage: reference_number_already_used_failure_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def enrolmentVerificationFailurePage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/PostcodeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/PostcodeController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.enrolment.Postcode
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.UserEnrolmentDetailsRepository
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.postcode_page
@@ -30,10 +30,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PostcodeController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  cache: UserEnrolmentDetailsRepository,
-  page: postcode_page
+                                     authenticate: NotEnrolledAuthAction,
+                                     mcc: MessagesControllerComponents,
+                                     cache: UserEnrolmentDetailsRepository,
+                                     page: postcode_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/PptReferenceController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/PptReferenceController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.enrolment.PptReference
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.UserEnrolmentDetailsRepository
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.ppt_reference_page
@@ -30,10 +30,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PptReferenceController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  cache: UserEnrolmentDetailsRepository,
-  page: ppt_reference_page
+                                         authenticate: NotEnrolledAuthAction,
+                                         mcc: MessagesControllerComponents,
+                                         cache: UserEnrolmentDetailsRepository,
+                                         page: ppt_reference_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/RegistrationDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/RegistrationDateController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.enrolment.RegistrationDate
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.UserEnrolmentDetails
 import uk.gov.hmrc.plasticpackagingtax.registration.repositories.UserEnrolmentDetailsRepository
@@ -31,10 +31,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class RegistrationDateController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  cache: UserEnrolmentDetailsRepository,
-  page: registration_date_page
+                                             authenticate: NotEnrolledAuthAction,
+                                             mcc: MessagesControllerComponents,
+                                             cache: UserEnrolmentDetailsRepository,
+                                             page: registration_date_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/VerifyOrganisationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/VerifyOrganisationController.scala
@@ -18,16 +18,16 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.enrolment
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.enrolment.verify_organisation_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Inject
 
 class VerifyOrganisationController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  page: verify_organisation_page
+                                               authenticate: NotEnrolledAuthAction,
+                                               mcc: MessagesControllerComponents,
+                                               page: verify_organisation_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ConfirmBusinessAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ConfirmBusinessAddressController.scala
@@ -20,7 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType.{OVERSEAS_COMPANY_UK_BRANCH, OrgType}
@@ -35,12 +35,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmBusinessAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents,
-  page: confirm_business_address
+                                                   authenticate: NotEnrolledAuthAction,
+                                                   journeyAction: JourneyAction,
+                                                   override val registrationConnector: RegistrationConnector,
+                                                   addressCaptureService: AddressCaptureService,
+                                                   mcc: MessagesControllerComponents,
+                                                   page: confirm_business_address
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsCheckAnswersController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.member_contact_check_answers_page
@@ -29,11 +29,11 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class ContactDetailsCheckAnswersController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: member_contact_check_answers_page
+                                                       authenticate: NotEnrolledAuthAction,
+                                                       journeyAction: JourneyAction,
+                                                       override val registrationConnector: RegistrationConnector,
+                                                       mcc: MessagesControllerComponents,
+                                                       page: member_contact_check_answers_page
 ) extends FrontendController(mcc) with Cacheable with I18nSupport {
 
   def displayPage(memberId: String): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsConfirmAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsConfirmAddressController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.services.AddressCaptureService
@@ -27,11 +27,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class ContactDetailsConfirmAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents,
-  registrationUpdater: NewRegistrationUpdateService
+                                                         authenticate: NotEnrolledAuthAction,
+                                                         journeyAction: JourneyAction,
+                                                         addressCaptureService: AddressCaptureService,
+                                                         mcc: MessagesControllerComponents,
+                                                         registrationUpdater: NewRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsConfirmAddressControllerBase(authenticate,
                                                        journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsEmailAddressController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.member_email_address_page
@@ -27,11 +27,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class ContactDetailsEmailAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_email_address_page,
-  registrationUpdater: NewRegistrationUpdateService
+                                                       authenticate: NotEnrolledAuthAction,
+                                                       journeyAction: JourneyAction,
+                                                       mcc: MessagesControllerComponents,
+                                                       page: member_email_address_page,
+                                                       registrationUpdater: NewRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsEmailAddressControllerBase(authenticate,
                                                      journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsNameController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.member_name_page
@@ -27,11 +27,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class ContactDetailsNameController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_name_page,
-  registrationUpdater: NewRegistrationUpdateService
+                                               authenticate: NotEnrolledAuthAction,
+                                               journeyAction: JourneyAction,
+                                               mcc: MessagesControllerComponents,
+                                               page: member_name_page,
+                                               registrationUpdater: NewRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsNameControllerBase(authenticate,
                                              journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsTelephoneNumberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/ContactDetailsTelephoneNumberController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.member_phone_number_page
@@ -27,11 +27,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class ContactDetailsTelephoneNumberController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: member_phone_number_page,
-  registrationUpdater: NewRegistrationUpdateService
+                                                          authenticate: NotEnrolledAuthAction,
+                                                          journeyAction: JourneyAction,
+                                                          mcc: MessagesControllerComponents,
+                                                          page: member_phone_number_page,
+                                                          registrationUpdater: NewRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends ContactDetailsTelephoneNumberControllerBase(authenticate,
                                                         journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/GroupMemberGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/GroupMemberGrsController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.utils.AddressConversionUtils
@@ -29,14 +29,14 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class GroupMemberGrsController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  ukCompanyGrsConnector: UkCompanyGrsConnector,
-  subscriptionsConnector: SubscriptionsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  registrationUpdater: NewRegistrationUpdateService,
-  addressConversionUtils: AddressConversionUtils,
-  mcc: MessagesControllerComponents
+                                           authenticate: NotEnrolledAuthAction,
+                                           journeyAction: JourneyAction,
+                                           ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                           subscriptionsConnector: SubscriptionsConnector,
+                                           partnershipGrsConnector: PartnershipGrsConnector,
+                                           registrationUpdater: NewRegistrationUpdateService,
+                                           addressConversionUtils: AddressConversionUtils,
+                                           mcc: MessagesControllerComponents
 )(implicit val executionContext: ExecutionContext)
     extends GroupMemberGrsControllerBase(
       authenticate,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorController.scala
@@ -18,26 +18,21 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.group
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthNoEnrolmentCheckAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.PermissiveAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
-import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.{
-  group_member_already_registered_page,
-  nominated_organisation_already_registered_page,
-  organisation_already_in_group_page
-}
+import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.{group_member_already_registered_page, nominated_organisation_already_registered_page, organisation_already_in_group_page}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-
 import javax.inject.{Inject, Singleton}
 
 @Singleton
 class NotableErrorController @Inject() (
-  authenticate: AuthNoEnrolmentCheckAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  nominatedOrganisationAlreadyRegisteredPage: nominated_organisation_already_registered_page,
-  organisationAlreadyInGroupPage: organisation_already_in_group_page,
-  groupMemberAlreadyRegisteredPage: group_member_already_registered_page
+                                         authenticate: PermissiveAuthAction,
+                                         journeyAction: JourneyAction,
+                                         mcc: MessagesControllerComponents,
+                                         nominatedOrganisationAlreadyRegisteredPage: nominated_organisation_already_registered_page,
+                                         organisationAlreadyInGroupPage: organisation_already_in_group_page,
+                                         groupMemberAlreadyRegisteredPage: group_member_already_registered_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def nominatedOrganisationAlreadyRegistered(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationDetailsTypeController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.group.organisation_type
@@ -34,16 +34,16 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class OrganisationDetailsTypeController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  appConfig: AppConfig,
-  page: organisation_type,
-  registrationUpdater: NewRegistrationUpdateService,
-  val soleTraderGrsConnector: SoleTraderGrsConnector,
-  val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  val partnershipGrsConnector: PartnershipGrsConnector,
-  val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector
+                                                    authenticate: NotEnrolledAuthAction,
+                                                    journeyAction: JourneyAction,
+                                                    mcc: MessagesControllerComponents,
+                                                    appConfig: AppConfig,
+                                                    page: organisation_type,
+                                                    registrationUpdater: NewRegistrationUpdateService,
+                                                    val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                                    val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                                    val partnershipGrsConnector: PartnershipGrsConnector,
+                                                    val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector
 )(implicit ec: ExecutionContext)
     extends OrganisationDetailsTypeControllerBase(authenticate,
                                                   journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationListController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/OrganisationListController.scala
@@ -22,7 +22,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -35,11 +35,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 @Singleton
 class OrganisationListController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: organisation_list
+                                             authenticate: NotEnrolledAuthAction,
+                                             journeyAction: JourneyAction,
+                                             override val registrationConnector: RegistrationConnector,
+                                             mcc: MessagesControllerComponents,
+                                             page: organisation_list
 ) extends FrontendController(mcc) with Cacheable with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/RemoveMemberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/RemoveMemberController.scala
@@ -21,7 +21,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.group.RemoveMember
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -33,11 +33,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class RemoveMemberController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: remove_group_member_page
+                                         authenticate: NotEnrolledAuthAction,
+                                         journeyAction: JourneyAction,
+                                         override val registrationConnector: RegistrationConnector,
+                                         mcc: MessagesControllerComponents,
+                                         page: remove_group_member_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport with RemoveMemberAction {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/CheckLiabilityDetailsAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/CheckLiabilityDetailsAnswersController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.RegType
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -29,10 +29,10 @@ import scala.concurrent.Future
 
 @Singleton
 class CheckLiabilityDetailsAnswersController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: check_liability_details_answers_page
+                                                         authenticate: NotEnrolledAuthAction,
+                                                         journeyAction: JourneyAction,
+                                                         mcc: MessagesControllerComponents,
+                                                         page: check_liability_details_answers_page
 ) extends LiabilityController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExceededThresholdWeightController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExceededThresholdWeightController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.ExceededThresholdWeight
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -31,11 +31,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ExceededThresholdWeightController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: exceeded_threshold_weight_page
+                                                    authenticate: NotEnrolledAuthAction,
+                                                    journeyAction: JourneyAction,
+                                                    override val registrationConnector: RegistrationConnector,
+                                                    mcc: MessagesControllerComponents,
+                                                    page: exceeded_threshold_weight_page
 )(implicit ec: ExecutionContext)
     extends LiabilityController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExceededThresholdWeightDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExceededThresholdWeightDateController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.Date
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.ExceededThresholdWeightDate
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
@@ -33,12 +33,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ExceededThresholdWeightDateController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: exceeded_threshold_weight_date_page,
-  exceededThresholdWeightDate: ExceededThresholdWeightDate
+                                                        authenticate: NotEnrolledAuthAction,
+                                                        journeyAction: JourneyAction,
+                                                        override val registrationConnector: RegistrationConnector,
+                                                        mcc: MessagesControllerComponents,
+                                                        page: exceeded_threshold_weight_date_page,
+                                                        exceededThresholdWeightDate: ExceededThresholdWeightDate
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExpectToExceedThresholdWeightController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExpectToExceedThresholdWeightController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.ExpectToExceedThresholdWeight
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -31,11 +31,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ExpectToExceedThresholdWeightController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: expect_to_exceed_threshold_weight_page
+                                                          authenticate: NotEnrolledAuthAction,
+                                                          journeyAction: JourneyAction,
+                                                          override val registrationConnector: RegistrationConnector,
+                                                          mcc: MessagesControllerComponents,
+                                                          page: expect_to_exceed_threshold_weight_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExpectToExceedThresholdWeightDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/ExpectToExceedThresholdWeightDateController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.Date
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.ExpectToExceedThresholdWeightDate
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
@@ -32,12 +32,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ExpectToExceedThresholdWeightDateController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  expectToExceedThresholdWeightDate: ExpectToExceedThresholdWeightDate,
-  page: expect_to_exceed_threshold_weight_date_page
+                                                              authenticate: NotEnrolledAuthAction,
+                                                              journeyAction: JourneyAction,
+                                                              override val registrationConnector: RegistrationConnector,
+                                                              mcc: MessagesControllerComponents,
+                                                              expectToExceedThresholdWeightDate: ExpectToExceedThresholdWeightDate,
+                                                              page: expect_to_exceed_threshold_weight_date_page
 )(implicit ec: ExecutionContext)
     extends LiabilityController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/LiabilityWeightController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/LiabilityWeightController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.LiabilityWeight
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -31,11 +31,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class LiabilityWeightController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: liability_weight_page
+                                            authenticate: NotEnrolledAuthAction,
+                                            journeyAction: JourneyAction,
+                                            override val registrationConnector: RegistrationConnector,
+                                            mcc: MessagesControllerComponents,
+                                            page: liability_weight_page
 )(implicit ec: ExecutionContext)
     extends LiabilityController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/MembersUnderGroupControlController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/MembersUnderGroupControlController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.MembersUnderGroupControl
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{
   Cacheable,
@@ -36,11 +36,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class MembersUnderGroupControlController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  journeyAction: JourneyAction,
-  page: members_under_group_control_page,
-  override val registrationConnector: RegistrationConnector
+                                                     authenticate: NotEnrolledAuthAction,
+                                                     mcc: MessagesControllerComponents,
+                                                     journeyAction: JourneyAction,
+                                                     page: members_under_group_control_page,
+                                                     override val registrationConnector: RegistrationConnector
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/NotLiableController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/NotLiableController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.not_liable
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -26,9 +26,9 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class NotLiableController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  page: not_liable
+                                      authenticate: NotEnrolledAuthAction,
+                                      mcc: MessagesControllerComponents,
+                                      page: not_liable
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/NotMembersUnderGroupControlController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/NotMembersUnderGroupControlController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.liability.not_members_under_group_control_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -27,10 +27,10 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class NotMembersUnderGroupControlController @Inject() (
-  authenticate: AuthAction,
-  mcc: MessagesControllerComponents,
-  journeyAction: JourneyAction,
-  page: not_members_under_group_control_page
+                                                        authenticate: NotEnrolledAuthAction,
+                                                        mcc: MessagesControllerComponents,
+                                                        journeyAction: JourneyAction,
+                                                        page: not_members_under_group_control_page
 ) extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/RegistrationTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/RegistrationTypeController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.liability.{RegType, RegistrationType}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -30,11 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class RegistrationTypeController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: registration_type_page
+                                             authenticate: NotEnrolledAuthAction,
+                                             journeyAction: JourneyAction,
+                                             override val registrationConnector: RegistrationConnector,
+                                             mcc: MessagesControllerComponents,
+                                             page: registration_type_page
 )(implicit ec: ExecutionContext)
     extends LiabilityController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/TaxStartDateController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/liability/TaxStartDateController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.liability
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.OldDate
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -33,12 +33,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class TaxStartDateController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  taxStarDateService: TaxStartDateService,
-  mcc: MessagesControllerComponents,
-  page: tax_start_date_page,
-  override val registrationConnector: RegistrationConnector
+                                         authenticate: NotEnrolledAuthAction,
+                                         journeyAction: JourneyAction,
+                                         taxStarDateService: TaxStartDateService,
+                                         mcc: MessagesControllerComponents,
+                                         page: tax_start_date_page,
+                                         override val registrationConnector: RegistrationConnector
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/CheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/CheckAnswersController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.check_answers_page
@@ -29,11 +29,11 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class CheckAnswersController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: check_answers_page
+                                         authenticate: NotEnrolledAuthAction,
+                                         journeyAction: JourneyAction,
+                                         override val registrationConnector: RegistrationConnector,
+                                         mcc: MessagesControllerComponents,
+                                         page: check_answers_page
 ) extends FrontendController(mcc) with Cacheable with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/ConfirmBusinessAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/ConfirmBusinessAddressController.scala
@@ -20,7 +20,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType.{OVERSEAS_COMPANY_UK_BRANCH, OrgType}
@@ -35,12 +35,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfirmBusinessAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents,
-  page: confirm_business_address
+                                                   authenticate: NotEnrolledAuthAction,
+                                                   journeyAction: JourneyAction,
+                                                   override val registrationConnector: RegistrationConnector,
+                                                   addressCaptureService: AddressCaptureService,
+                                                   mcc: MessagesControllerComponents,
+                                                   page: confirm_business_address
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/GrsController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.group.{routes => groupRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.RegistrationStatus.{
   BUSINESS_VERIFICATION_FAILED,
@@ -63,16 +63,16 @@ object RegistrationStatus extends Enumeration {
 
 @Singleton
 class GrsController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  ukCompanyGrsConnector: UkCompanyGrsConnector,
-  soleTraderGrsConnector: SoleTraderGrsConnector,
-  registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  subscriptionsConnector: SubscriptionsConnector,
-  addressConversionUtils: AddressConversionUtils,
-  mcc: MessagesControllerComponents
+                                authenticate: NotEnrolledAuthAction,
+                                journeyAction: JourneyAction,
+                                override val registrationConnector: RegistrationConnector,
+                                ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                soleTraderGrsConnector: SoleTraderGrsConnector,
+                                registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                partnershipGrsConnector: PartnershipGrsConnector,
+                                subscriptionsConnector: SubscriptionsConnector,
+                                addressConversionUtils: AddressConversionUtils,
+                                mcc: MessagesControllerComponents
 )(implicit val executionContext: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationDetailsTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/OrganisationDetailsTypeController.scala
@@ -49,18 +49,18 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class OrganisationDetailsTypeController @Inject() (
-  auditor: Auditor,
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val appConfig: AppConfig,
-  override val soleTraderGrsConnector: SoleTraderGrsConnector,
-  override val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  override val partnershipGrsConnector: PartnershipGrsConnector,
-  override val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  override val registrationConnector: RegistrationConnector,
-  override val registrationUpdater: NewRegistrationUpdateService,
-  mcc: MessagesControllerComponents,
-  page: organisation_type
+                                                    auditor: Auditor,
+                                                    authenticate: NotEnrolledAuthAction,
+                                                    journeyAction: JourneyAction,
+                                                    override val appConfig: AppConfig,
+                                                    override val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                                    override val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                                    override val partnershipGrsConnector: PartnershipGrsConnector,
+                                                    override val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                                    override val registrationConnector: RegistrationConnector,
+                                                    override val registrationUpdater: NewRegistrationUpdateService,
+                                                    mcc: MessagesControllerComponents,
+                                                    page: organisation_type
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport
     with OrganisationDetailsTypeHelper {

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/RegisterAsOtherOrganisationController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/organisation/RegisterAsOtherOrganisationController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.register_as_other_organisation
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -27,7 +27,7 @@ import javax.inject.Inject
 class RegisterAsOtherOrganisationController @Inject() (
   mcc: MessagesControllerComponents,
   page: register_as_other_organisation,
-  authenticate: AuthAction
+  authenticate: NotEnrolledAuthAction
 ) extends FrontendController(mcc) with I18nSupport {
 
   def onPageLoad: Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerCheckAnswersController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerCheckAnswersController.scala
@@ -20,7 +20,7 @@ import com.google.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_check_answers_page
@@ -28,11 +28,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 @Singleton
 class PartnerCheckAnswersController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: partner_check_answers_page
+                                                authenticate: NotEnrolledAuthAction,
+                                                journeyAction: JourneyAction,
+                                                override val registrationConnector: RegistrationConnector,
+                                                mcc: MessagesControllerComponents,
+                                                page: partner_check_answers_page
 ) extends FrontendController(mcc) with Cacheable with I18nSupport {
 
   def displayNewPartner(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactAddressController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
 import com.google.inject.{Inject, Singleton}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.services.AddressCaptureService
@@ -27,11 +27,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class PartnerContactAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  addressCaptureService: AddressCaptureService,
-  mcc: MessagesControllerComponents,
-  registrationUpdater: NewRegistrationUpdateService
+                                                  authenticate: NotEnrolledAuthAction,
+                                                  journeyAction: JourneyAction,
+                                                  addressCaptureService: AddressCaptureService,
+                                                  mcc: MessagesControllerComponents,
+                                                  registrationUpdater: NewRegistrationUpdateService
 )(implicit val ec: ExecutionContext)
     extends PartnerContactAddressControllerBase(authenticate,
                                                 journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
@@ -29,11 +29,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class PartnerContactNameController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: partner_member_name_page,
-  registrationUpdateService: NewRegistrationUpdateService
+                                               authenticate: NotEnrolledAuthAction,
+                                               journeyAction: JourneyAction,
+                                               mcc: MessagesControllerComponents,
+                                               page: partner_member_name_page,
+                                               registrationUpdateService: NewRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends PartnerContactNameControllerBase(authenticate = authenticate,
                                              journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerEmailAddressController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerEmailAddressController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.EmailAddressPasscode
@@ -37,15 +37,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PartnerEmailAddressController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: partner_email_address_page,
-  val emailPasscodePage: email_address_passcode_page,
-  val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
-  val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
-  val registrationUpdateService: NewRegistrationUpdateService,
-  val emailVerificationService: EmailVerificationService
+                                                authenticate: NotEnrolledAuthAction,
+                                                journeyAction: JourneyAction,
+                                                mcc: MessagesControllerComponents,
+                                                page: partner_email_address_page,
+                                                val emailPasscodePage: email_address_passcode_page,
+                                                val emailCorrectPasscodePage: email_address_passcode_confirmation_page,
+                                                val emailIncorrectPasscodeTooManyAttemptsPage: too_many_attempts_passcode_page,
+                                                val registrationUpdateService: NewRegistrationUpdateService,
+                                                val emailVerificationService: EmailVerificationService
 )(implicit ec: ExecutionContext)
     extends PartnerEmailAddressControllerBase(authenticate = authenticate,
                                               journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 
@@ -28,15 +28,15 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class PartnerGrsController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  ukCompanyGrsConnector: UkCompanyGrsConnector,
-  soleTraderGrsConnector: SoleTraderGrsConnector,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  registrationUpdater: NewRegistrationUpdateService,
-  subscriptionsConnector: SubscriptionsConnector,
-  mcc: MessagesControllerComponents
+                                       authenticate: NotEnrolledAuthAction,
+                                       journeyAction: JourneyAction,
+                                       ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                       soleTraderGrsConnector: SoleTraderGrsConnector,
+                                       partnershipGrsConnector: PartnershipGrsConnector,
+                                       registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                       registrationUpdater: NewRegistrationUpdateService,
+                                       subscriptionsConnector: SubscriptionsConnector,
+                                       mcc: MessagesControllerComponents
 )(implicit val executionContext: ExecutionContext)
     extends PartnerGrsControllerBase(authenticate = authenticate,
                                      journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerJobTitleController.scala
@@ -21,7 +21,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -42,11 +42,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PartnerJobTitleController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: partner_job_title_page
+                                            authenticate: NotEnrolledAuthAction,
+                                            journeyAction: JourneyAction,
+                                            override val registrationConnector: RegistrationConnector,
+                                            mcc: MessagesControllerComponents,
+                                            page: partner_job_title_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerListController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerListController.scala
@@ -21,7 +21,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.RegistrationConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.AddPartner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.Cacheable
@@ -31,11 +31,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 @Singleton
 class PartnerListController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: partner_list_page
+                                        authenticate: NotEnrolledAuthAction,
+                                        journeyAction: JourneyAction,
+                                        override val registrationConnector: RegistrationConnector,
+                                        mcc: MessagesControllerComponents,
+                                        page: partner_list_page
 ) extends FrontendController(mcc) with Cacheable with I18nSupport {
 
   def displayPage(): Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerNameController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
@@ -36,16 +36,16 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class PartnerNameController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  registrationUpdater: NewRegistrationUpdateService,
-  override val appConfig: AppConfig,
-  override val soleTraderGrsConnector: SoleTraderGrsConnector,
-  override val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  override val partnershipGrsConnector: PartnershipGrsConnector,
-  override val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  mcc: MessagesControllerComponents,
-  page: partner_name_page
+                                        authenticate: NotEnrolledAuthAction,
+                                        journeyAction: JourneyAction,
+                                        registrationUpdater: NewRegistrationUpdateService,
+                                        override val appConfig: AppConfig,
+                                        override val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                        override val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                        override val partnershipGrsConnector: PartnershipGrsConnector,
+                                        override val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                        mcc: MessagesControllerComponents,
+                                        page: partner_name_page
 )(implicit ec: ExecutionContext)
     extends PartnerNameControllerBase(authenticate = authenticate,
                                       journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerPhoneNumberController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerPhoneNumberController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
 import play.api.mvc._
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner.{routes => partnerRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
@@ -29,11 +29,11 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class PartnerPhoneNumberController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  mcc: MessagesControllerComponents,
-  page: partner_phone_number_page,
-  registrationUpdateService: NewRegistrationUpdateService
+                                               authenticate: NotEnrolledAuthAction,
+                                               journeyAction: JourneyAction,
+                                               mcc: MessagesControllerComponents,
+                                               page: partner_phone_number_page,
+                                               registrationUpdateService: NewRegistrationUpdateService
 )(implicit ec: ExecutionContext)
     extends PartnerPhoneNumberControllerBase(authenticate = authenticate,
                                              journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerRegistrationAvailableSoonController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.partner.partner_registration_available_soon_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -28,7 +28,7 @@ import javax.inject.{Inject, Singleton}
 class PartnerRegistrationAvailableSoonController @Inject() (
   mcc: MessagesControllerComponents,
   page: partner_registration_available_soon_page,
-  authenticate: AuthAction
+  authenticate: NotEnrolledAuthAction
 ) extends FrontendController(mcc) with I18nSupport {
 
   def onPageLoad: Action[AnyContent] =

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerTypeController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   SoleTraderGrsConnector,
   UkCompanyGrsConnector
 }
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.NewRegistrationUpdateService
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.plasticpackagingtax.registration.views.html.organisation.partner_type
@@ -34,16 +34,16 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PartnerTypeController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  registrationUpdater: NewRegistrationUpdateService,
-  mcc: MessagesControllerComponents,
-  page: partner_type,
-  val appConfig: AppConfig,
-  val soleTraderGrsConnector: SoleTraderGrsConnector,
-  val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  val partnershipGrsConnector: PartnershipGrsConnector
+                                        authenticate: NotEnrolledAuthAction,
+                                        journeyAction: JourneyAction,
+                                        registrationUpdater: NewRegistrationUpdateService,
+                                        mcc: MessagesControllerComponents,
+                                        page: partner_type,
+                                        val appConfig: AppConfig,
+                                        val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                        val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                        val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                        val partnershipGrsConnector: PartnershipGrsConnector
 )(implicit ec: ExecutionContext)
     extends PartnerTypeControllerBase(authenticate,
                                       journeyAction = journeyAction,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipNameController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipNameController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.plasticpackagingtax.registration.config.AppConfig
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.PartnershipGrsConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum.{
   GENERAL_PARTNERSHIP,
   SCOTTISH_PARTNERSHIP
@@ -40,13 +40,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PartnershipNameController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  appConfig: AppConfig,
-  partnershipGrsConnector: PartnershipGrsConnector,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: partnership_name
+                                            authenticate: NotEnrolledAuthAction,
+                                            journeyAction: JourneyAction,
+                                            appConfig: AppConfig,
+                                            partnershipGrsConnector: PartnershipGrsConnector,
+                                            override val registrationConnector: RegistrationConnector,
+                                            mcc: MessagesControllerComponents,
+                                            page: partnership_name
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipTypeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnershipTypeController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs.{
   UkCompanyGrsConnector
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthAction,
+  NotEnrolledAuthAction,
   FormAction,
   SaveAndContinue
 }
@@ -56,16 +56,16 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class PartnershipTypeController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  val appConfig: AppConfig,
-  val soleTraderGrsConnector: SoleTraderGrsConnector,
-  val ukCompanyGrsConnector: UkCompanyGrsConnector,
-  val partnershipGrsConnector: PartnershipGrsConnector,
-  val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: partnership_type
+                                            authenticate: NotEnrolledAuthAction,
+                                            journeyAction: JourneyAction,
+                                            val appConfig: AppConfig,
+                                            val soleTraderGrsConnector: SoleTraderGrsConnector,
+                                            val ukCompanyGrsConnector: UkCompanyGrsConnector,
+                                            val partnershipGrsConnector: PartnershipGrsConnector,
+                                            val registeredSocietyGrsConnector: RegisteredSocietyGrsConnector,
+                                            override val registrationConnector: RegistrationConnector,
+                                            mcc: MessagesControllerComponents,
+                                            page: partnership_type
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport with GRSRedirections {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/RemovePartnerController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/RemovePartnerController.scala
@@ -21,7 +21,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.{RegistrationConnector, ServiceError}
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthAction
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.NotEnrolledAuthAction
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.partner.RemovePartner
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{Cacheable, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.{JourneyAction, JourneyRequest}
@@ -33,11 +33,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class RemovePartnerController @Inject() (
-  authenticate: AuthAction,
-  journeyAction: JourneyAction,
-  override val registrationConnector: RegistrationConnector,
-  mcc: MessagesControllerComponents,
-  page: remove_partner_page
+                                          authenticate: NotEnrolledAuthAction,
+                                          journeyAction: JourneyAction,
+                                          override val registrationConnector: RegistrationConnector,
+                                          mcc: MessagesControllerComponents,
+                                          page: remove_partner_page
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with Cacheable with I18nSupport {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/testOnly/EmailPasscodeController.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/testOnly/EmailPasscodeController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.plasticpackagingtax.registration.controllers.testOnly
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.testOnly.EmailTestOnlyPasscodeConnector
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthRegistrationOrAmendmentActionImpl
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.PermissiveAuthActionImpl
 import uk.gov.hmrc.plasticpackagingtax.registration.models.request.JourneyAction
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
@@ -27,10 +27,10 @@ import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class EmailPasscodeController @Inject() (
-  authenticate: AuthRegistrationOrAmendmentActionImpl,
-  mcc: MessagesControllerComponents,
-  journeyAction: JourneyAction,
-  emailTestOnlyPasscodeConnector: EmailTestOnlyPasscodeConnector
+                                          authenticate: PermissiveAuthActionImpl,
+                                          mcc: MessagesControllerComponents,
+                                          journeyAction: JourneyAction,
+                                          emailTestOnlyPasscodeConnector: EmailTestOnlyPasscodeConnector
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -32,9 +32,9 @@ import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.plasticpackagingtax.registration.config.{AppConfig, Features}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.{
-  AuthActionImpl,
-  AuthNoEnrolmentCheckActionImpl,
-  AuthRegistrationOrAmendmentActionImpl
+  NotEnrolledAuthActionImpl,
+  EnrolledAuthActionImpl,
+  PermissiveAuthActionImpl
 }
 import uk.gov.hmrc.plasticpackagingtax.registration.models.SignedInUser
 import uk.gov.hmrc.plasticpackagingtax.registration.models.enrolment.PptEnrolment
@@ -46,20 +46,20 @@ trait MockAuthAction extends MockitoSugar with MetricsMocks {
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
   val appConfig: AppConfig             = mock[AppConfig]
 
-  val mockAuthAction = new AuthActionImpl(mockAuthConnector,
+  val mockAuthAction = new NotEnrolledAuthActionImpl(mockAuthConnector,
                                           metricsMock,
                                           stubMessagesControllerComponents(),
                                           appConfig
   )
 
-  val mockAuthAllowEnrolmentAction = new AuthNoEnrolmentCheckActionImpl(
+  val mockEnrolledAuthAction = new EnrolledAuthActionImpl(
     mockAuthConnector,
     metricsMock,
     stubMessagesControllerComponents(),
     appConfig
   )
 
-  val mockRegistrationOrAmendmentAction = new AuthRegistrationOrAmendmentActionImpl(
+  val mockPermissiveAuthAction= new PermissiveAuthActionImpl(
     mockAuthConnector,
     metricsMock,
     stubMessagesControllerComponents(),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/KeepAliveControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/KeepAliveControllerSpec.scala
@@ -40,7 +40,7 @@ class KeepAliveControllerSpec extends ControllerSpec {
   private val mockUserDataRepository = mock[MongoUserDataRepository]
 
   private val controller =
-    new KeepAliveController(authenticate = mockAuthAllowEnrolmentAction,
+    new KeepAliveController(authenticate = mockEnrolledAuthAction,
                             userDataRepository = mockUserDataRepository,
                             mcc = mcc
     )

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/NotEnrolledAuthActionSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/actions/NotEnrolledAuthActionSpec.scala
@@ -29,22 +29,22 @@ import uk.gov.hmrc.plasticpackagingtax.registration.models.request.Authenticated
 
 import scala.concurrent.Future
 
-class AuthActionSpec extends ControllerSpec with MetricsMocks {
+class NotEnrolledAuthActionSpec extends ControllerSpec with MetricsMocks {
 
   private val okResponseGenerator = (_: AuthenticatedRequest[_]) => Future(Results.Ok)
 
   private val expectedAcceptableCredentialsPredicate =
     AffinityGroup.Agent.or(CredentialStrength(CredentialStrength.strong))
 
-  private def registrationAuthAction: AuthAction =
-    new AuthActionImpl(mockAuthConnector,
+  private def registrationAuthAction: NotEnrolledAuthAction =
+    new NotEnrolledAuthActionImpl(mockAuthConnector,
                        metricsMock,
                        stubMessagesControllerComponents(),
                        appConfig
     )
 
-  private def amendmentAuthAction: AuthNoEnrolmentCheckAction =
-    new AuthNoEnrolmentCheckActionImpl(mockAuthConnector,
+  private def amendmentAuthAction: EnrolledAuthAction =
+    new EnrolledAuthActionImpl(mockAuthConnector,
                                        metricsMock,
                                        stubMessagesControllerComponents(),
                                        appConfig

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/address/AddressCaptureControllerSpec.scala
@@ -61,7 +61,7 @@ class AddressCaptureControllerSpec
   ).thenReturn(HtmlFormat.raw("Address Capture"))
 
   private val addressCaptureController = new AddressCaptureController(
-    authenticate = mockRegistrationOrAmendmentAction,
+    authenticate = mockPermissiveAuthAction,
     mcc = mcc,
     addressCaptureService = addressCaptureService,
     addressLookupFrontendConnector = mockAddressLookupFrontendConnector,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendContactDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendContactDetailsControllerSpec.scala
@@ -61,7 +61,7 @@ class AmendContactDetailsControllerSpec
   )
 
   private val controller =
-    new AmendContactDetailsController(mockAuthAllowEnrolmentAction,
+    new AmendContactDetailsController(mockEnrolledAuthAction,
                                       mcc,
                                       mockAmendmentJourneyAction,
                                       amendNamePage,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendEmailAddressControllerSpec.scala
@@ -120,7 +120,7 @@ class AmendEmailAddressControllerSpec
     )
 
   "Amend Email Address Controller" should {
-    val controller = new AmendEmailAddressController(mockAuthAllowEnrolmentAction,
+    val controller = new AmendEmailAddressController(mockEnrolledAuthAction,
                                                      mcc,
                                                      mockAmendmentJourneyAction,
                                                      amendEmailPage,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendOrganisationDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendOrganisationDetailsControllerSpec.scala
@@ -40,7 +40,7 @@ class AmendOrganisationDetailsControllerSpec
   private val registration = aRegistration()
 
   private val controller =
-    new AmendOrganisationDetailsController(mockAuthAllowEnrolmentAction,
+    new AmendOrganisationDetailsController(mockEnrolledAuthAction,
                                            mcc,
                                            mockAddressCaptureService,
                                            mockAmendmentJourneyAction

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/AmendRegistrationControllerSpec.scala
@@ -49,7 +49,7 @@ class AmendRegistrationControllerSpec
   )
 
   private val controller =
-    new AmendRegistrationController(mockAuthAllowEnrolmentAction,
+    new AmendRegistrationController(mockEnrolledAuthAction,
                                     mcc,
                                     mockAmendmentJourneyAction,
                                     amendRegistrationPage,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsCheckAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AddGroupMemberContactDetailsCheckAnswersControllerSpec.scala
@@ -42,7 +42,7 @@ class AddGroupMemberContactDetailsCheckAnswersControllerSpec extends ControllerS
   when(cyaPage.apply(any(), any(), any())(any(), any())).thenReturn(HtmlFormat.raw("Amend Reg - New Group Member CYA"))
 
   private val controller = new AddGroupMemberContactDetailsCheckAnswersController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     journeyAction = mockAmendmentJourneyAction,
     mcc = mcc,
     page = cyaPage

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AmendMemberContactDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/AmendMemberContactDetailsControllerSpec.scala
@@ -67,7 +67,7 @@ class AmendMemberContactDetailsControllerSpec
   )
 
   private val controller =
-    new AmendMemberContactDetailsController(mockAuthAllowEnrolmentAction,
+    new AmendMemberContactDetailsController(mockEnrolledAuthAction,
                                             mcc,
                                             mockAmendmentJourneyAction,
                                             mockAddressCaptureService,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ConfirmRemoveMemberControllerSpec.scala
@@ -45,7 +45,7 @@ class ConfirmRemoveMemberControllerSpec
   private val sessionId = UUID.randomUUID().toString
 
   private val controller =
-    new ConfirmRemoveMemberController(mockAuthAllowEnrolmentAction,
+    new ConfirmRemoveMemberController(mockEnrolledAuthAction,
                                       mockAmendmentJourneyAction,
                                       mcc,
                                       page

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ContactDetailsCheckAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ContactDetailsCheckAnswersControllerSpec.scala
@@ -39,7 +39,7 @@ class ContactDetailsCheckAnswersControllerSpec
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new ContactDetailsCheckAnswersController(authenticate = mockAuthAllowEnrolmentAction,
+    new ContactDetailsCheckAnswersController(authenticate = mockEnrolledAuthAction,
                                              amendmentJourneyAction = mockAmendmentJourneyAction,
                                              mcc = mcc,
                                              page = page

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/GroupMembersListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/GroupMembersListControllerSpec.scala
@@ -43,7 +43,7 @@ class GroupMembersListControllerSpec
 
   when(view.apply(any(), any())(any(), any())).thenReturn(Html("view"))
 
-  val sut = new GroupMembersListController(mockAuthAllowEnrolmentAction,
+  val sut = new GroupMembersListController(mockEnrolledAuthAction,
                                            mockAmendmentJourneyAction,
                                            stubMessagesControllerComponents(),
                                            view

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ManageGroupMembersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/group/ManageGroupMembersControllerSpec.scala
@@ -38,7 +38,7 @@ class ManageGroupMembersControllerSpec extends ControllerSpec with MockAmendment
 
   when(view.apply(any())(any(), any())).thenReturn(Html("view"))
 
-  val sut = new ManageGroupMembersController(mockAuthAllowEnrolmentAction,
+  val sut = new ManageGroupMembersController(mockEnrolledAuthAction,
                                              mockAmendmentJourneyAction,
                                              Helpers.stubMessagesControllerComponents(),
                                              view

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsCheckAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsCheckAnswersControllerSpec.scala
@@ -43,7 +43,7 @@ class AddPartnerContactDetailsCheckAnswersControllerSpec
   when(cyaPage.apply(any())(any(), any())).thenReturn(HtmlFormat.raw("Amend Reg - New Partner CYA"))
 
   private val controller = new AddPartnerContactDetailsCheckAnswersController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     journeyAction = mockAmendmentJourneyAction,
     mcc = mcc,
     page = cyaPage

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsConfirmAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AddPartnerContactDetailsConfirmAddressControllerSpec.scala
@@ -40,7 +40,7 @@ class AddPartnerContactDetailsConfirmAddressControllerSpec
 
   private val controller =
     new AddPartnerContactDetailsConfirmAddressController(
-      authenticate = mockAuthAllowEnrolmentAction,
+      authenticate = mockEnrolledAuthAction,
       journeyAction = mockAmendmentJourneyAction,
       registrationUpdater =
         new AmendRegistrationUpdateService(inMemoryRegistrationAmendmentRepository),

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AmendPartnerContactDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/AmendPartnerContactDetailsControllerSpec.scala
@@ -88,7 +88,7 @@ class AmendPartnerContactDetailsControllerSpec
   private val other = false
 
   private val controller = new AmendPartnerContactDetailsController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     mcc = mcc,
     amendmentJourneyAction = mockAmendmentJourneyAction,
     contactNamePage = mockContactNamePage,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ConfirmRemovePartnerControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ConfirmRemovePartnerControllerSpec.scala
@@ -45,7 +45,7 @@ class ConfirmRemovePartnerControllerSpec extends ControllerSpec with MockAmendme
   )
 
   private val confirmRemovePartnerController = new ConfirmRemovePartnerController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     amendmentJourneyAction = mockAmendmentJourneyAction,
     mcc = mcc,
     page = mockConfirmRemovePartnerPage

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ManagePartnersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/ManagePartnersControllerSpec.scala
@@ -41,7 +41,7 @@ class ManagePartnersControllerSpec extends ControllerSpec with MockAmendmentJour
   )
 
   private val managePartnersController = new ManagePartnersController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     amendmentJourneyAction = mockAmendmentJourneyAction,
     mcc = mcc,
     page = mockManagePartnersPage

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnerContactDetailsCheckAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnerContactDetailsCheckAnswersControllerSpec.scala
@@ -42,7 +42,7 @@ class PartnerContactDetailsCheckAnswersControllerSpec
   )
 
   private val controller = new PartnerContactDetailsCheckAnswersController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     amendmentJourneyAction = mockAmendmentJourneyAction,
     mcc = mcc,
     page = mockPartnerCYAsPage

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnersListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/amendment/partner/PartnersListControllerSpec.scala
@@ -41,7 +41,7 @@ class PartnersListControllerSpec extends ControllerSpec with MockAmendmentJourne
   )
 
   private val listPartnersController = new PartnersListController(
-    authenticate = mockAuthAllowEnrolmentAction,
+    authenticate = mockEnrolledAuthAction,
     amendmentJourneyAction = mockAmendmentJourneyAction,
     mcc = mcc,
     page = mockListPartnersPage

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterCheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterCheckYourAnswersControllerSpec.scala
@@ -57,7 +57,7 @@ class DeregisterCheckYourAnswersControllerSpec
     )
 
   private val controller =
-    new DeregisterCheckYourAnswersController(authenticate = mockAuthAllowEnrolmentAction,
+    new DeregisterCheckYourAnswersController(authenticate = mockEnrolledAuthAction,
                                              mcc = mcc,
                                              deregistrationDetailRepository = repository,
                                              deregistrationConnector = mockDegistrationConnector,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterControllerSpec.scala
@@ -42,7 +42,7 @@ class DeregisterControllerSpec
     ArgumentCaptor.forClass(classOf[Form[Boolean]])
 
   private val deregisterController = new DeregisterController(
-    mockAuthAllowEnrolmentAction,
+    mockEnrolledAuthAction,
     mcc,
     inMemoryDeregistrationDetailRepository,
     appConfig,

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterReasonControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregisterReasonControllerSpec.scala
@@ -49,7 +49,7 @@ class DeregisterReasonControllerSpec extends ControllerSpec {
     DeregistrationDetails(deregister = Some(true), reason = None)
 
   private val controller =
-    new DeregisterReasonController(authenticate = mockAuthAllowEnrolmentAction,
+    new DeregisterReasonController(authenticate = mockEnrolledAuthAction,
                                    mcc = mcc,
                                    deregistrationDetailRepository = repository,
                                    page = page

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregistrationSubmittedControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/deregistration/DeregistrationSubmittedControllerSpec.scala
@@ -35,7 +35,7 @@ class DeregistrationSubmittedControllerSpec
   when(mockPage.apply()(any(), any())).thenReturn(HtmlFormat.raw("Deregistration Submitted"))
 
   private val deregistrationSubmittedController =
-    new DeregistrationSubmittedController(mockAuthAllowEnrolmentAction, mcc, mockPage)
+    new DeregistrationSubmittedController(mockEnrolledAuthAction, mcc, mockPage)
 
   "Deregistration Submitted Controller" should {
     "display page" when {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/enrolment/ConfirmationControllerSpec.scala
@@ -34,7 +34,7 @@ class ConfirmationControllerSpec extends ControllerSpec {
   private val mcc  = stubMessagesControllerComponents()
 
   private val controller =
-    new ConfirmationController(authenticate = mockAuthAllowEnrolmentAction, mcc = mcc, page = page)
+    new ConfirmationController(authenticate = mockEnrolledAuthAction, mcc = mcc, page = page)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorControllerSpec.scala
@@ -48,7 +48,7 @@ class NotableErrorControllerSpec extends ControllerSpec {
   private val groupMemberAlreadyRegisteredPage = mock[group_member_already_registered_page]
 
   private val controller =
-    new NotableErrorController(authenticate = mockAuthAllowEnrolmentAction,
+    new NotableErrorController(authenticate = mockPermissiveAuthAction,
                                mockJourneyAction,
                                mcc = mcc,
                                nominatedOrganisationAlreadyRegisteredPage =

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/testOnly/EmailPasscodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/testOnly/EmailPasscodeControllerSpec.scala
@@ -38,7 +38,7 @@ class EmailPasscodeControllerSpec extends ControllerSpec {
     mock[EmailTestOnlyPasscodeConnector]
 
   private val controller =
-    new EmailPasscodeController(authenticate = mockRegistrationOrAmendmentAction,
+    new EmailPasscodeController(authenticate = mockPermissiveAuthAction,
                                 mcc = mcc,
                                 mockJourneyAction,
                                 emailTestOnlyPasscodeConnector = mockEmailTestOnlyPasscodeConnector


### PR DESCRIPTION
Auth Actions renamed across the whole service.

Importantly, now using a different Auth Action on which should allow users without enrolments to see the errors

app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/NotableErrorController.scala