### PR TITLE
DDCYLS-8570 PPT:Previously entered information should persist when using Change links

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -102,7 +102,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val soleTraderJourneyInitUrl =
     s"$soleTraderHost/sole-trader-identification/api/sole-trader-journey"
 
-  lazy val soleTraderJourneyUrl = s"$soleTraderHost/sole-trader-identification/api/journey"
+  lazy val soleTraderJourneyUrl      = s"$soleTraderHost/sole-trader-identification/api/journey"
   lazy val soleTraderFrontendBaseUrl = s"$soleTraderHost/identify-your-sole-trader-business"
 
   def soleTraderFullNameUrl(journeyId: String): String =
@@ -111,7 +111,7 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   private lazy val partnershipHost: String =
     servicesConfig.baseUrl("partnership-identification-frontend")
 
-  lazy val partnershipFrontendBaseUrl = s"$partnershipHost/identify-your-partnership"
+  lazy val partnershipFrontendBaseUrl    = s"$partnershipHost/identify-your-partnership"
   lazy val partnershipBaseUrl            = s"$partnershipHost/partnership-identification/api"
   lazy val partnershipJourneyUrl         = s"$partnershipBaseUrl/journey"
   lazy val generalPartnershipJourneyUrl  = s"$partnershipBaseUrl/general-partnership-journey"

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -91,6 +91,10 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
   lazy val incorpLimitedCompanyJourneyUrl  = s"$incorpBaseUrl/limited-company-journey"
   lazy val incorpRegistedSocietyJourneyUrl = s"$incorpBaseUrl/registered-society-journey"
   lazy val incorpDetailsUrl                = s"$incorpBaseUrl/journey"
+  lazy val incorpFrontendBaseUrl           = s"$incorpIdHost/identify-your-incorporated-business"
+
+  def incorpCompanyNumberUrl(journeyId: String): String =
+    s"$incorpFrontendBaseUrl/$journeyId/company-number"
 
   private lazy val soleTraderHost: String =
     servicesConfig.baseUrl("sole-trader-identification-frontend")
@@ -99,10 +103,15 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
     s"$soleTraderHost/sole-trader-identification/api/sole-trader-journey"
 
   lazy val soleTraderJourneyUrl = s"$soleTraderHost/sole-trader-identification/api/journey"
+  lazy val soleTraderFrontendBaseUrl = s"$soleTraderHost/identify-your-sole-trader-business"
+
+  def soleTraderFullNameUrl(journeyId: String): String =
+    s"$soleTraderFrontendBaseUrl/$journeyId/full-name"
 
   private lazy val partnershipHost: String =
     servicesConfig.baseUrl("partnership-identification-frontend")
 
+  lazy val partnershipFrontendBaseUrl = s"$partnershipHost/identify-your-partnership"
   lazy val partnershipBaseUrl            = s"$partnershipHost/partnership-identification/api"
   lazy val partnershipJourneyUrl         = s"$partnershipBaseUrl/journey"
   lazy val generalPartnershipJourneyUrl  = s"$partnershipBaseUrl/general-partnership-journey"
@@ -114,6 +123,12 @@ class AppConfig @Inject() (config: Configuration, val servicesConfig: ServicesCo
 
   lazy val limitedLiabilityPartnershipJourneyUrl =
     s"$partnershipBaseUrl/limited-liability-partnership-journey"
+
+  def partnershipSautrUrl(journeyId: String): String =
+    s"$partnershipFrontendBaseUrl/$journeyId/sa-utr"
+
+  def partnershipCompanyRegistrationNumberUrl(journeyId: String): String =
+    s"$partnershipFrontendBaseUrl/$journeyId/company-registration-number"
 
   // Define other partnership URLs here?
 

--- a/app/controllers/group/OrganisationDetailsTypeHelper.scala
+++ b/app/controllers/group/OrganisationDetailsTypeHelper.scala
@@ -25,7 +25,8 @@ import connectors.grs.{PartnershipGrsConnector, RegisteredSocietyGrsConnector, S
 import controllers.organisation.{routes => organisationRoutes}
 import controllers.partner.{routes => partnerRoutes}
 import forms.organisation.{OrgType, OrganisationType}
-import models.genericregistration.{IncorpEntityGrsCreateRequest, PartnershipGrsCreateRequest, SoleTraderGrsCreateRequest}
+import forms.organisation.PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
+import models.genericregistration.{IncorpEntityGrsCreateRequest, PartnershipDetails, PartnershipGrsCreateRequest, SoleTraderGrsCreateRequest}
 import models.registration.RegistrationUpdater
 import models.request.JourneyRequest
 
@@ -51,17 +52,25 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
   ): Future[Result] =
     organisationType.answer match {
       case Some(OrgType.UK_COMPANY) =>
-        getUkCompanyRedirectUrl(businessVerificationCheck, memberId)
-          .map(journeyStartUrl => SeeOther(journeyStartUrl))
+        getIncorpRedirectResultOrResume(
+          orgType = OrgType.UK_COMPANY,
+          createJourney = getUkCompanyRedirectUrl(businessVerificationCheck, memberId),
+          memberId = memberId
+        )
       case Some(OrgType.OVERSEAS_COMPANY_UK_BRANCH) =>
-        getUkCompanyRedirectUrl(businessVerificationCheck, memberId)
-          .map(journeyStartUrl => SeeOther(journeyStartUrl))
+        getIncorpRedirectResultOrResume(
+          orgType = OrgType.OVERSEAS_COMPANY_UK_BRANCH,
+          createJourney = getUkCompanyRedirectUrl(businessVerificationCheck, memberId),
+          memberId = memberId
+        )
       case Some(OrgType.SOLE_TRADER) =>
-        getSoleTraderRedirectUrl(memberId)
-          .map(journeyStartUrl => SeeOther(journeyStartUrl))
+        getSoleTraderRedirectResultOrResume(memberId)
       case Some(OrgType.REGISTERED_SOCIETY) =>
-        getRegisteredSocietyRedirectUrl(memberId)
-          .map(journeyStartUrl => SeeOther(journeyStartUrl))
+        getIncorpRedirectResultOrResume(
+          orgType = OrgType.REGISTERED_SOCIETY,
+          createJourney = getRegisteredSocietyRedirectUrl(memberId),
+          memberId = memberId
+        )
       case Some(OrgType.PARTNERSHIP) =>
         getPartnershipRedirectUrl(memberId, businessVerificationCheck)
       case _ =>
@@ -76,8 +85,11 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
     executionContext: ExecutionContext
   ): Future[Result] =
     if (request.registration.isGroup)
-      getRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl, businessVerificationCheck, memberId).map(
-        journeyStartUrl => SeeOther(journeyStartUrl)
+      getPartnershipRedirectResultOrResume(
+        createJourney =
+          getRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl, businessVerificationCheck, memberId),
+        resumeUrl = appConfig.partnershipCompanyRegistrationNumberUrl,
+        memberId = memberId
       )
     else
       Future(Redirect(partnerRoutes.PartnershipTypeController.displayPage()))
@@ -94,6 +106,28 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
         appConfig.grsAccessibilityStatementPath
       )
     )
