### PR TITLE
PPTP-2391b: More error link fixes

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address/uk_address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address/uk_address_page.scala.html
@@ -39,7 +39,7 @@
     title = Title(headingKey = "ukAddress.title", headingArg = entityName.getOrElse(messages("missing.organisationName"))),
     backButton = Some(BackButton(messages("site.back"), backLink, messages("site.back.hiddenText")))
 ) {
-
+    @errorSummary(form.errors)
     @formHelper(action = routes.AddressCaptureController.submitAddressInUk(), 'autoComplete -> "off") {
         @govukFieldset(Fieldset(
             legend = Some(Legend(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/errorSummary.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/errorSummary.scala.html
@@ -21,8 +21,8 @@
 @(errors: Seq[FormError], errorFieldName: Option[String] = None)(implicit messages: Messages)
 
 @errorList = @{errors.map { error =>
-    val errorKey = error.key.replace(".", "_").replace('[', '_').replace("]", "")
-    val errorMsg = messages(error.message, errorKey)
+    val errorKey = error.key
+    val errorMsg = messages(error.message, error.args)
 
     if(errorMsg.nonEmpty){
         ErrorLink(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
@@ -77,10 +77,25 @@
 @yearField = @{form("exceeded-threshold-weight-date.year")}
 
 @errorMessages = @{
-        val errors = form.errors.map(err => messages(err.message, err.key)).mkString("<br>")
-        if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
+    val errors = form.errors
+        .filter(err => !err.message.contains("liability.exceededThresholdWeight.question.empty.error"))
+        .map(er => messages(er.message, er.key)).mkString("<br>")
+
+    if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 }
 
+@formErrors = @{
+    form.errors.map{
+        case yesNoErr if(yesNoErr.key == "answer") =>
+            yesNoErr.copy(key = "value-yes")
+        case monthYearErr if(monthYearErr.key == "month and year") =>
+            monthYearErr.copy(key = "exceeded-threshold-weight-date.month", args = "month and year")
+        case yearErr if(yearErr.key == "year") =>
+            yearErr.copy(key = "exceeded-threshold-weight-date.year", args = "year")
+        case err =>
+            err.copy(key = "exceeded-threshold-weight-date.day")
+    }
+}
 
 @hints = {
     <p class="govuk-hint">@messages("liability.exceededThresholdWeight.hint")</p>
@@ -97,7 +112,7 @@
         pptRoutes.ExpectToExceedThresholdWeightController.displayPage(), 
         messages("site.back.hiddenText")))) {
 
-    @errorSummary(form.errors, errorFieldName = Some("exceeded-threshold-weight-date.day"))
+    @errorSummary(formErrors)
 
     @sectionHeader(messages("liability.exceededThresholdWeight.sectionHeader"))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/expect_to_exceed_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/expect_to_exceed_threshold_weight_page.scala.html
@@ -28,7 +28,7 @@
     errorSummary: errorSummary,
     govukDateInput : GovukDateInput,
     conditionalYesNo : conditionalYesNoRadio,
-    paragraphBody: paragraphBody,
+    paragraphBody: paragraphBody
 )
 
 
@@ -39,8 +39,24 @@
 @yearField = @{form("expect-to-exceed-threshold-weight-date.year")}
 
 @errorMessages = @{
-val errors = form.errors.map(err => messages(err.message, err.key)).mkString("<br>")
-if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
+    val errors = form.errors
+        .filter(err => !err.message.contains("liability.expectToExceedThresholdWeight.question.empty.error"))
+        .map(er => messages(er.message, er.key)).mkString("<br>")
+
+    if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
+}
+
+@formErrors = @{
+    form.errors.map{
+        case yesNoErr if(yesNoErr.key == "answer") =>
+            yesNoErr.copy(key = "value-yes")
+        case monthYearErr if(monthYearErr.key == "month and year") =>
+            monthYearErr.copy(key = "expect-to-exceed-threshold-weight-date.month", args = "month and year")
+        case yearErr if(yearErr.key == "year") =>
+            yearErr.copy(key = "expect-to-exceed-threshold-weight-date.year", args = "year")
+        case err =>
+            err.copy(key = "expect-to-exceed-threshold-weight-date.day")
+    }
 }
 
 @yesContent = {
@@ -87,7 +103,7 @@ if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 
 @govukLayout(title = Title("liability.expectToExceedThresholdWeight.title")) {
 
-    @errorSummary(form.errors, Some("expect-to-exceed-threshold-weight-date.day"))
+    @errorSummary(formErrors)
 
     @sectionHeader(messages("liability.expectToExceedThresholdWeight.sectionHeader"))
     


### PR DESCRIPTION
1. Fixed error summary links on various pages for the various error keys seen
2. Prevented yes / no missing answer error from being shown on the expandable date field
3. Added a missing error summary