### PR TITLE
Country code lookup by synonym

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerContactNameControllerBase.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
-import com.sun.org.apache.xpath.internal.operations.Bool
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/controllers/partner/PartnerGrsControllerBase.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.plasticpackagingtax.registration.controllers.partner
 
-import play.api.{Logger, Logging}
+import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.http.HttpReads.Implicits._
@@ -24,7 +24,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, InternalServerException}
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors._
 import uk.gov.hmrc.plasticpackagingtax.registration.connectors.grs._
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.actions.AuthActioning
-import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.RegistrationStatus.{DUPLICATE_SUBSCRIPTION, GRS_FAILED, RegistrationStatus, STATUS_OK, UNSUPPORTED_ORGANISATION}
+import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.RegistrationStatus._
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.organisation.{routes => orgRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.controllers.{routes => commonRoutes}
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.PartnerTypeEnum._

--- a/conf/resources/countrySynonyms.json
+++ b/conf/resources/countrySynonyms.json
@@ -1,0 +1,7 @@
+{
+  "GB": {
+    "synonyms": [
+        "England", "Scotland", "Wales", "Northern Ireland"
+      ]
+  }
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewTaskListControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/ReviewTaskListControllerSpec.scala
@@ -66,7 +66,7 @@ class ReviewTaskListControllerSpec extends ControllerSpec with TableDrivenProper
     authorizedUser()
     given(mockReviewRegistrationPage.apply(any())(any(), any())).willReturn(HtmlFormat.empty)
     given(mockDuplicateSubscriptionPage.apply()(any(), any())).willReturn(HtmlFormat.empty)
-    when(mockRegistrationFilterService.removeGroupDetails(any())).then(returnsFirstArg())
+    when(mockRegistrationFilterService.removeGroupDetails(any())).thenAnswer(returnsFirstArg())
   }
 
   override protected def afterEach(): Unit = {

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/GroupMemberGrsControllerSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/controllers/group/GroupMemberGrsControllerSpec.scala
@@ -29,8 +29,7 @@ import uk.gov.hmrc.plasticpackagingtax.registration.connectors.DownstreamService
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.organisation.OrgType.{OrgType, PARTNERSHIP}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.genericregistration.{CompanyProfile, IncorporationDetails}
-import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.GroupErrorType.MEMBER_IN_GROUP
-import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.{GroupError, GroupMember, OrganisationDetails => GroupOrgDetails}
+import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group.{GroupMember, OrganisationDetails => GroupOrgDetails}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.{GroupDetail, NewRegistrationUpdateService, Registration}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.SubscriptionStatus.{NOT_SUBSCRIBED, SUBSCRIBED}
 import uk.gov.hmrc.plasticpackagingtax.registration.models.subscriptions.SubscriptionStatusResponse
@@ -268,9 +267,6 @@ class GroupMemberGrsControllerSpec extends ControllerSpec with MatcherWords {
 
   private def groupMemberSize(registration: Registration): Int =
     registration.groupDetail.map(_.members.size).getOrElse(0)
-
-  private def groupError(registration: Registration) =
-    registration.groupDetail.flatMap(_.groupError)
 
   private def simulateLimitedCompanyCallback(registration: Registration, memberId: Option[String] = None) = {
     authorizedUser()

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/services/CountryServiceSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/services/CountryServiceSpec.scala
@@ -44,8 +44,15 @@ class CountryServiceSpec extends AnyWordSpecLike {
   }
 
   ".getKeyForName" should {
-    "retrieve the key for a country name" in {
+    "retrieve the key for a country name in the countriesEN resource" in {
       countryService.getKeyForName("United Kingdom") mustBe Some("GB")
+    }
+    "retrieve the key for a country name in the synonyms resource if it cannot be found in the countriesEN resource" +
+      " but is found in the countrySynonyms resource" in {
+      countryService.getKeyForName("england") mustBe Some("GB")
+    }
+    "return None if the country is not found in the countriesEN or countrySynonyms resources" in {
+      countryService.getKeyForName("Mars") mustBe None
     }
   }
 }


### PR DESCRIPTION
Logic to try to find country code from synonyms resource if an invalid FCO country name received from GRS.

Tidied a few warnings as well.