+
+  private def getSoleTraderRedirectResultOrResume(memberId: Option[String])(implicit
+    request: JourneyRequest[AnyContent],
+    executionContext: ExecutionContext,
+    headerCarrier: HeaderCarrier
+  ): Future[Result] =
+    request.registration.incorpJourneyId match {
+      case Some(journeyId)
+          if isMainOrganisationJourney(memberId) &&
+            request.registration.organisationDetails.organisationType.contains(OrgType.SOLE_TRADER) =>
+        Future.successful(SeeOther(appConfig.soleTraderFullNameUrl(journeyId)))
+      case _ =>
+        getSoleTraderRedirectUrl(memberId).flatMap { journeyStartUrl =>
+          persistOrganisationJourneyOrRedirect(journeyStartUrl, memberId, extractSoleTraderJourneyId) { journeyId =>
+            _.copy(
+              incorpJourneyId = Some(journeyId),
+              organisationDetails =
+                request.registration.organisationDetails.copy(organisationType = Some(OrgType.SOLE_TRADER))
+            )
+          }
+        }
+    }
 
   private def incorpEntityGrsCreateRequest(businessVerificationCheck: Boolean, memberId: Option[String])(implicit
     request: Request[_]
@@ -112,6 +146,119 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
     headerCarrier: HeaderCarrier
   ): Future[String] =
     ukCompanyGrsConnector.createJourney(incorpEntityGrsCreateRequest(businessVerificationCheck, memberId))
+
+  private def getIncorpRedirectResultOrResume(
+    orgType: OrgType,
+    createJourney: => Future[String],
+    memberId: Option[String]
+  )(implicit
+    request: JourneyRequest[AnyContent],
+    executionContext: ExecutionContext,
+    headerCarrier: HeaderCarrier
+  ): Future[Result] =
+    request.registration.incorpJourneyId match {
+      case Some(journeyId)
+          if isMainOrganisationJourney(memberId) &&
+            request.registration.organisationDetails.organisationType.contains(orgType) =>
+        Future.successful(SeeOther(appConfig.incorpCompanyNumberUrl(journeyId)))
+      case _ =>
+        createJourney.flatMap { journeyStartUrl =>
+          persistOrganisationJourneyOrRedirect(journeyStartUrl, memberId, extractJourneyId) { journeyId =>
+            _.copy(
+              incorpJourneyId = Some(journeyId),
+              organisationDetails =
+                request.registration.organisationDetails.copy(organisationType = Some(orgType))
+            )
+          }
+        }
+    }
+
+  private def getPartnershipRedirectResultOrResume(
+    createJourney: => Future[String],
+    resumeUrl: String => String,
+    memberId: Option[String]
+  )(implicit
+    request: JourneyRequest[AnyContent],
+    executionContext: ExecutionContext,
+    headerCarrier: HeaderCarrier
+  ): Future[Result] =
+    request.registration.incorpJourneyId match {
+      case Some(journeyId)
+          if isMainOrganisationJourney(memberId) &&
+            request.registration.organisationDetails.organisationType.contains(OrgType.PARTNERSHIP) &&
+            request.registration.organisationDetails.partnershipDetails.exists(
+              _.partnershipType == LIMITED_LIABILITY_PARTNERSHIP
+            ) =>
+        Future.successful(SeeOther(resumeUrl(journeyId)))
+      case _ =>
+        createJourney.flatMap { journeyStartUrl =>
+          persistOrganisationJourneyOrRedirect(journeyStartUrl, memberId, extractPartnershipJourneyId) { journeyId =>
+            registration =>
+              registration.copy(
+                incorpJourneyId = Some(journeyId),
+                organisationDetails = registration.organisationDetails.copy(
+                  organisationType = Some(OrgType.PARTNERSHIP),
+                  partnershipDetails = Some(
+                    registration.organisationDetails.partnershipDetails
+                      .getOrElse(PartnershipDetails(LIMITED_LIABILITY_PARTNERSHIP))
+                      .copy(partnershipType = LIMITED_LIABILITY_PARTNERSHIP)
+                  )
+                )
+              )
+          }
+        }
+    }
+
+  private def persistOrganisationJourneyOrRedirect(
+    journeyStartUrl: String,
+    memberId: Option[String],
+    extractJourneyId: String => Option[String]
+  )(updateRegistrationModel: String => models.registration.Registration => models.registration.Registration)(implicit
+    request: JourneyRequest[AnyContent],
+    executionContext: ExecutionContext,
+    headerCarrier: HeaderCarrier
+  ): Future[Result] =
+    if (isMainOrganisationJourney(memberId))
+      extractJourneyId(journeyStartUrl).fold(Future.successful(SeeOther(journeyStartUrl))) { journeyId =>
+        registrationUpdater
+          .updateRegistration(updateRegistrationModel(journeyId))
+          .map(_ => SeeOther(journeyStartUrl))
+      }
+    else
+      Future.successful(SeeOther(journeyStartUrl))
+
+  private def isMainOrganisationJourney(memberId: Option[String])(implicit request: JourneyRequest[AnyContent]): Boolean =
+    memberId.isEmpty && request.registration.groupDetail.forall(_.currentMemberOrganisationType.isEmpty)
+
+  private def extractJourneyId(journeyStartUrl: String): Option[String] =
+    """.*/identify-your-incorporated-business/([^/]+)/company-number$""".r
+      .findFirstMatchIn(journeyStartUrl)
+      .map(_.group(1))
+      .orElse(
+        """/identify-your-incorporated-business/([^/]+)/company-number$""".r
+          .findFirstMatchIn(journeyStartUrl)
+          .map(_.group(1))
+      )
+
+  private def extractSoleTraderJourneyId(journeyStartUrl: String): Option[String] =
+    """.*/identify-your-sole-trader-business/([^/]+)/full-name$""".r
+      .findFirstMatchIn(journeyStartUrl)
+      .map(_.group(1))
+      .orElse(
+        """/identify-your-sole-trader-business/([^/]+)/full-name$""".r
+          .findFirstMatchIn(journeyStartUrl)
+          .map(_.group(1))
+      )
+
+  private def extractPartnershipJourneyId(journeyStartUrl: String): Option[String] =
+    """.*/identify-your-partnership/([^/]+)/(?:company-registration-number|sa-utr)$""".r
+      .findFirstMatchIn(journeyStartUrl)
+      .map(_.group(1))
+      .orElse(
+        """/identify-your-partnership/([^/]+)/(?:company-registration-number|sa-utr)$""".r
+          .findFirstMatchIn(journeyStartUrl)
+          .map(_.group(1))
+      )
 
   private def getRegisteredSocietyRedirectUrl(
     memberId: Option[String]

--- a/app/controllers/group/OrganisationDetailsTypeHelper.scala
+++ b/app/controllers/group/OrganisationDetailsTypeHelper.scala
@@ -166,8 +166,7 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
           persistOrganisationJourneyOrRedirect(journeyStartUrl, memberId, extractJourneyId) { journeyId =>
             _.copy(
               incorpJourneyId = Some(journeyId),
-              organisationDetails =
-                request.registration.organisationDetails.copy(organisationType = Some(orgType))
+              organisationDetails = request.registration.organisationDetails.copy(organisationType = Some(orgType))
             )
           }
         }
