### PR TITLE
Sanitise redirectTo address for group member ALF callback

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/utils/URLSanitisationUtils.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/utils/URLSanitisationUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.utils
+
+import java.net.URI
+import scala.util.Try
+
+object URLSanitisationUtils {
+
+  def asRelativeUrl(url: String): Option[String] =
+    for {
+      uri <- Try(new URI(url)).toOption
+      path <- Option(uri.getPath)
+      query <- Option(uri.getQuery).map("?" + _).orElse(Some(""))
+      fragment <- Option(uri.getRawFragment).map("#" + _).orElse(Some(""))
+    } yield s"$path$query$fragment"
+}

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/utils/URLSanitisationUtilsSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/utils/URLSanitisationUtilsSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.plasticpackagingtax.registration.utils
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class URLSanitisationUtilsSpec extends AnyWordSpec with Matchers {
+
+  ".asRelativeUrl" should {
+    "convert an absolute url to a relative url" in {
+      URLSanitisationUtils.asRelativeUrl(
+        "https://dodgy-website.com/register-for-plastic-packaging-tax/contact-name"
+      ) mustBe Some("/register-for-plastic-packaging-tax/contact-name")
+    }
+  }
+}


### PR DESCRIPTION
Convert redirectTo addresses to relative urls to prevent url hijacking on callback from ALF with redirectTo.