### PR TITLE
PPTP-2391: Fixed threshold date error links

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/errorSummary.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/errorSummary.scala.html
@@ -22,11 +22,15 @@
 
 @errorList = @{errors.map { error =>
     val errorKey = error.key.replace(".", "_").replace('[', '_').replace("]", "")
-    ErrorLink(
-        href = Some(s"#${errorFieldName.getOrElse(errorKey)}"),
-        content = Text(messages(error.message, errorKey))
-    )
-}}
+    val errorMsg = messages(error.message, errorKey)
+
+    if(errorMsg.nonEmpty){
+        ErrorLink(
+            href = Some(s"#${errorFieldName.getOrElse(errorKey)}"),
+            content = Text(errorMsg)
+        )
+    }
+}.collect{case errLink: ErrorLink => errLink}}
 
 @if(errorList.nonEmpty) {
     @govukErrorSummary(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
@@ -97,7 +97,7 @@
         pptRoutes.ExpectToExceedThresholdWeightController.displayPage(), 
         messages("site.back.hiddenText")))) {
 
-    @errorSummary(form.errors)
+    @errorSummary(form.errors, errorFieldName = Some("exceeded-threshold-weight-date.day"))
 
     @sectionHeader(messages("liability.exceededThresholdWeight.sectionHeader"))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/expect_to_exceed_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/expect_to_exceed_threshold_weight_page.scala.html
@@ -87,7 +87,7 @@ if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 
 @govukLayout(title = Title("liability.expectToExceedThresholdWeight.title")) {
 
-    @errorSummary(form.errors)
+    @errorSummary(form.errors, Some("expect-to-exceed-threshold-weight-date.day"))
 
     @sectionHeader(messages("liability.expectToExceedThresholdWeight.sectionHeader"))
     

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -482,7 +482,7 @@ liability.expectToExceedThreshold.two.required.fields = Date must include the {0
 liability.expectToExceedThreshold.one.field = Date must include the {0}
 
 liability.exceededThresholdWeightDate.sectionHeader = Liability details
-liability.exceededThresholdWeightDate.title = When did you you meet the 10,000kg threshold?
+liability.exceededThresholdWeightDate.title = When did you meet the 10,000kg threshold?
 liability.exceededThresholdWeightDate.hint = For example, 15 5 2022.
 liability.exceededThresholdWeightDate.formatting.error = Date must be a real date
 liability.exceededThresholdWeightDate.outOfRange.error = Date must be today or in the past


### PR DESCRIPTION
1. Fixed error summary links to take focus to  the date entry
2. Stopped empty links from being in the error summary
3. Fixed a type on a message