### PR TITLE
PPTP-2391b: More error link fixes

### DIFF
--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/liability/ExceededThresholdWeight.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/liability/ExceededThresholdWeight.scala
@@ -45,9 +45,7 @@ class ExceededThresholdWeight @Inject()(appConfig: AppConfig, clock: Clock) exte
   def form()(implicit messages: Messages): Form[ExceededThresholdWeightAnswer] =
     Form(
       mapping(
-        "answer" -> nonEmptyString(emptyError)
-          .verifying(emptyError, contains(Seq(YesNoValues.YES, YesNoValues.NO)))
-          .transform[Boolean](_ == YesNoValues.YES, bool => if (bool) YesNoValues.YES else YesNoValues.NO),
+        "answer" -> toBoolean(emptyError),
         "exceeded-threshold-weight-date" -> mandatoryIf(isEqual("answer", YesNoValues.YES),
           localDate(emptyDateKey =
             dateEmptyError,
@@ -60,7 +58,4 @@ class ExceededThresholdWeight @Inject()(appConfig: AppConfig, clock: Clock) exte
         )
       )(ExceededThresholdWeightAnswer.apply)(ExceededThresholdWeightAnswer.unapply)
     )
-
-  
-
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/liability/ExpectToExceedThresholdWeight.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/liability/ExpectToExceedThresholdWeight.scala
@@ -45,9 +45,7 @@ class ExpectToExceedThresholdWeight @Inject()(appConfig: AppConfig, clock: Clock
   def apply()(implicit messages: Messages): Form[ExpectToExceedThresholdWeightAnswer] =
     Form(
       mapping(
-        "answer" -> nonEmptyString(emptyError)
-          .verifying(emptyError, contains(Seq(YesNoValues.YES, YesNoValues.NO)))
-          .transform[Boolean](_ == YesNoValues.YES, bool => if (bool) YesNoValues.YES else YesNoValues.NO),
+        "answer" -> toBoolean(emptyError),
         "expect-to-exceed-threshold-weight-date" -> mandatoryIf(isEqual("answer", YesNoValues.YES),
           localDate(emptyDateKey =
             dateEmptyError,

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/mappings/Formatters.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/mappings/Formatters.scala
@@ -23,6 +23,19 @@ import scala.util.control.Exception.nonFatalCatch
 
 trait Formatters {
 
+  private[mappings] def booleanFormatter(msgKey: String): Formatter[Boolean] = new Formatter[Boolean] {
+
+    def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Boolean] = {
+      data.get(key) match {
+        case Some("yes") => Right(true)
+        case Some("no") => Right(false)
+        case _ => Left(Seq(FormError(key, msgKey)))
+      }
+    }
+
+    def unbind(key: String, value: Boolean) = Map(key -> value.toString)
+  }
+
   private[mappings] def stringFormatter(errorKey: String): Formatter[String] =
     new Formatter[String] {
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/mappings/LocalDateFormatter.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/mappings/LocalDateFormatter.scala
@@ -79,31 +79,21 @@ private[mappings] class LocalDateFormatter(
 
     fields.count(_._2.isDefined) match {
       case 3 =>
-        formatDate(key, data).left.map {
-          _.map(_.copy(key = key, args = args))
-        }
+        formatDate(key, data)
       case 2 =>
-        Left(
-          List(FormError(messages(s"general.${missingFields.head}"), singleRequiredKey, missingFields),
-               FormError(s"$key.${missingFields.head}", "")
-          )
-        )
+        Left(List(FormError(s"$key.${missingFields.head}", singleRequiredKey, Seq(messages(s"general.${missingFields.head}")))))
       case 1 =>
         Left(
           List(
-            FormError(messages("general.and", messages(s"general.${missingFields.head}"), messages(s"general.${missingFields.last}")),
-                      twoRequiredKey,
-                      missingFields
-            ),
-            FormError(s"$key.${missingFields.head}", ""),
-            FormError(s"$key.${missingFields.last}", "")
+            FormError(s"$key.${missingFields.head}",
+              twoRequiredKey,
+              Seq(messages("general.and", messages(s"general.${missingFields.head}"), messages(s"general.${missingFields.last}")))
+            )
           )
         )
       case _ =>
         Left(
-          List(FormError(s"$key.day", emptyDateKey, args),
-               FormError(s"$key.month", ""),
-               FormError(s"$key.year", "")
+          List(FormError(s"$key.day", emptyDateKey, args)
           )
         )
     }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/mappings/Mappings.scala
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/forms/mappings/Mappings.scala
@@ -33,14 +33,6 @@ trait Mappings extends Formatters with Constraints {
   )(implicit messages: Messages) : FieldMapping[LocalDate] =
     of(new LocalDateFormatter(emptyDateKey, singleRequiredKey, twoRequiredKey, invalidKey, args))
 
-  protected def optLocalDate(
-                           emptyDateKey: String,
-                           singleRequiredKey: String,
-                           twoRequiredKey: String,
-                           invalidKey: String,
-                           args: Seq[String] = Seq.empty
-                         )(implicit messages: Messages) : FieldMapping[LocalDate] =
-    of(new LocalDateFormatter(emptyDateKey, singleRequiredKey, twoRequiredKey, invalidKey, args))
-
+  protected def toBoolean(msgKey: String) : FieldMapping[Boolean] = of(booleanFormatter(msgKey))
 
 }

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address/uk_address_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/address/uk_address_page.scala.html
@@ -40,6 +40,7 @@
     backButton = Some(BackButton(messages("site.back"), backLink, messages("site.back.hiddenText")))
 ) {
 
+    @errorSummary(form.errors)
     @formHelper(action = routes.AddressCaptureController.submitAddressInUk(), 'autoComplete -> "off") {
         @govukFieldset(Fieldset(
             legend = Some(Legend(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/conditionalYesNoRadio.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/conditionalYesNoRadio.scala.html
@@ -45,7 +45,7 @@
             content = HtmlContent(hint)
         )},
             items = Seq(
-                RadioItem(id = Some("value-yes"),
+                RadioItem(id = Some("answer"),
                 value = Some(YesNoValues.YES),
                 content = Text(messages("general.true")),
                 checked = form("answer").value.contains(YesNoValues.YES),
@@ -58,5 +58,5 @@
                 conditionalHtml = ifNo
             )
         ),
-errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+        errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
 ))

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/errorSummary.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/components/errorSummary.scala.html
@@ -21,16 +21,11 @@
 @(errors: Seq[FormError], errorFieldName: Option[String] = None)(implicit messages: Messages)
 
 @errorList = @{errors.map { error =>
-    val errorKey = error.key.replace(".", "_").replace('[', '_').replace("]", "")
-    val errorMsg = messages(error.message, errorKey)
-
-    if(errorMsg.nonEmpty){
-        ErrorLink(
-            href = Some(s"#${errorFieldName.getOrElse(errorKey)}"),
-            content = Text(errorMsg)
-        )
-    }
-}.collect{case errLink: ErrorLink => errLink}}
+    ErrorLink(
+        href = Some(s"#${errorFieldName.getOrElse(error.key)}"),
+        content = Text(messages(error.message, error.args: _*))
+    )
+}}
 
 @if(errorList.nonEmpty) {
     @govukErrorSummary(

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/exceeded_threshold_weight_page.scala.html
@@ -77,8 +77,10 @@
 @yearField = @{form("exceeded-threshold-weight-date.year")}
 
 @errorMessages = @{
-        val errors = form.errors.map(err => messages(err.message, err.key)).mkString("<br>")
-        if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
+    val errors = form.errors
+        .filter(err => !err.message.contains("liability.exceededThresholdWeight.question.empty.error"))
+        .map(er => messages(er.message, er.key)).mkString("<br>")
+    if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 }
 
 
@@ -97,7 +99,7 @@
         pptRoutes.ExpectToExceedThresholdWeightController.displayPage(), 
         messages("site.back.hiddenText")))) {
 
-    @errorSummary(form.errors, errorFieldName = Some("exceeded-threshold-weight-date.day"))
+    @errorSummary(form.errors)
 
     @sectionHeader(messages("liability.exceededThresholdWeight.sectionHeader"))
 

--- a/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/expect_to_exceed_threshold_weight_page.scala.html
+++ b/app/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/expect_to_exceed_threshold_weight_page.scala.html
@@ -39,8 +39,10 @@
 @yearField = @{form("expect-to-exceed-threshold-weight-date.year")}
 
 @errorMessages = @{
-val errors = form.errors.map(err => messages(err.message, err.key)).mkString("<br>")
-if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
+    val errors = form.errors
+        .filter(err => !err.message.contains("liability.expectToExceedThresholdWeight.question.empty.error"))
+        .map(er => messages(er.message, er.key)).mkString("<br>")
+    if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 }
 
 @yesContent = {
@@ -87,7 +89,7 @@ if(errors.nonEmpty) Some(ErrorMessage(content = HtmlContent(errors))) else None
 
 @govukLayout(title = Title("liability.expectToExceedThresholdWeight.title")) {
 
-    @errorSummary(form.errors, Some("expect-to-exceed-threshold-weight-date.day"))
+    @errorSummary(form.errors)
 
     @sectionHeader(messages("liability.expectToExceedThresholdWeight.sectionHeader"))
     

--- a/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/ExpectToExceedThresholdWeightViewSpec.scala
+++ b/test/uk/gov/hmrc/plasticpackagingtax/registration/views/liability/ExpectToExceedThresholdWeightViewSpec.scala
@@ -70,8 +70,8 @@ class ExpectToExceedThresholdWeightViewSpec
 
     "display radio inputs" in {
 
-      view must containElementWithID("value-yes")
-      view.getElementById("value-yes").attr("value") mustBe YesNoValues.YES
+      view must containElementWithID("answer")
+      view.getElementById("answer").attr("value") mustBe YesNoValues.YES
       view must containElementWithID("value-no")
       view.getElementById("value-no").attr("value") mustBe YesNoValues.NO
     }
@@ -91,7 +91,7 @@ class ExpectToExceedThresholdWeightViewSpec
       val form = formProvider().fill(ExpectToExceedThresholdWeightAnswer(true, Some(LocalDate.now())))
       val view = createView(form)
 
-      view.getElementById("value-yes").attr("value") mustBe "yes"
+      view.getElementById("answer").attr("value") mustBe "yes"
     }
 
     "display error" when {
@@ -122,7 +122,7 @@ class ExpectToExceedThresholdWeightViewSpec
       }
 
       "display question" in {
-        view.select("#conditional-value-yes > div > fieldset > legend").text() must include(
+        view.select("#conditional-answer > div > fieldset > legend").text() must include(
           messages("liability.expectToExceedThreshold.date.question")
         )
       }


### PR DESCRIPTION
1. Fixed error summary links on various pages for the various error keys seen
2. Prevented yes / no missing answer error from being shown on the expandable date field
3. Added a missing error summary
4. Simplified boolean mapping logic