### PR TITLE
Updated group task list to show in progress for partial group members

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/GroupDetail.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/GroupDetail.scala
@@ -29,8 +29,10 @@ case class GroupDetail(
 ) {
 
   def status: TaskStatus =
-    if (members.isEmpty)
+    if(members.isEmpty)
       TaskStatus.NotStarted
+    else if(members.exists(member => !member.isValid))
+      TaskStatus.InProgress
     else TaskStatus.Completed
 
   def businessName(memberId: String): Option[String] = findGroupMember(Some(memberId), None).map(_.businessName)

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/group/GroupDetailSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/models/registration/group/GroupDetailSpec.scala
@@ -18,9 +18,12 @@ package uk.gov.hmrc.plasticpackagingtax.registration.models.registration.group
 
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address
 import uk.gov.hmrc.plasticpackagingtax.registration.forms.contact.Address.UKAddress
 import uk.gov.hmrc.plasticpackagingtax.registration.models.registration.GroupDetail
 import uk.gov.hmrc.plasticpackagingtax.registration.views.models.TaskStatus
+
+import java.util.UUID
 
 class GroupDetailSpec extends AnyWordSpec with Matchers {
 
@@ -30,6 +33,14 @@ class GroupDetailSpec extends AnyWordSpec with Matchers {
       "members is empty" in {
         val groupDetail = GroupDetail()
         groupDetail.status mustBe TaskStatus.NotStarted
+      }
+    }
+
+    "be IN_PROGRESS" when {
+      "there is a member with no contact details" in {
+        val groupDetail = GroupDetail().withUpdatedOrNewMember(aGroupMember("Barbie Plastic Ltd")
+          .copy(contactDetails = None))
+        groupDetail.status mustBe TaskStatus.InProgress
       }
     }
 


### PR DESCRIPTION
Show in progress status on the task list if any group members are missing details (instead of completed).

This will protect against the scenario where a user times out or needs to drop out and come back later in the middle of providing a group member's details.