### PR TITLE
pr suggested updates

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,7 +128,7 @@ microservice {
   }
 }
 
-session {
+play.http.session {
   maxAge = "15m"
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,13 +5,13 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.5.1")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 


### PR DESCRIPTION
SBT can be updated to 1.7.2 in [project/build.properties](https://github.com/hmrc/plastic-packaging-tax-registration-frontend/blob/repackage/project/build.properties#L1)
uk.gov.hmrc.sbt-auto-build can be updated to 3.8.0 in [project/plugins.sbt](https://github.com/hmrc/plastic-packaging-tax-registration-frontend/blob/repackage/project/plugins.sbt#L8)
Runtime issues may occur. Change com.typesafe.play.sbt-plugin to 2.8.8 in [project/plugins.sbt](https://github.com/hmrc/plastic-packaging-tax-registration-frontend/blob/repackage/project/plugins.sbt#L14) - to match what uk.gov.hmrc.play-frontend-hmrc uses
Deprecated config key session.maxAge can be changed to play.http.session.maxAge in [conf/application.conf](https://github.com/hmrc/plastic-packaging-tax-registration-frontend/blob/repackage/conf/application.conf#L132)