@@ -192,8 +191,8 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
         Future.successful(SeeOther(resumeUrl(journeyId)))
       case _ =>
         createJourney.flatMap { journeyStartUrl =>
-          persistOrganisationJourneyOrRedirect(journeyStartUrl, memberId, extractPartnershipJourneyId) { journeyId =>
-            registration =>
+          persistOrganisationJourneyOrRedirect(journeyStartUrl, memberId, extractPartnershipJourneyId) {
+            journeyId => registration =>
               registration.copy(
                 incorpJourneyId = Some(journeyId),
                 organisationDetails = registration.organisationDetails.copy(
@@ -227,7 +226,9 @@ trait OrganisationDetailsTypeHelper extends I18nSupport {
     else
       Future.successful(SeeOther(journeyStartUrl))
 
-  private def isMainOrganisationJourney(memberId: Option[String])(implicit request: JourneyRequest[AnyContent]): Boolean =
+  private def isMainOrganisationJourney(memberId: Option[String])(implicit
+    request: JourneyRequest[AnyContent]
+  ): Boolean =
     memberId.isEmpty && request.registration.groupDetail.forall(_.currentMemberOrganisationType.isEmpty)
 
   private def extractJourneyId(journeyStartUrl: String): Option[String] =

--- a/app/controllers/partner/PartnershipNameController.scala
+++ b/app/controllers/partner/PartnershipNameController.scala
@@ -69,11 +69,16 @@ class PartnershipNameController @Inject() (
           (formWithErrors: Form[PartnershipName]) => Future(BadRequest(page(formWithErrors))),
           partnershipName =>
             updatePartnershipName(partnershipName.value).flatMap { registration =>
-              getGrsRedirectUrl(getPartnershipType(registration) match {
-                case GENERAL_PARTNERSHIP  => appConfig.generalPartnershipJourneyUrl
-                case SCOTTISH_PARTNERSHIP => appConfig.scottishPartnershipJourneyUrl
-                case _                    => throw new IllegalStateException("Unexpected partnership type")
-              }).map(grsRedirectUrl => Redirect(grsRedirectUrl))
+              val partnershipType = getPartnershipType(registration)
+              getPartnershipRedirectResultOrResume(
+                registration = registration,
+                selectedPartnershipType = partnershipType,
+                createJourney = getGrsRedirectUrl(partnershipType match {
+                  case GENERAL_PARTNERSHIP  => appConfig.generalPartnershipJourneyUrl
+                  case SCOTTISH_PARTNERSHIP => appConfig.scottishPartnershipJourneyUrl
+                  case _                    => throw new IllegalStateException("Unexpected partnership type")
+                })
+              )
             }
         )
     }
@@ -110,5 +115,35 @@ class PartnershipNameController @Inject() (
       ),
       url
     )
+
+  private def getPartnershipRedirectResultOrResume(
+    registration: Registration,
+    selectedPartnershipType: forms.organisation.PartnerTypeEnum,
+    createJourney: => Future[String]
+  )(implicit request: JourneyRequest[AnyContent]): Future[play.api.mvc.Result] =
+    registration.incorpJourneyId match {
+      case Some(journeyId)
+          if registration.organisationDetails.partnershipDetails.exists(_.partnershipType == selectedPartnershipType) =>
+        Future.successful(Redirect(appConfig.partnershipSautrUrl(journeyId)))
+      case _ =>
+        createJourney.flatMap { journeyStartUrl =>
+          extractPartnershipJourneyId(journeyStartUrl).fold(Future.successful(Redirect(journeyStartUrl))) { journeyId =>
+            update(_.copy(incorpJourneyId = Some(journeyId))).map {
+              case Right(_)    => Redirect(journeyStartUrl)
+              case Left(error) => throw error
+            }
+          }
+        }
+    }
+
+  private def extractPartnershipJourneyId(journeyStartUrl: String): Option[String] =
+    """.*/identify-your-partnership/([^/]+)/sa-utr$""".r
+      .findFirstMatchIn(journeyStartUrl)
+      .map(_.group(1))
+      .orElse(
+        """/identify-your-partnership/([^/]+)/sa-utr$""".r
+          .findFirstMatchIn(journeyStartUrl)
+          .map(_.group(1))
+      )
 
 }

--- a/app/controllers/partner/PartnershipTypeController.scala
+++ b/app/controllers/partner/PartnershipTypeController.scala
@@ -86,21 +86,19 @@ class PartnershipTypeController @Inject() (
                   case SCOTTISH_LIMITED_PARTNERSHIP =>
                     getPartnershipRedirectResultOrResume(
                       selectedPartnershipType = SCOTTISH_LIMITED_PARTNERSHIP,
-                      createJourney =
-                        getPartnershipRedirectUrl(
-                          appConfig.scottishLimitedPartnershipJourneyUrl,
-                          appConfig.grsCallbackUrl
-                        ),
+                      createJourney = getPartnershipRedirectUrl(
+                        appConfig.scottishLimitedPartnershipJourneyUrl,
+                        appConfig.grsCallbackUrl
+                      ),
                       resumeUrl = appConfig.partnershipCompanyRegistrationNumberUrl
                     )
                   case LIMITED_LIABILITY_PARTNERSHIP =>
                     getPartnershipRedirectResultOrResume(
                       selectedPartnershipType = LIMITED_LIABILITY_PARTNERSHIP,
-                      createJourney =
-                        getPartnershipRedirectUrl(
-                          appConfig.limitedLiabilityPartnershipJourneyUrl,
-                          appConfig.grsCallbackUrl
-                        ),
+                      createJourney = getPartnershipRedirectUrl(
+                        appConfig.limitedLiabilityPartnershipJourneyUrl,
+                        appConfig.grsCallbackUrl
+                      ),
                       resumeUrl = appConfig.partnershipCompanyRegistrationNumberUrl
                     )
                   case _ =>

--- a/app/controllers/partner/PartnershipTypeController.scala
+++ b/app/controllers/partner/PartnershipTypeController.scala
@@ -77,14 +77,32 @@ class PartnershipTypeController @Inject() (
                   case GENERAL_PARTNERSHIP | SCOTTISH_PARTNERSHIP =>
                     Future(Redirect(routes.PartnershipNameController.displayPage().url))
                   case LIMITED_PARTNERSHIP =>
-                    getPartnershipRedirectUrl(appConfig.limitedPartnershipJourneyUrl, appConfig.grsCallbackUrl)
-                      .map(journeyStartUrl => SeeOther(journeyStartUrl))
+                    getPartnershipRedirectResultOrResume(
+                      selectedPartnershipType = LIMITED_PARTNERSHIP,
+                      createJourney =
+                        getPartnershipRedirectUrl(appConfig.limitedPartnershipJourneyUrl, appConfig.grsCallbackUrl),
+                      resumeUrl = appConfig.partnershipCompanyRegistrationNumberUrl
+                    )
                   case SCOTTISH_LIMITED_PARTNERSHIP =>
-                    getPartnershipRedirectUrl(appConfig.scottishLimitedPartnershipJourneyUrl, appConfig.grsCallbackUrl)
-                      .map(journeyStartUrl => SeeOther(journeyStartUrl))
+                    getPartnershipRedirectResultOrResume(
+                      selectedPartnershipType = SCOTTISH_LIMITED_PARTNERSHIP,
+                      createJourney =
+                        getPartnershipRedirectUrl(
+                          appConfig.scottishLimitedPartnershipJourneyUrl,
+                          appConfig.grsCallbackUrl
+                        ),
+                      resumeUrl = appConfig.partnershipCompanyRegistrationNumberUrl
+                    )
                   case LIMITED_LIABILITY_PARTNERSHIP =>
-                    getPartnershipRedirectUrl(appConfig.limitedLiabilityPartnershipJourneyUrl, appConfig.grsCallbackUrl)
-                      .map(journeyStartUrl => SeeOther(journeyStartUrl))
+                    getPartnershipRedirectResultOrResume(
+                      selectedPartnershipType = LIMITED_LIABILITY_PARTNERSHIP,
+                      createJourney =
+                        getPartnershipRedirectUrl(
+                          appConfig.limitedLiabilityPartnershipJourneyUrl,
+                          appConfig.grsCallbackUrl
+                        ),
+                      resumeUrl = appConfig.partnershipCompanyRegistrationNumberUrl
+                    )
                   case _ =>
                     Future(Redirect(organisationRoutes.RegisterAsOtherOrganisationController.onPageLoad()))
                 }
@@ -92,6 +110,49 @@ class PartnershipTypeController @Inject() (
             }
         )
     }
+
+  private def getPartnershipRedirectResultOrResume(
+    selectedPartnershipType: forms.organisation.PartnerTypeEnum,
+    createJourney: => Future[String],
+    resumeUrl: String => String
+  )(implicit request: JourneyRequest[AnyContent]): Future[play.api.mvc.Result] =
+    request.registration.incorpJourneyId match {
+      case Some(journeyId)
+          if request.registration.organisationDetails.partnershipDetails.exists(
+            _.partnershipType == selectedPartnershipType
+          ) =>
+        Future.successful(SeeOther(resumeUrl(journeyId)))
+      case _ =>
+        createJourney.flatMap { journeyStartUrl =>
+          extractPartnershipJourneyId(journeyStartUrl).fold(Future.successful(SeeOther(journeyStartUrl))) { journeyId =>
+            update { registration =>
+              registration.copy(
+                incorpJourneyId = Some(journeyId),
+                organisationDetails = registration.organisationDetails.copy(
+                  partnershipDetails = Some(
+                    registration.organisationDetails.partnershipDetails
+                      .getOrElse(PartnershipDetails(partnershipType = selectedPartnershipType))
+                      .copy(partnershipType = selectedPartnershipType)
+                  )
+                )
+              )
+            }.map {
+              case Right(_)    => SeeOther(journeyStartUrl)
+              case Left(error) => throw error
+            }
+          }
+        }
+    }
+
+  private def extractPartnershipJourneyId(journeyStartUrl: String): Option[String] =
+    """.*/identify-your-partnership/([^/]+)/company-registration-number$""".r
+      .findFirstMatchIn(journeyStartUrl)
+      .map(_.group(1))
+      .orElse(
+        """/identify-your-partnership/([^/]+)/company-registration-number$""".r
+          .findFirstMatchIn(journeyStartUrl)
+          .map(_.group(1))
+      )
 
   private def updateRegistration(
     formData: PartnerType

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,7 +11,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"       %% s"bootstrap-frontend-$playVersion"            % bootstrapVersion,
-    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"            % "13.4.0",
+    "uk.gov.hmrc"       %% s"play-frontend-hmrc-$playVersion"            % "13.8.0",
     "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"                    % mongoVersion,
     "uk.gov.hmrc"       %% s"play-conditional-form-mapping-$playVersion" % "3.5.0"
   )

--- a/test/base/unit/MockRegistrationConnector.scala
+++ b/test/base/unit/MockRegistrationConnector.scala
@@ -20,7 +20,7 @@ import builders.RegistrationBuilder
 import connectors.{DownstreamServiceError, RegistrationConnector, ServiceError}
 import models.registration.Registration
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{atLeastOnce, verify, when}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.OngoingStubbing
 import org.mockito.{ArgumentCaptor, Mockito}
@@ -48,8 +48,8 @@ trait MockRegistrationConnector extends MockitoSugar with RegistrationBuilder wi
 
   def modifiedRegistration: Registration = {
     val captor = ArgumentCaptor.forClass(classOf[Registration])
-    verify(mockRegistrationConnector).update(captor.capture())(any())
-    captor.getValue
+    verify(mockRegistrationConnector, atLeastOnce()).update(captor.capture())(any())
+    captor.getAllValues.get(captor.getAllValues.size() - 1)
   }
 
   override protected def afterEach(): Unit = {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -60,9 +60,21 @@ class AppConfigSpec extends AnyWordSpec with Matchers with MockitoSugar {
       validAppConfig.incorpDetailsUrl must be("http://localhost:9718/incorporated-entity-identification/api/journey")
     }
 
+    "have 'incorpCompanyNumberUrl(...)' defined" in {
+      validAppConfig.incorpCompanyNumberUrl("journey-123") must be(
+        "http://localhost:9718/identify-your-incorporated-business/journey-123/company-number"
+      )
+    }
+
     "have 'soleTraderJourneyUrl' defined" in {
       validAppConfig.soleTraderJourneyInitUrl must be(
         "http://localhost:9717/sole-trader-identification/api/sole-trader-journey"
+      )
+    }
+
+    "have 'soleTraderFullNameUrl(...)' defined" in {
+      validAppConfig.soleTraderFullNameUrl("journey-123") must be(
+        "http://localhost:9717/identify-your-sole-trader-business/journey-123/full-name"
       )
     }
 

--- a/test/controllers/group/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/controllers/group/OrganisationDetailsTypeControllerSpec.scala
@@ -25,7 +25,7 @@ import forms.organisation.OrgType
 import forms.organisation.OrgType.{CHARITABLE_INCORPORATED_ORGANISATION, OVERSEAS_COMPANY_NO_UK_BRANCH, OVERSEAS_COMPANY_UK_BRANCH, PARTNERSHIP, UK_COMPANY}
 import forms.organisation.OrganisationType
 import models.registration.group.{GroupMember, OrganisationDetails}
-import models.registration.{GroupDetail, NewRegistrationUpdateService, Registration}
+import models.registration.{GroupDetail, NewRegistrationUpdateService, OrganisationDetails as MainOrganisationDetails, Registration}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import play.api.data.Form
@@ -174,7 +174,13 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         )
       )
 
-      spyJourneyAction.setReg(aRegistration(withGroupDetail(groupDetail = Some(groupDetails))))
+      spyJourneyAction.setReg(
+        aRegistration(
+          withIncorpJourneyId(None),
+          withOrganisationDetails(MainOrganisationDetails()),
+          withGroupDetail(groupDetail = Some(groupDetails))
+        )
+      )
       mockRegistrationUpdate()
 
       val correctForm = Seq("answer" -> orgType.toString)

--- a/test/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
@@ -25,7 +25,7 @@ import forms.organisation.OrgType.{CHARITABLE_INCORPORATED_ORGANISATION, OVERSEA
 import forms.organisation.{OrgType, OrganisationType, PartnerTypeEnum}
 import models.registration.{NewRegistrationUpdateService, OrganisationDetails}
 import org.mockito.ArgumentMatchers.{any, refEq}
-import org.mockito.Mockito.atLeastOnce
+import org.mockito.Mockito.{atLeastOnce, never}
 import org.mockito.Mockito.{reset, verify, when}
 
 import play.api.data.Form
@@ -62,6 +62,11 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     when(page.apply(any[Form[OrganisationType]], any())(any(), any())).thenReturn(HtmlFormat.empty)
+    when(config.incorpCompanyNumberUrl(any())).thenAnswer(invocation => s"http://test/incorp/${invocation.getArgument[String](0)}/company-number")
+    when(config.soleTraderFullNameUrl(any())).thenAnswer(invocation => s"http://test/sole-trader/${invocation.getArgument[String](0)}/full-name")
+    when(config.partnershipCompanyRegistrationNumberUrl(any())).thenAnswer(
+      invocation => s"http://test/partnership/${invocation.getArgument[String](0)}/company-registration-number"
+    )
   }
 
   override protected def afterEach(): Unit = {
@@ -117,12 +122,107 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
     "return 303 (OK)" when {
 
       "user submits organisation type: " + UK_COMPANY in {
-        mockUkCompanyCreateIncorpJourneyId("http://test/redirect/uk-company")
-        assertRedirectForOrgType(UK_COMPANY, "http://test/redirect/uk-company")
+        mockUkCompanyCreateIncorpJourneyId("http://test/identify-your-incorporated-business/uk-company/company-number")
+        assertRedirectForOrgType(
+          UK_COMPANY,
+          "http://test/identify-your-incorporated-business/uk-company/company-number",
+          expectedJourneyId = Some("uk-company")
+        )
       }
+
+      "user reselects organisation type: " + UK_COMPANY + " with an existing incorporated journey" in {
+        spyJourneyAction.setReg(
+          aRegistration(
+            withIncorpJourneyId(Some("journey-123")),
+            withOrganisationDetails(OrganisationDetails(organisationType = Some(OrgType.UK_COMPANY), incorporationDetails = Some(incorporationDetails)))
+          )
+        )
+        mockRegistrationUpdate()
+
+        val correctForm = Seq("answer" -> UK_COMPANY.toString)
+        val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+        status(result) shouldBe SEE_OTHER
+        modifiedRegistration.organisationDetails.organisationType shouldBe Some(UK_COMPANY)
+        redirectLocation(result) shouldBe Some("http://test/incorp/journey-123/company-number")
+
+        verify(mockUkCompanyGrsConnector, never()).createJourney(any())(any(), any())
+      }
+
+      "user reselects organisation type: " + OVERSEAS_COMPANY_UK_BRANCH + " with an existing incorporated journey" in {
+        spyJourneyAction.setReg(
+          aRegistration(
+            withIncorpJourneyId(Some("journey-456")),
+            withOrganisationDetails(
+              OrganisationDetails(
+                organisationType = Some(OrgType.OVERSEAS_COMPANY_UK_BRANCH),
+                incorporationDetails = Some(incorporationDetails)
+              )
+            )
+          )
+        )
+        mockRegistrationUpdate()
+
+        val correctForm = Seq("answer" -> OVERSEAS_COMPANY_UK_BRANCH.toString)
+        val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+        status(result) shouldBe SEE_OTHER
+        modifiedRegistration.organisationDetails.organisationType shouldBe Some(OVERSEAS_COMPANY_UK_BRANCH)
+        redirectLocation(result) shouldBe Some("http://test/incorp/journey-456/company-number")
+
+        verify(mockUkCompanyGrsConnector, never()).createJourney(any())(any(), any())
+      }
+
+      "user reselects organisation type: " + REGISTERED_SOCIETY + " with an existing incorporated journey" in {
+        spyJourneyAction.setReg(
+          aRegistration(
+            withIncorpJourneyId(Some("journey-789")),
+            withOrganisationDetails(
+              OrganisationDetails(
+                organisationType = Some(OrgType.REGISTERED_SOCIETY),
+                incorporationDetails = Some(incorporationDetails)
+              )
+            )
+          )
+        )
+        mockRegistrationUpdate()
+
+        val correctForm = Seq("answer" -> REGISTERED_SOCIETY.toString)
+        val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+        status(result) shouldBe SEE_OTHER
+        modifiedRegistration.organisationDetails.organisationType shouldBe Some(REGISTERED_SOCIETY)
+        redirectLocation(result) shouldBe Some("http://test/incorp/journey-789/company-number")
+
+        verify(mockRegisteredSocietyGrsConnector, never()).createJourney(any())(any(), any())
+      }
+
       "user submits organisation type: " + SOLE_TRADER in {
-        mockSoleTraderCreateIncorpJourneyId("http://test/redirect/sole-trader")
-        assertRedirectForOrgType(SOLE_TRADER, "http://test/redirect/sole-trader")
+        mockSoleTraderCreateIncorpJourneyId("http://test/identify-your-sole-trader-business/sole-trader/full-name")
+        assertRedirectForOrgType(
+          SOLE_TRADER,
+          "http://test/identify-your-sole-trader-business/sole-trader/full-name",
+          expectedJourneyId = Some("sole-trader")
+        )
+      }
+
+      "user reselects organisation type: " + SOLE_TRADER + " with an existing sole trader journey" in {
+        spyJourneyAction.setReg(
+          aRegistration(
+            withIncorpJourneyId(Some("journey-321")),
+            withOrganisationDetails(OrganisationDetails(organisationType = Some(OrgType.SOLE_TRADER), soleTraderDetails = Some(soleTraderDetails)))
+          )
+        )
+        mockRegistrationUpdate()
+
+        val correctForm = Seq("answer" -> SOLE_TRADER.toString)
+        val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+        status(result) shouldBe SEE_OTHER
+        modifiedRegistration.organisationDetails.organisationType shouldBe Some(SOLE_TRADER)
+        redirectLocation(result) shouldBe Some("http://test/sole-trader/journey-321/full-name")
+
+        verify(mockSoleTraderGrsConnector, never()).createJourney(any())(any(), any())
       }
       "user submits organisation type: " + PARTNERSHIP in {
         mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
@@ -130,9 +230,17 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
       }
 
       "user submits organisation type Limited Liability Partnership in group: " + PARTNERSHIP in {
-        mockCreatePartnershipGrsJourneyCreation("http://test/redirect/partnership")
+        mockCreatePartnershipGrsJourneyCreation(
+          "http://test/identify-your-partnership/group-llp/company-registration-number"
+        )
 
-        spyJourneyAction.setReg(aRegistration(withRegistrationType(Some(RegType.GROUP))))
+        spyJourneyAction.setReg(
+          aRegistration(
+            withRegistrationType(Some(RegType.GROUP)),
+            withIncorpJourneyId(None),
+            withOrganisationDetails(OrganisationDetails())
+          )
+        )
         mockRegistrationUpdate()
 
         val correctForm = Seq("answer" -> PARTNERSHIP.toString)
@@ -141,8 +249,35 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         status(result) shouldBe SEE_OTHER
         modifiedRegistration.organisationDetails.organisationType shouldBe Some(PARTNERSHIP)
         modifiedRegistration.organisationDetails.partnershipDetails.get.partnershipType shouldBe PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
+        modifiedRegistration.incorpJourneyId shouldBe Some("group-llp")
 
-        redirectLocation(result) shouldBe Some("http://test/redirect/partnership")
+        redirectLocation(result) shouldBe Some("http://test/identify-your-partnership/group-llp/company-registration-number")
+      }
+
+      "group user reselects organisation type Limited Liability Partnership with an existing partnership journey" in {
+        spyJourneyAction.setReg(
+          aRegistration(
+            withRegistrationType(Some(RegType.GROUP)),
+            withIncorpJourneyId(Some("journey-654")),
+            withOrganisationDetails(
+              OrganisationDetails(
+                organisationType = Some(PARTNERSHIP),
+                partnershipDetails = Some(llpPartnershipDetails)
+              )
+            )
+          )
+        )
+        mockRegistrationUpdate()
+
+        val correctForm = Seq("answer" -> PARTNERSHIP.toString)
+        val result      = controller.submit()(postJsonRequestEncoded(correctForm: _*))
+
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) shouldBe Some("http://test/partnership/journey-654/company-registration-number")
+        modifiedRegistration.organisationDetails.organisationType shouldBe Some(PARTNERSHIP)
+        modifiedRegistration.organisationDetails.partnershipDetails.get.partnershipType shouldBe PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
+
+        verify(mockPartnershipGrsConnector, never()).createJourney(any(), any())(any(), any())
       }
 
       "user submits organisation type Limited Liability Partnership in group with partnership details present: " + PARTNERSHIP in {
@@ -151,6 +286,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         spyJourneyAction.setReg(
           aRegistration(
             withRegistrationType(Some(RegType.GROUP)),
+            withIncorpJourneyId(None),
             withPartnershipDetails(
               Some(
                 partnershipDetailsWithBusinessAddress(partnerTypeEnum = PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP)
@@ -171,8 +307,12 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
       }
 
       "user submits organisation type: " + REGISTERED_SOCIETY in {
-        mockRegisteredSocietyCreateIncorpJourneyId("http://test/redirect/reg-soc")
-        assertRedirectForOrgType(REGISTERED_SOCIETY, "http://test/redirect/reg-soc")
+        mockRegisteredSocietyCreateIncorpJourneyId("http://test/identify-your-incorporated-business/reg-soc/company-number")
+        assertRedirectForOrgType(
+          REGISTERED_SOCIETY,
+          "http://test/identify-your-incorporated-business/reg-soc/company-number",
+          expectedJourneyId = Some("reg-soc")
+        )
       }
 
       "user submits organisation type: " + CHARITABLE_INCORPORATED_ORGANISATION in {
@@ -182,8 +322,14 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         )
       }
       "user submits organisation type: " + OVERSEAS_COMPANY_UK_BRANCH in {
-        mockUkCompanyCreateIncorpJourneyId("http://test/redirect/overseas-uk-company")
-        assertRedirectForOrgType(OVERSEAS_COMPANY_UK_BRANCH, "http://test/redirect/overseas-uk-company")
+        mockUkCompanyCreateIncorpJourneyId(
+          "http://test/identify-your-incorporated-business/overseas-uk-company/company-number"
+        )
+        assertRedirectForOrgType(
+          OVERSEAS_COMPANY_UK_BRANCH,
+          "http://test/identify-your-incorporated-business/overseas-uk-company/company-number",
+          expectedJourneyId = Some("overseas-uk-company")
+        )
       }
 
       "user submits organisation type: " + TRUST in {
@@ -208,9 +354,14 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
       }
     }
 
-    def assertRedirectForOrgType(orgType: OrgType, redirectUrl: String): Unit = {
+    def assertRedirectForOrgType(orgType: OrgType, redirectUrl: String, expectedJourneyId: Option[String] = None): Unit = {
 
-      spyJourneyAction.setReg(aRegistration())
+      spyJourneyAction.setReg(
+        aRegistration(
+          withIncorpJourneyId(None),
+          withOrganisationDetails(OrganisationDetails())
+        )
+      )
       mockRegistrationUpdate()
 
       val correctForm = Seq("answer" -> orgType.toString)
@@ -218,6 +369,7 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
 
       status(result) shouldBe SEE_OTHER
       modifiedRegistration.organisationDetails.organisationType shouldBe Some(orgType)
+      modifiedRegistration.incorpJourneyId shouldBe expectedJourneyId
 
       verify(mockAuditor, atLeastOnce()).orgTypeSelected(any(), refEq(Some(orgType)))(any(), any())
 
@@ -285,7 +437,12 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
 
     "user submits form for uk company" in {
 
-      spyJourneyAction.setReg(aRegistration())
+      spyJourneyAction.setReg(
+        aRegistration(
+          withIncorpJourneyId(None),
+          withOrganisationDetails(OrganisationDetails())
+        )
+      )
       mockRegistrationUpdate()
       mockUkCompanyCreateIncorpJourneyIdException()
 

--- a/test/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
+++ b/test/controllers/organisation/OrganisationDetailsTypeControllerSpec.scala
@@ -62,10 +62,14 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     when(page.apply(any[Form[OrganisationType]], any())(any(), any())).thenReturn(HtmlFormat.empty)
-    when(config.incorpCompanyNumberUrl(any())).thenAnswer(invocation => s"http://test/incorp/${invocation.getArgument[String](0)}/company-number")
-    when(config.soleTraderFullNameUrl(any())).thenAnswer(invocation => s"http://test/sole-trader/${invocation.getArgument[String](0)}/full-name")
-    when(config.partnershipCompanyRegistrationNumberUrl(any())).thenAnswer(
-      invocation => s"http://test/partnership/${invocation.getArgument[String](0)}/company-registration-number"
+    when(config.incorpCompanyNumberUrl(any())).thenAnswer(invocation =>
+      s"http://test/incorp/${invocation.getArgument[String](0)}/company-number"
+    )
+    when(config.soleTraderFullNameUrl(any())).thenAnswer(invocation =>
+      s"http://test/sole-trader/${invocation.getArgument[String](0)}/full-name"
+    )
+    when(config.partnershipCompanyRegistrationNumberUrl(any())).thenAnswer(invocation =>
+      s"http://test/partnership/${invocation.getArgument[String](0)}/company-registration-number"
     )
   }
 
@@ -134,7 +138,12 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         spyJourneyAction.setReg(
           aRegistration(
             withIncorpJourneyId(Some("journey-123")),
-            withOrganisationDetails(OrganisationDetails(organisationType = Some(OrgType.UK_COMPANY), incorporationDetails = Some(incorporationDetails)))
+            withOrganisationDetails(
+              OrganisationDetails(
+                organisationType = Some(OrgType.UK_COMPANY),
+                incorporationDetails = Some(incorporationDetails)
+              )
+            )
           )
         )
         mockRegistrationUpdate()
@@ -210,7 +219,12 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         spyJourneyAction.setReg(
           aRegistration(
             withIncorpJourneyId(Some("journey-321")),
-            withOrganisationDetails(OrganisationDetails(organisationType = Some(OrgType.SOLE_TRADER), soleTraderDetails = Some(soleTraderDetails)))
+            withOrganisationDetails(
+              OrganisationDetails(
+                organisationType = Some(OrgType.SOLE_TRADER),
+                soleTraderDetails = Some(soleTraderDetails)
+              )
+            )
           )
         )
         mockRegistrationUpdate()
@@ -251,7 +265,9 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
         modifiedRegistration.organisationDetails.partnershipDetails.get.partnershipType shouldBe PartnerTypeEnum.LIMITED_LIABILITY_PARTNERSHIP
         modifiedRegistration.incorpJourneyId shouldBe Some("group-llp")
 
-        redirectLocation(result) shouldBe Some("http://test/identify-your-partnership/group-llp/company-registration-number")
+        redirectLocation(result) shouldBe Some(
+          "http://test/identify-your-partnership/group-llp/company-registration-number"
+        )
       }
 
       "group user reselects organisation type Limited Liability Partnership with an existing partnership journey" in {
@@ -307,7 +323,9 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
       }
 
       "user submits organisation type: " + REGISTERED_SOCIETY in {
-        mockRegisteredSocietyCreateIncorpJourneyId("http://test/identify-your-incorporated-business/reg-soc/company-number")
+        mockRegisteredSocietyCreateIncorpJourneyId(
+          "http://test/identify-your-incorporated-business/reg-soc/company-number"
+        )
         assertRedirectForOrgType(
           REGISTERED_SOCIETY,
           "http://test/identify-your-incorporated-business/reg-soc/company-number",
@@ -354,7 +372,11 @@ class OrganisationDetailsTypeControllerSpec extends ControllerSpec {
       }
     }
 
-    def assertRedirectForOrgType(orgType: OrgType, redirectUrl: String, expectedJourneyId: Option[String] = None): Unit = {
+    def assertRedirectForOrgType(
+      orgType: OrgType,
+      redirectUrl: String,
+      expectedJourneyId: Option[String] = None
+    ): Unit = {
 
       spyJourneyAction.setReg(
         aRegistration(

--- a/test/controllers/partner/PartnershipNameControllerSpec.scala
+++ b/test/controllers/partner/PartnershipNameControllerSpec.scala
@@ -18,12 +18,13 @@ package controllers.partner
 
 import base.unit.ControllerSpec
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{never, verify, when}
 
 import play.api.http.Status.BAD_REQUEST
-import play.api.test.Helpers.{await, contentAsString, status}
+import play.api.test.Helpers.{await, contentAsString, redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import forms.organisation.PartnershipName
+import forms.organisation.PartnerTypeEnum.{GENERAL_PARTNERSHIP, SCOTTISH_PARTNERSHIP}
 import play.api.test.FakeRequest
 import views.html.organisation.partnership_name
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -42,7 +43,8 @@ class PartnershipNameControllerSpec extends ControllerSpec {
     page = page
   )
 
-  private val partnershipRegistration = aRegistration(withPartnershipDetails(Some(generalPartnershipDetails)))
+  private val partnershipRegistration =
+    aRegistration(withIncorpJourneyId(None), withPartnershipDetails(Some(generalPartnershipDetails)))
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -54,6 +56,9 @@ class PartnershipNameControllerSpec extends ControllerSpec {
 
     when(config.generalPartnershipJourneyUrl).thenReturn("/general-partnership-grs-journey-creation")
     when(config.scottishPartnershipJourneyUrl).thenReturn("/scottish-partnership-grs-journey-creation")
+    when(config.partnershipSautrUrl(any())).thenAnswer(
+      invocation => s"http://test/partnership/${invocation.getArgument[String](0)}/sa-utr"
+    )
   }
 
   "Partnership Name Controller" should {
@@ -100,13 +105,37 @@ class PartnershipNameControllerSpec extends ControllerSpec {
 
     "redirect to scottish partnership grs journey" in {
 
-      spyJourneyAction.setReg(aRegistration(withPartnershipDetails(Some(scottishPartnershipDetails))))
+      spyJourneyAction.setReg(
+        aRegistration(withIncorpJourneyId(None), withPartnershipDetails(Some(scottishPartnershipDetails)))
+      )
 
       await(controller.submit()(postRequestEncoded(PartnershipName("Partners in Plastic"))))
 
       val (_, grsJourneyCreationUrl) = lastPartnershipGrsJourneyCreation()
 
       grsJourneyCreationUrl shouldBe config.scottishPartnershipJourneyUrl
+    }
+
+    "resume an existing general or scottish partnership journey" when {
+      Seq(
+        GENERAL_PARTNERSHIP -> generalPartnershipDetails,
+        SCOTTISH_PARTNERSHIP -> scottishPartnershipDetails
+      ).foreach { case (partnershipType, partnershipDetails) =>
+        s"the same $partnershipType was reselected" in {
+          spyJourneyAction.setReg(
+            aRegistration(
+              withIncorpJourneyId(Some("journey-321")),
+              withPartnershipDetails(Some(partnershipDetails))
+            )
+          )
+
+          val result = controller.submit()(postRequestEncoded(PartnershipName("Partners in Plastic")))
+
+          redirectLocation(result) shouldBe Some("http://test/partnership/journey-321/sa-utr")
+
+          verify(mockPartnershipGrsConnector, never()).createJourney(any(), any())(any(), any())
+        }
+      }
     }
 
     "reject invalid partnership names" in {
@@ -132,7 +161,9 @@ class PartnershipNameControllerSpec extends ControllerSpec {
 
       "submitting partnership name" when {
         "registration is of unexpected partnership type" in {
-          spyJourneyAction.setReg(aRegistration(withPartnershipDetails(Some(llpPartnershipDetails))))
+          spyJourneyAction.setReg(
+            aRegistration(withIncorpJourneyId(None), withPartnershipDetails(Some(llpPartnershipDetails)))
+          )
 
           intercept[IllegalStateException] {
             await(controller.submit()(postRequestEncoded(PartnershipName("Partners in Plastic"))))

--- a/test/controllers/partner/PartnershipNameControllerSpec.scala
+++ b/test/controllers/partner/PartnershipNameControllerSpec.scala
@@ -56,8 +56,8 @@ class PartnershipNameControllerSpec extends ControllerSpec {
 
     when(config.generalPartnershipJourneyUrl).thenReturn("/general-partnership-grs-journey-creation")
     when(config.scottishPartnershipJourneyUrl).thenReturn("/scottish-partnership-grs-journey-creation")
-    when(config.partnershipSautrUrl(any())).thenAnswer(
-      invocation => s"http://test/partnership/${invocation.getArgument[String](0)}/sa-utr"
+    when(config.partnershipSautrUrl(any())).thenAnswer(invocation =>
+      s"http://test/partnership/${invocation.getArgument[String](0)}/sa-utr"
     )
   }
 
@@ -118,7 +118,7 @@ class PartnershipNameControllerSpec extends ControllerSpec {
 
     "resume an existing general or scottish partnership journey" when {
       Seq(
-        GENERAL_PARTNERSHIP -> generalPartnershipDetails,
+        GENERAL_PARTNERSHIP  -> generalPartnershipDetails,
         SCOTTISH_PARTNERSHIP -> scottishPartnershipDetails
       ).foreach { case (partnershipType, partnershipDetails) =>
         s"the same $partnershipType was reselected" in {

--- a/test/controllers/partner/PartnershipTypeControllerSpec.scala
+++ b/test/controllers/partner/PartnershipTypeControllerSpec.scala
@@ -53,8 +53,8 @@ class PartnershipTypeControllerSpec extends ControllerSpec {
     super.beforeEach()
     when(page.apply(any[Form[PartnerType]])(any(), any())).thenReturn(HtmlFormat.empty)
     mockCreatePartnershipGrsJourneyCreation("/partnership-grs-journey")
-    when(config.partnershipCompanyRegistrationNumberUrl(any())).thenAnswer(
-      invocation => s"http://test/partnership/${invocation.getArgument[String](0)}/company-registration-number"
+    when(config.partnershipCompanyRegistrationNumberUrl(any())).thenAnswer(invocation =>
+      s"http://test/partnership/${invocation.getArgument[String](0)}/company-registration-number"
     )
   }
 
@@ -115,12 +115,18 @@ class PartnershipTypeControllerSpec extends ControllerSpec {
 
       spyJourneyAction.setReg(registration)
       mockRegistrationUpdate()
-      mockCreatePartnershipGrsJourneyCreation("http://test/identify-your-partnership/new-journey/company-registration-number")
+      mockCreatePartnershipGrsJourneyCreation(
+        "http://test/identify-your-partnership/new-journey/company-registration-number"
+      )
 
       val result = controller.submit()(postJsonRequestEncoded("answer" -> LIMITED_PARTNERSHIP.toString))
 
-      redirectLocation(result) shouldBe Some("http://test/identify-your-partnership/new-journey/company-registration-number")
-      modifiedRegistration.organisationDetails.partnershipDetails.map(_.partnershipType) shouldBe Some(LIMITED_PARTNERSHIP)
+      redirectLocation(result) shouldBe Some(
+        "http://test/identify-your-partnership/new-journey/company-registration-number"
+      )
+      modifiedRegistration.organisationDetails.partnershipDetails.map(_.partnershipType) shouldBe Some(
+        LIMITED_PARTNERSHIP
+      )
       modifiedRegistration.incorpJourneyId shouldBe Some("new-journey")
     }
 

--- a/test/controllers/partner/PartnershipTypeControllerSpec.scala
+++ b/test/controllers/partner/PartnershipTypeControllerSpec.scala
@@ -22,7 +22,7 @@ import forms.organisation.PartnerType
 import forms.organisation.PartnerTypeEnum.{GENERAL_PARTNERSHIP, LIMITED_LIABILITY_PARTNERSHIP, LIMITED_PARTNERSHIP, SCOTTISH_LIMITED_PARTNERSHIP, SCOTTISH_PARTNERSHIP}
 import models.genericregistration.PartnershipDetails
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{never, verify, when}
 import org.scalatest.Inspectors.forAll
 
 import play.api.data.Form
@@ -53,6 +53,9 @@ class PartnershipTypeControllerSpec extends ControllerSpec {
     super.beforeEach()
     when(page.apply(any[Form[PartnerType]])(any(), any())).thenReturn(HtmlFormat.empty)
     mockCreatePartnershipGrsJourneyCreation("/partnership-grs-journey")
+    when(config.partnershipCompanyRegistrationNumberUrl(any())).thenAnswer(
+      invocation => s"http://test/partnership/${invocation.getArgument[String](0)}/company-registration-number"
+    )
   }
 
   "Partnership Type Controller" should {
@@ -88,7 +91,8 @@ class PartnershipTypeControllerSpec extends ControllerSpec {
         )
       ) { partnershipDetails =>
         s"a ${partnershipDetails._1} type was selected" in {
-          val registration = aRegistration(withPartnershipDetails(Some(partnershipDetails._2)))
+          val registration =
+            aRegistration(withIncorpJourneyId(None), withPartnershipDetails(Some(partnershipDetails._2)))
 
           spyJourneyAction.setReg(registration)
           mockRegistrationUpdate()
@@ -99,6 +103,49 @@ class PartnershipTypeControllerSpec extends ControllerSpec {
           val result = controller.submit()(postJsonRequestEncoded(correctForm: _*))
 
           redirectLocation(result) shouldBe Some("http://test/redirect/partnership")
+        }
+      }
+    }
+
+    "persist the newly selected partnership type when starting a fresh partnership GRS journey" in {
+      val registration = aRegistration(
+        withIncorpJourneyId(None),
+        withPartnershipDetails(Some(PartnershipDetails(partnershipType = GENERAL_PARTNERSHIP)))
+      )
+
+      spyJourneyAction.setReg(registration)
+      mockRegistrationUpdate()
+      mockCreatePartnershipGrsJourneyCreation("http://test/identify-your-partnership/new-journey/company-registration-number")
+
+      val result = controller.submit()(postJsonRequestEncoded("answer" -> LIMITED_PARTNERSHIP.toString))
+
+      redirectLocation(result) shouldBe Some("http://test/identify-your-partnership/new-journey/company-registration-number")
+      modifiedRegistration.organisationDetails.partnershipDetails.map(_.partnershipType) shouldBe Some(LIMITED_PARTNERSHIP)
+      modifiedRegistration.incorpJourneyId shouldBe Some("new-journey")
+    }
+
+    "resume an existing partnership GRS journey" when {
+      forAll(
+        Seq(
+          SCOTTISH_LIMITED_PARTNERSHIP,
+          LIMITED_PARTNERSHIP,
+          LIMITED_LIABILITY_PARTNERSHIP
+        )
+      ) { partnershipType =>
+        s"the same $partnershipType was reselected" in {
+          val registration = aRegistration(
+            withIncorpJourneyId(Some("journey-123")),
+            withPartnershipDetails(Some(PartnershipDetails(partnershipType = partnershipType)))
+          )
+
+          spyJourneyAction.setReg(registration)
+          mockRegistrationUpdate()
+
+          val result = controller.submit()(postJsonRequestEncoded("answer" -> partnershipType.toString))
+
+          redirectLocation(result) shouldBe Some("http://test/partnership/journey-123/company-registration-number")
+
+          verify(mockPartnershipGrsConnector, never()).createJourney(any(), any())(any(), any())
         }
       }
     }


### PR DESCRIPTION
Changes - 

Fixed redundant entry and prepopulation for organisation types

- amended AppConfig.scala
- amended OrganisationDetailsTypeHelper.scala
- amended PartnershipTypeController.scala
- amended PartnershipNameController.scala
- amended MockRegistrationConnector.scala
- amended AppConfigSpec.scala
- amended OrganisationDetailsTypeControllerSpec.scala amended PartnershipTypeControllerSpec.scala
- amended PartnershipNameControllerSpec.scala
- amended OrganisationDetailsTypeControllerSpec.scala

Related PR's - 

- https://github.com/hmrc/incorporated-entity-identification-frontend/pull/244
- https://github.com/hmrc/partnership-identification-frontend/pull/116
- https://github.com/hmrc/sole-trader-identification-frontend/pull/257


