### PR TITLE
Switch to internal ID

### DIFF
--- a/app/models/request/AuthenticatedRequest.scala
+++ b/app/models/request/AuthenticatedRequest.scala
@@ -23,7 +23,7 @@ import play.api.mvc.{Request, WrappedRequest}
 sealed abstract class AuthenticatedRequest[+A](request: Request[A]) extends WrappedRequest[A](request) {
   val identityData: IdentityData
   val internalID: String = identityData.internalId.getOrElse(throw new RuntimeException("Internal ID not found."))
-  def cacheId: String
+  def cacheId: String = internalID
   val credId: String = identityData.credentials.map(_.providerId).getOrElse(
     throw DownstreamServiceError("Cannot find user credentials id",
       RegistrationException("Cannot find user credentials id")
@@ -36,17 +36,13 @@ object AuthenticatedRequest {
   final case class RegistrationRequest[+A](
                                       request: Request[A],
                                       identityData: IdentityData
-                                    ) extends AuthenticatedRequest[A](request) {
-    override def cacheId: String = internalID
-  }
+                                    ) extends AuthenticatedRequest[A](request)
 
   final case class PPTEnrolledRequest[+A](
                                      request: Request[A],
                                      identityData: IdentityData,
                                      pptReference: String
-                                   ) extends AuthenticatedRequest[A](request) {
-    override def cacheId: String = s"$internalID-$pptReference"
-  }
+                                   ) extends AuthenticatedRequest[A](request)
 
 }
 

--- a/app/repositories/UserDataRepository.scala
+++ b/app/repositories/UserDataRepository.scala
@@ -65,7 +65,7 @@ class MongoUserDataRepository @Inject() (
       cacheIdType = CacheIdType.SimpleCacheId
     ) with UserDataRepository {
 
-  private def id(implicit request: AuthenticatedRequest[Any]): String = request.cacheId
+  private def id(implicit request: AuthenticatedRequest[Any]): String = request.internalID
 
   override def putData[T: Writes](key: String, data: T)(implicit
     request: AuthenticatedRequest[Any]

--- a/app/repositories/UserDataRepository.scala
+++ b/app/repositories/UserDataRepository.scala
@@ -65,7 +65,7 @@ class MongoUserDataRepository @Inject() (
       cacheIdType = CacheIdType.SimpleCacheId
     ) with UserDataRepository {
 
-  private def id(implicit request: AuthenticatedRequest[Any]): String = request.internalID
+  private def id(implicit request: AuthenticatedRequest[Any]): String = request.cacheId
 
   override def putData[T: Writes](key: String, data: T)(implicit
     request: AuthenticatedRequest[Any]


### PR DESCRIPTION
While ideally this would be the cache ID to stop agents from potentially having answers leak from one client to another, the way its been built this is endpoint is used by both registrations and amends and is non trivial to divide. Changing to internalID will be used the same by both user types and the document will be found regardless of which auth action you have come through 